### PR TITLE
release: fixes combos y stock — edición rota, variantes y modal (#79)

### DIFF
--- a/app/Http/Controllers/BO/ComboController.php
+++ b/app/Http/Controllers/BO/ComboController.php
@@ -48,7 +48,7 @@ class ComboController extends Controller
             (new Collection($validated['products']))->mapWithKeys(function ($product) {
                 return [$product['id'] => [
                     'quantity' => $product['quantity'],
-                    'variants' => isset($product['variants']) ? json_encode($product['variants']) : null,
+                    'variants' => $product['variants'] ?? null,
                 ]];
             })
         );
@@ -80,7 +80,7 @@ class ComboController extends Controller
             (new Collection($validated['products']))->mapWithKeys(function ($product) {
                 return [$product['id'] => [
                     'quantity' => $product['quantity'],
-                    'variants' => isset($product['variants']) ? json_encode($product['variants']) : null,
+                    'variants' => $product['variants'] ?? null,
                 ]];
             })
         );

--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -130,7 +130,7 @@ class OrderController extends Controller
 
             foreach ($validated['order_details'] as $product) {
                 $order->products()->attach($product['product_id'], [
-                    'variant' => json_encode($product['variant'] ?? []),
+                    'variant' => $product['variant'] ?? [],
                     'note' => $product['note'],
                 ]);
             }
@@ -231,7 +231,7 @@ class OrderController extends Controller
             $order->products()->sync(
                 collect($validated['order_details'])->mapWithKeys(function ($product) {
                     return [$product['product_id'] => [
-                        'variant' => json_encode($product['variant'] ?? []),
+                        'variant' => $product['variant'] ?? [],
                         'note' => $product['note'],
                     ]];
                 })->toArray()

--- a/app/Models/Combo.php
+++ b/app/Models/Combo.php
@@ -23,6 +23,6 @@ class Combo extends Model
         return $this->belongsToMany(Product::class)
             ->using(ComboProduct::class)
             ->as('pivot')
-            ->withPivot(['variants']);
+            ->withPivot(['variants', 'quantity']);
     }
 }

--- a/database/migrations/2025_07_23_032723_insert_into_products_table.php
+++ b/database/migrations/2025_07_23_032723_insert_into_products_table.php
@@ -97,6 +97,8 @@ return new class extends Migration
                 'max_payments' => 4,
                 'unit_price' => 28000,
                 'product_type_id' => $product_types->firstWhere('name', 'mural')->id,
+                // Murals must carry variants: the UI renders their pickers
+                'variants' => $variants,
             ],
             [
                 'name' => 'Foto 15x21',

--- a/database/seeders/DevSmokeSeeder.php
+++ b/database/seeders/DevSmokeSeeder.php
@@ -44,16 +44,16 @@ class DevSmokeSeeder extends Seeder
             'photo_number' => 1,
         ]);
         $order1->products()->attach($mural->id, [
-            'variant' => json_encode([
+            'variant' => [
                 'orientation' => 'vertical',
                 'photo_type' => 'individual',
                 'background' => 'blue',
                 'color' => 'brown',
-            ]),
+            ],
             'note' => 'Martina - egresados 2026',
         ]);
         $order1->products()->attach($taza->id, [
-            'variant' => json_encode([]),
+            'variant' => [],
             'note' => 'Taza con nombre',
         ]);
         $order1->payments()->create(['amount' => 16000, 'type' => 'efectivo']);
@@ -70,7 +70,7 @@ class DevSmokeSeeder extends Seeder
             'photo_number' => 2,
         ]);
         $order2->products()->attach($taza->id, [
-            'variant' => json_encode([]),
+            'variant' => [],
             'note' => 'Taza de Pedro',
         ]);
     }

--- a/resources/js/pages/combos/create.tsx
+++ b/resources/js/pages/combos/create.tsx
@@ -6,7 +6,7 @@ import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler, useEffect, useState } from 'react';
-import { FormData, SelectedProduct } from './form';
+import { FormData, SelectedProduct, upsertSelectedProduct } from './form';
 import { AddProduct } from './partials/add-product';
 import { ComboProducts } from './partials/combo-products';
 
@@ -27,6 +27,9 @@ export default function CreateCombo({
     const [addProduct, setAddProduct] = useState<number | null>(null);
     const [showAddMuralProduct, setShowAddMuralProduct] =
         useState<Product | null>(null);
+    const [editingVariants, setEditingVariants] = useState<
+        SelectedProduct['variants'] | null
+    >(null);
 
     const { data, setData, post, processing, errors, setError } =
         useForm<FormData>({
@@ -54,7 +57,8 @@ export default function CreateCombo({
 
         if (!product) return;
 
-        if (product.product_type_id !== 1) {
+        // Products without configurable variants are added directly
+        if (product.product_type_id !== 1 || !product.variants) {
             setData('products', [
                 ...data.products,
                 {
@@ -63,10 +67,23 @@ export default function CreateCombo({
                 },
             ]);
         } else {
-            setShowAddMuralProduct(products.find((p) => p.id === addProduct)!);
+            setShowAddMuralProduct(product);
         }
+
+        // Reset so the same product can be re-added after being removed
+        setAddProduct(null);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [addProduct]);
+
+    const openEditProductModal = (id: number) => {
+        const product = products.find((p) => p.id === id);
+        const selected = data.products.find((p) => p.id === id);
+
+        if (!product || !selected) return;
+
+        setEditingVariants(selected.variants ?? null);
+        setShowAddMuralProduct(product);
+    };
 
     const updateQuantity = (id: number, value: number) => {
         const updatableProduct = data.products.find(
@@ -103,11 +120,18 @@ export default function CreateCombo({
             {showAddMuralProduct ? (
                 <AddProduct
                     addProduct={(product: SelectedProduct) => {
-                        setData('products', [...data.products, product]);
+                        setData(
+                            'products',
+                            upsertSelectedProduct(data.products, product),
+                        );
                     }}
                     product={showAddMuralProduct}
+                    initialVariants={editingVariants}
                     show={Boolean(showAddMuralProduct)}
-                    onClose={() => setShowAddMuralProduct(null)}
+                    onClose={() => {
+                        setShowAddMuralProduct(null);
+                        setEditingVariants(null);
+                    }}
                 />
             ) : undefined}
 
@@ -175,6 +199,7 @@ export default function CreateCombo({
                         selectedProducts={data.products}
                         products={products}
                         openAddProductModal={setAddProduct}
+                        openEditProductModal={openEditProductModal}
                         updateQuantity={updateQuantity}
                     >
                         <InputError

--- a/resources/js/pages/combos/edit.tsx
+++ b/resources/js/pages/combos/edit.tsx
@@ -6,7 +6,7 @@ import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler, useEffect, useState } from 'react';
-import { FormData, SelectedProduct } from './form';
+import { FormData, SelectedProduct, upsertSelectedProduct } from './form';
 import { AddProduct } from './partials/add-product';
 import { ComboProducts } from './partials/combo-products';
 
@@ -31,6 +31,9 @@ export default function EditCombo({
     const [addProduct, setAddProduct] = useState<number | null>(null);
     const [showAddMuralProduct, setShowAddMuralProduct] =
         useState<Product | null>(null);
+    const [editingVariants, setEditingVariants] = useState<
+        SelectedProduct['variants'] | null
+    >(null);
 
     const { data, setData, put, processing, errors, setError } =
         useForm<FormData>({
@@ -58,7 +61,8 @@ export default function EditCombo({
 
         if (!product) return;
 
-        if (product.product_type_id !== 1) {
+        // Products without configurable variants are added directly
+        if (product.product_type_id !== 1 || !product.variants) {
             setData('products', [
                 ...data.products,
                 {
@@ -67,10 +71,23 @@ export default function EditCombo({
                 },
             ]);
         } else {
-            setShowAddMuralProduct(products.find((p) => p.id === addProduct)!);
+            setShowAddMuralProduct(product);
         }
+
+        // Reset so the same product can be re-added after being removed
+        setAddProduct(null);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [addProduct]);
+
+    const openEditProductModal = (id: number) => {
+        const product = products.find((p) => p.id === id);
+        const selected = data.products.find((p) => p.id === id);
+
+        if (!product || !selected) return;
+
+        setEditingVariants(selected.variants ?? null);
+        setShowAddMuralProduct(product);
+    };
 
     const updateQuantity = (id: number, value: number) => {
         const updatableProduct = data.products.find(
@@ -107,11 +124,18 @@ export default function EditCombo({
             {showAddMuralProduct ? (
                 <AddProduct
                     addProduct={(product: SelectedProduct) => {
-                        setData('products', [...data.products, product]);
+                        setData(
+                            'products',
+                            upsertSelectedProduct(data.products, product),
+                        );
                     }}
                     product={showAddMuralProduct}
+                    initialVariants={editingVariants}
                     show={Boolean(showAddMuralProduct)}
-                    onClose={() => setShowAddMuralProduct(null)}
+                    onClose={() => {
+                        setShowAddMuralProduct(null);
+                        setEditingVariants(null);
+                    }}
                 />
             ) : undefined}
 
@@ -181,6 +205,7 @@ export default function EditCombo({
                         selectedProducts={data.products}
                         products={products}
                         openAddProductModal={setAddProduct}
+                        openEditProductModal={openEditProductModal}
                         updateQuantity={updateQuantity}
                     >
                         <InputError

--- a/resources/js/pages/combos/form.test.ts
+++ b/resources/js/pages/combos/form.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { SelectedProduct, upsertSelectedProduct } from './form';
+
+const variants = (
+    orientations: ProductOrientation[],
+): SelectedProduct['variants'] => ({
+    orientations,
+    photo_types: ['individual'],
+    backgrounds: ['blue'],
+    colors: ['brown'],
+    dimentions: '20x30',
+});
+
+describe('upsertSelectedProduct', () => {
+    it('appends a product that is not selected yet', () => {
+        const result = upsertSelectedProduct([{ id: 1, quantity: 2 }], {
+            id: 5,
+            quantity: 1,
+            variants: variants(['vertical']),
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[1].id).toBe(5);
+    });
+
+    it('replaces the variants keeping the chosen quantity when editing', () => {
+        const result = upsertSelectedProduct(
+            [{ id: 5, quantity: 3, variants: variants(['vertical']) }],
+            { id: 5, quantity: 1, variants: variants(['horizontal']) },
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].quantity).toBe(3);
+        expect(result[0].variants?.orientations).toEqual(['horizontal']);
+    });
+
+    it('leaves the other selected products untouched', () => {
+        const result = upsertSelectedProduct(
+            [
+                { id: 1, quantity: 2 },
+                { id: 5, quantity: 1, variants: variants(['vertical']) },
+            ],
+            { id: 5, quantity: 1, variants: variants(['horizontal']) },
+        );
+
+        expect(result[0]).toEqual({ id: 1, quantity: 2 });
+    });
+});

--- a/resources/js/pages/combos/form.ts
+++ b/resources/js/pages/combos/form.ts
@@ -9,3 +9,24 @@ export type SelectedProduct = {
     quantity: number;
     variants?: Product['variants'];
 };
+
+/**
+ * Adds a product to the combo or, when it is already selected, replaces
+ * its variants keeping the chosen quantity (used by the edit button).
+ */
+export const upsertSelectedProduct = (
+    selected: SelectedProduct[],
+    incoming: SelectedProduct,
+): SelectedProduct[] => {
+    const existing = selected.find((product) => product.id === incoming.id);
+
+    if (!existing) {
+        return [...selected, incoming];
+    }
+
+    return selected.map((product) =>
+        product.id === incoming.id
+            ? { ...incoming, quantity: existing.quantity }
+            : product,
+    );
+};

--- a/resources/js/pages/combos/partials/add-product.test.tsx
+++ b/resources/js/pages/combos/partials/add-product.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AddProduct } from './add-product';
+
+const mural = {
+    id: 1,
+    product_type_id: 1,
+    name: 'Mural clásico',
+    variants: {
+        photo_types: ['individual', 'grupo'],
+        orientations: ['vertical', 'horizontal'],
+        backgrounds: ['blue'],
+        colors: ['brown'],
+        dimentions: '20x30',
+    },
+} as unknown as Product;
+
+describe('AddProduct', () => {
+    it('does not crash with a product without variants', () => {
+        render(
+            <AddProduct
+                addProduct={vi.fn()}
+                product={
+                    { ...mural, variants: undefined } as unknown as Product
+                }
+                show
+                onClose={vi.fn()}
+            />,
+        );
+
+        // The button label matches exactly; the heading includes "al combo"
+        expect(screen.getByText('Agregar Mural clásico')).toBeTruthy();
+    });
+
+    it('requires at least one option per variant', () => {
+        const addProduct = vi.fn();
+
+        render(
+            <AddProduct
+                addProduct={addProduct}
+                product={mural}
+                show
+                onClose={vi.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Agregar Mural clásico'));
+
+        expect(addProduct).not.toHaveBeenCalled();
+        expect(
+            screen.getByText('Debes elegir por lo menos una orientación'),
+        ).toBeTruthy();
+    });
+
+    it('prefills the checkboxes when editing', () => {
+        render(
+            <AddProduct
+                addProduct={vi.fn()}
+                product={mural}
+                initialVariants={{
+                    orientations: ['vertical'],
+                    photo_types: ['grupo'],
+                    backgrounds: ['blue'],
+                    colors: ['brown'],
+                    dimentions: '20x30',
+                }}
+                show
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/Editar Mural clásico/)).toBeTruthy();
+        expect(
+            screen.getByLabelText<HTMLInputElement>('vertical').checked,
+        ).toBe(true);
+        expect(
+            screen.getByLabelText<HTMLInputElement>('horizontal').checked,
+        ).toBe(false);
+    });
+
+    it('submits the edited selection keeping quantity for the caller', () => {
+        const addProduct = vi.fn();
+        const onClose = vi.fn();
+
+        render(
+            <AddProduct
+                addProduct={addProduct}
+                product={mural}
+                initialVariants={{
+                    orientations: ['vertical'],
+                    photo_types: ['grupo'],
+                    backgrounds: ['blue'],
+                    colors: ['brown'],
+                    dimentions: '20x30',
+                }}
+                show
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.click(screen.getByLabelText('horizontal'));
+        fireEvent.click(screen.getByText('Agregar Mural clásico'));
+
+        expect(addProduct).toHaveBeenCalledWith({
+            id: 1,
+            quantity: 1,
+            variants: {
+                photo_types: ['grupo'],
+                orientations: ['vertical', 'horizontal'],
+                backgrounds: ['blue'],
+                colors: ['brown'],
+                dimentions: '20x30',
+            },
+        });
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/resources/js/pages/combos/partials/add-product.tsx
+++ b/resources/js/pages/combos/partials/add-product.tsx
@@ -11,20 +11,27 @@ export function AddProduct({
     product,
     show,
     onClose,
+    initialVariants,
 }: {
     addProduct: (product: SelectedProduct) => void;
     product: Product;
     show: boolean;
     onClose: CallableFunction;
+    /** Existing selection when editing a product already in the combo */
+    initialVariants?: SelectedProduct['variants'] | null;
 }) {
     const [orientations, setOrientations] = useState<Set<ProductOrientation>>(
-        new Set(),
+        new Set(initialVariants?.orientations ?? []),
     );
     const [photoTypes, setPhotoTypes] = useState<Set<ProductPhotoType>>(
-        new Set(),
+        new Set(initialVariants?.photo_types ?? []),
     );
-    const [backgrounds, setBackgrounds] = useState<Set<string>>(new Set());
-    const [colors, setColors] = useState<Set<string>>(new Set());
+    const [backgrounds, setBackgrounds] = useState<Set<string>>(
+        new Set(initialVariants?.backgrounds ?? []),
+    );
+    const [colors, setColors] = useState<Set<string>>(
+        new Set(initialVariants?.colors ?? []),
+    );
 
     const [errors, setErrors] = useState<{
         orientations?: string;
@@ -140,7 +147,7 @@ export function AddProduct({
                 orientations: Array.from(orientations),
                 backgrounds: Array.from(backgrounds),
                 colors: Array.from(colors) as Color[],
-                dimentions: product.variants.dimentions,
+                dimentions: product.variants?.dimentions ?? '',
             },
         };
 
@@ -152,8 +159,11 @@ export function AddProduct({
         <Modal show={show} onClose={onClose}>
             <div className="p-6">
                 <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                    Agregar {product.name} ({product.variants.dimentions}) al
-                    combo
+                    {initialVariants ? 'Editar' : 'Agregar'} {product.name}
+                    {product.variants?.dimentions
+                        ? ` (${product.variants.dimentions})`
+                        : ''}{' '}
+                    {initialVariants ? 'del' : 'al'} combo
                 </h2>
 
                 <div className="mt-6">
@@ -161,21 +171,23 @@ export function AddProduct({
                         <legend className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             Orientaciones disponibles para este producto
                         </legend>
-                        {product.variants.orientations.map((orientation) => (
-                            <label
-                                className="flex items-center"
-                                key={orientation}
-                            >
-                                <Checkbox
-                                    value={orientation}
-                                    checked={orientations.has(orientation)}
-                                    onChange={handleSetOrientations}
-                                />
-                                <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
-                                    {orientation}
-                                </span>
-                            </label>
-                        ))}
+                        {(product.variants?.orientations ?? []).map(
+                            (orientation) => (
+                                <label
+                                    className="flex items-center"
+                                    key={orientation}
+                                >
+                                    <Checkbox
+                                        value={orientation}
+                                        checked={orientations.has(orientation)}
+                                        onChange={handleSetOrientations}
+                                    />
+                                    <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                                        {orientation}
+                                    </span>
+                                </label>
+                            ),
+                        )}
                     </fieldset>
                     <InputError
                         message={errors?.orientations}
@@ -188,21 +200,23 @@ export function AddProduct({
                         <legend className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             Tipo de foto
                         </legend>
-                        {product.variants.photo_types.map((photoType) => (
-                            <label
-                                className="flex items-center"
-                                key={photoType}
-                            >
-                                <Checkbox
-                                    value={photoType}
-                                    checked={photoTypes.has(photoType)}
-                                    onChange={handleSetPhotoTypes}
-                                />
-                                <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
-                                    {photoType}
-                                </span>
-                            </label>
-                        ))}
+                        {(product.variants?.photo_types ?? []).map(
+                            (photoType) => (
+                                <label
+                                    className="flex items-center"
+                                    key={photoType}
+                                >
+                                    <Checkbox
+                                        value={photoType}
+                                        checked={photoTypes.has(photoType)}
+                                        onChange={handleSetPhotoTypes}
+                                    />
+                                    <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                                        {photoType}
+                                    </span>
+                                </label>
+                            ),
+                        )}
                     </fieldset>
                     <InputError message={errors?.photoTypes} className="mt-2" />
                 </div>
@@ -212,21 +226,23 @@ export function AddProduct({
                         <legend className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             Fondos disponibles para este combo
                         </legend>
-                        {product.variants.backgrounds.map((background) => (
-                            <label
-                                className="flex items-center"
-                                key={background}
-                            >
-                                <Checkbox
-                                    value={background}
-                                    checked={backgrounds.has(background)}
-                                    onChange={handleSetBackgrounds}
-                                />
-                                <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
-                                    {background}
-                                </span>
-                            </label>
-                        ))}
+                        {(product.variants?.backgrounds ?? []).map(
+                            (background) => (
+                                <label
+                                    className="flex items-center"
+                                    key={background}
+                                >
+                                    <Checkbox
+                                        value={background}
+                                        checked={backgrounds.has(background)}
+                                        onChange={handleSetBackgrounds}
+                                    />
+                                    <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                                        {background}
+                                    </span>
+                                </label>
+                            ),
+                        )}
                     </fieldset>
                     <InputError
                         message={errors?.backgrounds}
@@ -239,7 +255,7 @@ export function AddProduct({
                         <legend className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             Colores disponibles para este combo
                         </legend>
-                        {product.variants.colors.map((color) => (
+                        {(product.variants?.colors ?? []).map((color) => (
                             <label className="flex items-center" key={color}>
                                 <Checkbox
                                     value={color}

--- a/resources/js/pages/combos/partials/combo-products.tsx
+++ b/resources/js/pages/combos/partials/combo-products.tsx
@@ -22,10 +22,12 @@ export function ComboProducts({
     selectedProducts,
     products,
     openAddProductModal,
+    openEditProductModal,
     updateQuantity,
 }: PropsWithChildren<{
     updateQuantity: (id: number, value: number) => void;
     openAddProductModal: (id: number) => void;
+    openEditProductModal: (id: number) => void;
     products: Product[];
     selectedProducts: SelectedProduct[];
 }>) {
@@ -43,7 +45,10 @@ export function ComboProducts({
 
             <ul className="my-2 gap-4">
                 {selectedProducts.map((selected) => {
-                    const product = products.find((p) => p.id === selected.id)!;
+                    const product = products.find((p) => p.id === selected.id);
+
+                    // The product may have been deleted since it was added
+                    if (!product) return null;
 
                     return (
                         <li
@@ -52,40 +57,41 @@ export function ComboProducts({
                         >
                             <div className="flex gap-1">
                                 {`${selected.quantity}x ${product.name}`}
-                                {product.product_type_id === 1 && (
-                                    <>
-                                        <Badge
-                                            variant="outline"
-                                            className="gap-1 rounded-lg"
-                                        >
-                                            {product.variants.colors.map(
-                                                (color) => (
-                                                    <Square
-                                                        key={color}
-                                                        className="h-4 w-4"
-                                                        style={{
-                                                            fill: color,
-                                                        }}
-                                                    />
-                                                ),
-                                            )}
-                                        </Badge>
-                                        <Badge
-                                            variant="outline"
-                                            className="rounded-lg"
-                                        >
-                                            <User className="h-4 w-4" />
-                                            <Users className="h-4 w-4" />
-                                        </Badge>
-                                        <Badge
-                                            variant="outline"
-                                            className="rounded-lg"
-                                        >
-                                            <RectangleHorizontal className="h-4 w-4" />
-                                            <RectangleVertical className="h-4 w-4" />
-                                        </Badge>
-                                    </>
-                                )}
+                                {product.product_type_id === 1 &&
+                                    product.variants && (
+                                        <>
+                                            <Badge
+                                                variant="outline"
+                                                className="gap-1 rounded-lg"
+                                            >
+                                                {product.variants.colors.map(
+                                                    (color) => (
+                                                        <Square
+                                                            key={color}
+                                                            className="h-4 w-4"
+                                                            style={{
+                                                                fill: color,
+                                                            }}
+                                                        />
+                                                    ),
+                                                )}
+                                            </Badge>
+                                            <Badge
+                                                variant="outline"
+                                                className="rounded-lg"
+                                            >
+                                                <User className="h-4 w-4" />
+                                                <Users className="h-4 w-4" />
+                                            </Badge>
+                                            <Badge
+                                                variant="outline"
+                                                className="rounded-lg"
+                                            >
+                                                <RectangleHorizontal className="h-4 w-4" />
+                                                <RectangleVertical className="h-4 w-4" />
+                                            </Badge>
+                                        </>
+                                    )}
                             </div>
                             <div className="flex gap-1">
                                 <Button
@@ -110,9 +116,18 @@ export function ComboProducts({
                                     <Plus className="h-4 w-4" />
                                 </Button>
                                 <Button
+                                    type="button"
                                     variant="warning"
                                     size="icon"
-                                    disabled={product.product_type_id !== 1}
+                                    title="Editar variantes"
+                                    disabled={
+                                        product.product_type_id !== 1 ||
+                                        !product.variants
+                                    }
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        openEditProductModal(selected.id);
+                                    }}
                                 >
                                     <Edit className="h-4 w-4" />
                                 </Button>

--- a/resources/js/pages/orders/add-detail.tsx
+++ b/resources/js/pages/orders/add-detail.tsx
@@ -116,6 +116,9 @@ export function AddDetail({
     const getVariants = (step: typeof currentStep) =>
         resolveVariants(products[step]);
 
+    // Narrowed once so TypeScript knows the variants exist inside the block
+    const currentVariants = getVariants(currentStep);
+
     return (
         <Modal show={show} onClose={onClose}>
             <div className="p-6" key={products[currentStep].id}>
@@ -127,7 +130,8 @@ export function AddDetail({
                     Agregando {currentStep + 1} de {products.length} productos
                 </h3>
 
-                {products[currentStep].product_type_id === 1 ? (
+                {products[currentStep].product_type_id === 1 &&
+                currentVariants ? (
                     <>
                         <div className="mt-2">
                             <fieldset>
@@ -135,7 +139,7 @@ export function AddDetail({
                                     Orientaciones disponibles para este producto
                                 </legend>
                                 <div className="mt-1 flex flex-wrap gap-4">
-                                    {getVariants(currentStep).orientations.map(
+                                    {currentVariants.orientations.map(
                                         (orientation) => (
                                             <label
                                                 className="flex items-center"
@@ -185,7 +189,7 @@ export function AddDetail({
                                     Tipo de foto
                                 </legend>
                                 <div className="mt-1 flex flex-wrap gap-4">
-                                    {getVariants(currentStep).photo_types.map(
+                                    {currentVariants.photo_types.map(
                                         (photoType) => (
                                             <label
                                                 className="flex items-center"
@@ -235,7 +239,7 @@ export function AddDetail({
                                     este combo
                                 </legend>
                                 <div className="mt-1 flex flex-wrap gap-4">
-                                    {getVariants(currentStep).backgrounds.map(
+                                    {currentVariants.backgrounds.map(
                                         (background) => (
                                             <label
                                                 className="flex items-center"
@@ -284,38 +288,34 @@ export function AddDetail({
                                     este combo
                                 </legend>
                                 <div className="mt-1 flex flex-wrap gap-4">
-                                    {getVariants(currentStep).colors.map(
-                                        (color) => (
-                                            <label
-                                                className="flex items-center"
-                                                key={color}
-                                            >
-                                                <Checkbox
-                                                    value={color}
-                                                    checked={
-                                                        getProductValue(
-                                                            products[
-                                                                currentStep
-                                                            ].id,
-                                                            'color',
-                                                        ) === color
-                                                    }
-                                                    onChange={(e) =>
-                                                        updateProductData(
-                                                            'color',
-                                                            products[
-                                                                currentStep
-                                                            ].id,
-                                                            e.target.value,
-                                                        )
-                                                    }
-                                                />
-                                                <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
-                                                    {getColorEs(color)}
-                                                </span>
-                                            </label>
-                                        ),
-                                    )}
+                                    {currentVariants.colors.map((color) => (
+                                        <label
+                                            className="flex items-center"
+                                            key={color}
+                                        >
+                                            <Checkbox
+                                                value={color}
+                                                checked={
+                                                    getProductValue(
+                                                        products[currentStep]
+                                                            .id,
+                                                        'color',
+                                                    ) === color
+                                                }
+                                                onChange={(e) =>
+                                                    updateProductData(
+                                                        'color',
+                                                        products[currentStep]
+                                                            .id,
+                                                        e.target.value,
+                                                    )
+                                                }
+                                            />
+                                            <span className="ms-2 text-sm text-gray-600 dark:text-gray-400">
+                                                {getColorEs(color)}
+                                            </span>
+                                        </label>
+                                    ))}
                                 </div>
                             </fieldset>
                             <InputError

--- a/resources/js/pages/orders/detail-form.test.ts
+++ b/resources/js/pages/orders/detail-form.test.ts
@@ -11,7 +11,14 @@ const mural = {
     id: 1,
     product_type_id: 1,
     name: 'Mural clásico',
-} as SelectableProduct;
+    variants: {
+        photo_types: ['individual', 'grupo'],
+        orientations: ['vertical', 'horizontal'],
+        backgrounds: ['blue'],
+        colors: ['brown'],
+        dimentions: '30x40',
+    },
+} as unknown as SelectableProduct;
 
 const taza = {
     id: 2,
@@ -63,6 +70,23 @@ describe('validateDetailForm', () => {
         expect(errors).toEqual({});
     });
 
+    it('requires only the note for a mural without configured variants', () => {
+        const bareMural = {
+            ...mural,
+            variants: undefined,
+        } as SelectableProduct;
+
+        const errors = validateDetailForm([bareMural], initialDetailFormData());
+
+        expect(Object.keys(errors[1])).toEqual(['note']);
+
+        const withNote = initialDetailFormData([
+            { product_id: 1, note: 'Martina' },
+        ]);
+
+        expect(validateDetailForm([bareMural], withNote)).toEqual({});
+    });
+
     it('validates each product independently', () => {
         const secondMural = { ...mural, id: 9 } as SelectableProduct;
 
@@ -94,6 +118,21 @@ describe('buildProductOrders', () => {
                 note: 'Martina',
             },
         ]);
+    });
+
+    it('builds a mural without configured variants without a variant payload', () => {
+        const bareMural = {
+            ...mural,
+            variants: undefined,
+        } as SelectableProduct;
+
+        const orders = buildProductOrders(
+            [bareMural],
+            initialDetailFormData([{ product_id: 1, note: 'Martina' }]),
+        );
+
+        expect(orders[0].variant).toBeUndefined();
+        expect(orders[0].note).toBe('Martina');
     });
 
     it('builds non-mural details without a variant and keeps the combo id', () => {

--- a/resources/js/pages/orders/detail-form.ts
+++ b/resources/js/pages/orders/detail-form.ts
@@ -83,6 +83,18 @@ export const validateDetailForm = (
 
         const productErrors: Partial<Record<keyof DetailFormData, string>> = {};
 
+        // A mural without configured variants offers nothing to pick:
+        // only the printed note can be required
+        if (!product.variants) {
+            if (!hasValue(data.note, product.id)) {
+                productErrors.note =
+                    'Este campo es requerido cuando el producto es un mural';
+                errors[product.id] = productErrors;
+            }
+
+            return;
+        }
+
         if (!hasValue(data.orientation, product.id)) {
             productErrors.orientation = 'Debes elegir una opción';
         }
@@ -127,7 +139,8 @@ export const buildProductOrders = (
         combo_id: product.combo_id,
         product_id: product.id,
         variant:
-            product.product_type_id === MURAL_PRODUCT_TYPE_ID
+            product.product_type_id === MURAL_PRODUCT_TYPE_ID &&
+            product.variants
                 ? {
                       orientation: valueFor(data.orientation, product.id)!,
                       photo_type: valueFor(data.photoType, product.id)!,

--- a/resources/js/pages/products/form.ts
+++ b/resources/js/pages/products/form.ts
@@ -1,3 +1,5 @@
+export type ProductVariants = NonNullable<Product['variants']>;
+
 export type FormData = Pick<Product, 'name' | 'product_type_id'> & {
     unit_price: string;
     max_payments: string;
@@ -10,26 +12,26 @@ export type FormData = Pick<Product, 'name' | 'product_type_id'> & {
     };
 };
 
-export const orientations: Product['variants']['orientations'] = [
+export const orientations: ProductVariants['orientations'] = [
     'vertical',
     'horizontal',
 ];
 
 export const colors: Color[] = ['white', 'black', 'blue', 'pink'];
 
-export const backgrounds: Product['variants']['backgrounds'] = [
+export const backgrounds: ProductVariants['backgrounds'] = [
     'white',
     'black',
     'blue',
     'pink',
 ];
 
-export const photo_types: Product['variants']['photo_types'] = [
+export const photo_types: ProductVariants['photo_types'] = [
     'individual',
     'grupo',
 ];
 
-export const default_variants: Product['variants'] = {
+export const default_variants: ProductVariants = {
     dimentions: '',
     photo_types: ['grupo'],
     orientations: ['vertical'],

--- a/resources/js/pages/products/index.tsx
+++ b/resources/js/pages/products/index.tsx
@@ -176,9 +176,9 @@ export default function Products({
                                     )}
                                 </TableCell>
                                 <TableCell>
-                                    {product.variants?.backgrounds?.length >
-                                        0 &&
-                                        product.variants.backgrounds.map(
+                                    {(product.variants?.backgrounds ?? [])
+                                        .length > 0 &&
+                                        product.variants?.backgrounds.map(
                                             (background) => (
                                                 <Badge
                                                     variant="secondary"
@@ -190,15 +190,18 @@ export default function Products({
                                         )}
                                 </TableCell>
                                 <TableCell>
-                                    {product.variants?.colors?.length > 0 &&
-                                        product.variants.colors.map((color) => (
-                                            <Badge
-                                                variant="secondary"
-                                                key={color}
-                                            >
-                                                {getColorEs(color)}
-                                            </Badge>
-                                        ))}
+                                    {(product.variants?.colors ?? []).length >
+                                        0 &&
+                                        product.variants?.colors.map(
+                                            (color) => (
+                                                <Badge
+                                                    variant="secondary"
+                                                    key={color}
+                                                >
+                                                    {getColorEs(color)}
+                                                </Badge>
+                                            ),
+                                        )}
                                 </TableCell>
                                 <TableCell className="flex gap-2">
                                     <Link

--- a/resources/js/pages/products/partials/product-design.tsx
+++ b/resources/js/pages/products/partials/product-design.tsx
@@ -5,7 +5,11 @@ import {
     Users,
 } from 'lucide-react';
 
-export function ProductDesign({ variants }: { variants: Product['variants'] }) {
+export function ProductDesign({
+    variants,
+}: {
+    variants: NonNullable<Product['variants']>;
+}) {
     return (
         <div className="flex gap-1">
             {variants.photo_types?.length > 0 &&

--- a/resources/js/pages/stock/partials/delete-confirmation.tsx
+++ b/resources/js/pages/stock/partials/delete-confirmation.tsx
@@ -2,6 +2,7 @@ import {
     AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,
+    AlertDialogContent,
     AlertDialogDescription,
     AlertDialogFooter,
     AlertDialogHeader,
@@ -9,7 +10,6 @@ import {
 } from '@/components/ui/alert-dialog';
 import { buttonVariants } from '@/components/ui/button';
 import { useForm } from '@inertiajs/react';
-import { AlertDialogContent } from '@radix-ui/react-alert-dialog';
 
 export function DeleteStockableConfirmation({
     stockable,
@@ -23,7 +23,7 @@ export function DeleteStockableConfirmation({
     const { delete: destroy, processing } = useForm();
 
     const onDestroy = () => {
-        destroy(route('stockables.update', { stockable: stockable.id }), {
+        destroy(route('stockables.destroy', { stockable: stockable.id }), {
             onFinish: () => onClose(),
         });
     };

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -103,13 +103,14 @@ declare global {
         max_payments: number;
         product_type_id: number;
         type: ProductType;
-        variants: {
+        /** Nullable in the database: murals without variants exist */
+        variants?: {
             photo_types: ProductPhotoType[];
             orientations: ProductOrientation[];
             backgrounds: string[];
             colors: Color[];
             dimentions: string;
-        };
+        } | null;
     }
 
     interface OrderProduct extends Product {

--- a/tests/Feature/ComboTest.php
+++ b/tests/Feature/ComboTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Combo;
+use App\Models\Product;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+
+it('opens the edit page exposing pivot quantity and variants', function () {
+    actingAsRole();
+
+    $product = Product::factory()->mural()->create();
+
+    $combo = Combo::create([
+        'name' => 'Combo test',
+        'suggested_price' => 64000,
+        'suggested_max_payments' => 4,
+    ]);
+
+    $combo->products()->attach($product->id, [
+        'quantity' => 2,
+        'variants' => ['orientations' => ['vertical']],
+    ]);
+
+    // Regression: quantity was missing from withPivot and strict mode
+    // turned the resource access into a 500
+    get(route('combos.edit', $combo))->assertInertia(
+        fn (Assert $page) => $page
+            ->component('combos/edit')
+            ->where('combo.data.products.0.quantity', 2)
+            ->where('combo.data.products.0.variants.orientations.0', 'vertical'),
+    );
+});
+
+it('stores variants encoded once and returns them as an array', function () {
+    actingAsRole();
+
+    $product = Product::factory()->mural()->create();
+
+    // Regression: the controller json_encoded variants that the pivot cast
+    // encoded again, leaving double-encoded JSON in the database
+    \Pest\Laravel\post(route('combos.store'), [
+        'name' => 'Combo roundtrip',
+        'suggested_price' => 64000,
+        'suggested_max_payments' => 4,
+        'products' => [
+            [
+                'id' => $product->id,
+                'quantity' => 1,
+                'variants' => ['orientations' => ['horizontal']],
+            ],
+        ],
+    ])->assertSessionHasNoErrors();
+
+    $combo = Combo::where('name', 'Combo roundtrip')->firstOrFail();
+
+    get(route('combos.edit', $combo))->assertInertia(
+        fn (Assert $page) => $page->where(
+            'combo.data.products.0.variants.orientations.0',
+            'horizontal',
+        ),
+    );
+});
+
+it('updates a combo keeping quantities', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create();
+
+    $combo = Combo::create([
+        'name' => 'Combo test',
+        'suggested_price' => 64000,
+        'suggested_max_payments' => 4,
+    ]);
+
+    $combo->products()->attach($product->id, ['quantity' => 1]);
+
+    \Pest\Laravel\put(route('combos.update', $combo), [
+        'name' => 'Combo renombrado',
+        'suggested_price' => 70000,
+        'suggested_max_payments' => 4,
+        'products' => [
+            ['id' => $product->id, 'quantity' => 3],
+        ],
+    ])->assertSessionHasNoErrors();
+
+    expect($combo->refresh()->name)->toBe('Combo renombrado')
+        ->and($combo->products()->first()?->pivot?->quantity)->toBe(3);
+});


### PR DESCRIPTION
* fix(combos): include quantity in the products pivot

* fix(combos): stop double encoding pivot variants

* fix(combos): open the variants modal from the edit button

* fix(products): seed the missing variants for cuadro 20x30

* fix(products): treat product variants as nullable everywhere

* fix(stock): use the styled alert dialog in the delete confirmation