### PR TITLE
feat(production-statuses): manage production stages per product type

### DIFF
--- a/app/Actions/ProductionStatuses/CreateProductionStatus.php
+++ b/app/Actions/ProductionStatuses/CreateProductionStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\ProductionStatuses;
+
+use App\Models\ProductionStatus;
+
+class CreateProductionStatus
+{
+    /**
+     * Append a new stage at the end of the product type's chain.
+     */
+    public function handle(int $productTypeId, string $name): ProductionStatus
+    {
+        $lastPosition = ProductionStatus::query()
+            ->where('product_type_id', $productTypeId)
+            ->max('position');
+
+        return ProductionStatus::create([
+            'product_type_id' => $productTypeId,
+            'name' => $name,
+            'position' => (is_numeric($lastPosition) ? (int) $lastPosition : 0) + 1,
+        ]);
+    }
+}

--- a/app/Actions/ProductionStatuses/DeleteProductionStatus.php
+++ b/app/Actions/ProductionStatuses/DeleteProductionStatus.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\ProductionStatuses;
+
+use App\Models\ProductionStatus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class DeleteProductionStatus
+{
+    /**
+     * Delete an unused stage and close the gap it leaves in the chain.
+     *
+     * @throws ValidationException when the stage is the only one of its
+     *                             type or has details currently in it
+     */
+    public function handle(ProductionStatus $status): void
+    {
+        $siblings = ProductionStatus::query()
+            ->where('product_type_id', $status->product_type_id)
+            ->count();
+
+        if ($siblings <= 1) {
+            throw ValidationException::withMessages([
+                'status' => 'No se puede eliminar la única etapa del tipo de producto.',
+            ]);
+        }
+
+        if ($status->orderDetails()->exists()) {
+            throw ValidationException::withMessages([
+                'status' => 'No se puede eliminar: hay productos en esta etapa. Renombrala o movelos primero.',
+            ]);
+        }
+
+        DB::transaction(function () use ($status) {
+            $status->delete();
+
+            $this->compactPositions($status->product_type_id);
+        });
+    }
+
+    private function compactPositions(int $productTypeId): void
+    {
+        $statuses = ProductionStatus::query()
+            ->where('product_type_id', $productTypeId)
+            ->orderBy('position')
+            ->get();
+
+        foreach ($statuses->values() as $index => $status) {
+            if ($status->position !== $index + 1) {
+                $status->update(['position' => $index + 1]);
+            }
+        }
+    }
+}

--- a/app/Actions/ProductionStatuses/ReorderProductionStatuses.php
+++ b/app/Actions/ProductionStatuses/ReorderProductionStatuses.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\ProductionStatuses;
+
+use App\Models\ProductionStatus;
+use Illuminate\Support\Facades\DB;
+
+class ReorderProductionStatuses
+{
+    /**
+     * Apply the given order to the stages of a product type. Expects an
+     * id list already validated against the type's stages.
+     *
+     * @param  array<int, int>  $orderedIds
+     */
+    public function handle(int $productTypeId, array $orderedIds): void
+    {
+        DB::transaction(function () use ($productTypeId, $orderedIds) {
+            // Two-phase update: (product_type_id, position) is unique, so
+            // park every stage above the current range first
+            $maxPosition = ProductionStatus::query()
+                ->where('product_type_id', $productTypeId)
+                ->max('position');
+
+            $offset = is_numeric($maxPosition) ? (int) $maxPosition : 0;
+
+            foreach ($orderedIds as $index => $id) {
+                ProductionStatus::whereKey($id)->update(['position' => $offset + $index + 1]);
+            }
+
+            foreach ($orderedIds as $index => $id) {
+                ProductionStatus::whereKey($id)->update(['position' => $index + 1]);
+            }
+        });
+    }
+}

--- a/app/Http/Controllers/BO/ProductionStatusController.php
+++ b/app/Http/Controllers/BO/ProductionStatusController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Actions\ProductionStatuses\CreateProductionStatus;
+use App\Actions\ProductionStatuses\DeleteProductionStatus;
+use App\Actions\ProductionStatuses\ReorderProductionStatuses;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\BO\ReorderProductionStatusesRequest;
+use App\Http\Requests\BO\StoreProductionStatusRequest;
+use App\Http\Requests\BO\UpdateProductionStatusRequest;
+use App\Http\Resources\ProductTypeResource;
+use App\Models\ProductionStatus;
+use App\Models\ProductType;
+use Inertia\Inertia;
+
+class ProductionStatusController extends Controller
+{
+    public function index(): \Inertia\Response
+    {
+        $types = ProductType::query()
+            ->with(['productionStatuses' => fn ($query) => $query
+                ->withCount(['orderDetails as details_count'])
+                ->orderBy('position'),
+            ])
+            ->get();
+
+        return Inertia::render('production-statuses/index', [
+            'productTypes' => ProductTypeResource::collection($types)->resolve(),
+        ]);
+    }
+
+    public function store(StoreProductionStatusRequest $request, CreateProductionStatus $action): \Illuminate\Http\RedirectResponse
+    {
+        /** @var array{product_type_id: int, name: string} $validated */
+        $validated = $request->validated();
+
+        $action->handle($validated['product_type_id'], $validated['name']);
+
+        return back()->with('success', "Etapa \"{$validated['name']}\" agregada");
+    }
+
+    public function update(UpdateProductionStatusRequest $request, ProductionStatus $productionStatus): \Illuminate\Http\RedirectResponse
+    {
+        $productionStatus->update($request->validated());
+
+        return back()->with('success', 'Etapa renombrada');
+    }
+
+    public function destroy(ProductionStatus $productionStatus, DeleteProductionStatus $action): \Illuminate\Http\RedirectResponse
+    {
+        $action->handle($productionStatus);
+
+        return back()->with('success', "Etapa \"{$productionStatus->name}\" eliminada");
+    }
+
+    public function reorder(ReorderProductionStatusesRequest $request, ReorderProductionStatuses $action): \Illuminate\Http\RedirectResponse
+    {
+        /** @var array{product_type_id: int, ordered_ids: array<int, int>} $validated */
+        $validated = $request->validated();
+
+        $action->handle($validated['product_type_id'], $validated['ordered_ids']);
+
+        return back()->with('success', 'Orden de etapas actualizado');
+    }
+}

--- a/app/Http/Requests/BO/ReorderProductionStatusesRequest.php
+++ b/app/Http/Requests/BO/ReorderProductionStatusesRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Models\ProductionStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class ReorderProductionStatusesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'product_type_id' => ['required', 'integer', 'exists:product_types,id'],
+            'ordered_ids' => ['required', 'array', 'min:1'],
+            'ordered_ids.*' => ['required', 'integer', 'distinct'],
+        ];
+    }
+
+    /**
+     * The reorder must include every stage of the type, and nothing else.
+     *
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                if ($validator->errors()->isNotEmpty()) {
+                    return;
+                }
+
+                $currentIds = ProductionStatus::query()
+                    ->where('product_type_id', $this->integer('product_type_id'))
+                    ->pluck('id')
+                    ->sort()
+                    ->values()
+                    ->all();
+
+                $orderedIds = collect($this->array('ordered_ids'))
+                    ->map(fn ($id) => intval($id))
+                    ->sort()
+                    ->values()
+                    ->all();
+
+                if ($currentIds !== $orderedIds) {
+                    $validator->errors()->add(
+                        'ordered_ids',
+                        'El orden enviado no coincide con las etapas del tipo de producto.',
+                    );
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Requests/BO/StoreProductionStatusRequest.php
+++ b/app/Http/Requests/BO/StoreProductionStatusRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProductionStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'product_type_id' => ['required', 'integer', 'exists:product_types,id'],
+            'name' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('production_statuses')
+                    ->where('product_type_id', $this->integer('product_type_id')),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.unique' => 'Ya existe una etapa con ese nombre para este tipo de producto.',
+        ];
+    }
+}

--- a/app/Http/Requests/BO/UpdateProductionStatusRequest.php
+++ b/app/Http/Requests/BO/UpdateProductionStatusRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Models\ProductionStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateProductionStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        /** @var ProductionStatus $status */
+        $status = $this->route('productionStatus');
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('production_statuses')
+                    ->where('product_type_id', $status->product_type_id)
+                    ->ignore($status->id),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.unique' => 'Ya existe una etapa con ese nombre para este tipo de producto.',
+        ];
+    }
+}

--- a/app/Http/Resources/ProductTypeResource.php
+++ b/app/Http/Resources/ProductTypeResource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\ProductionStatus;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\ProductType
+ */
+class ProductTypeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'statuses' => $this->whenLoaded('productionStatuses', function () {
+                return $this->productionStatuses->map(function (ProductionStatus $status) {
+                    $detailsCount = $status->getAttribute('details_count');
+
+                    return [
+                        'id' => $status->id,
+                        'name' => $status->name,
+                        'position' => $status->position,
+                        'details_count' => is_numeric($detailsCount) ? (int) $detailsCount : 0,
+                    ];
+                });
+            }),
+        ];
+    }
+}

--- a/app/Models/ProductionStatus.php
+++ b/app/Models/ProductionStatus.php
@@ -17,4 +17,12 @@ class ProductionStatus extends Model
     {
         return $this->belongsTo(ProductType::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<OrderDetail, $this>
+     */
+    public function orderDetails()
+    {
+        return $this->hasMany(OrderDetail::class);
+    }
 }

--- a/resources/js/components/app-sidebar.test.tsx
+++ b/resources/js/components/app-sidebar.test.tsx
@@ -50,6 +50,7 @@ describe('AppSidebar', () => {
             'Seguimiento',
             'Stockeables',
             'Reciclaje',
+            'Etapas',
             'Usuarios',
         ]) {
             expect(screen.getByText(item)).toBeTruthy();
@@ -73,6 +74,7 @@ describe('AppSidebar', () => {
             'Escuelas',
             'Combos',
             'Productos',
+            'Etapas',
             'Usuarios',
         ]) {
             expect(screen.queryByText(item)).toBeNull();
@@ -83,6 +85,7 @@ describe('AppSidebar', () => {
         renderSidebarAs(['administración']);
 
         expect(screen.getByText('Pedidos')).toBeTruthy();
+        expect(screen.getByText('Etapas')).toBeTruthy();
         expect(screen.queryByText('Usuarios')).toBeNull();
     });
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import { Link, usePage } from '@inertiajs/react';
 import {
     Group,
     Home,
+    ListOrdered,
     Package,
     PackageOpen,
     Recycle,
@@ -27,6 +28,7 @@ import { NavUser } from './nav-user';
 
 const SALES = ['master', 'administración', 'oficina'];
 const PRODUCTION = ['master', 'administración', 'oficina', 'taller'];
+const MANAGEMENT = ['master', 'administración'];
 
 const routeables = [
     { name: 'Dashboard', route: 'dashboard', icon: Home, roles: null },
@@ -56,6 +58,12 @@ const routeables = [
         route: 'recycling.index',
         icon: Recycle,
         roles: PRODUCTION,
+    },
+    {
+        name: 'Etapas',
+        route: 'production-statuses.index',
+        icon: ListOrdered,
+        roles: MANAGEMENT,
     },
     { name: 'Usuarios', route: 'users.index', icon: Users, roles: ['master'] },
 ] as const;

--- a/resources/js/pages/production-statuses/index.tsx
+++ b/resources/js/pages/production-statuses/index.tsx
@@ -1,0 +1,94 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { capitalize } from '@/lib/utils';
+import { BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/react';
+import { ListOrdered } from 'lucide-react';
+import { useState } from 'react';
+import { AddStatusForm } from './partials/add-status-form';
+import { DeleteStatusConfirmation } from './partials/delete-confirmation';
+import { StatusItem } from './partials/status-item';
+import {
+    ProductTypeRow,
+    StatusRow,
+    useStatusActions,
+} from './partials/use-status-actions';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Etapas de producción',
+        href: route('production-statuses.index'),
+    },
+];
+
+export default function ProductionStatusesIndex({
+    productTypes,
+}: PageProps<{ productTypes: ProductTypeRow[] }>) {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Etapas de producción" />
+
+            <section className="px-6 pt-6">
+                <h1 className="flex items-center gap-2 text-3xl font-bold">
+                    <ListOrdered className="h-8 w-8" />
+                    Etapas de producción
+                </h1>
+                <p className="mt-1 text-gray-500">
+                    Agregá, renombrá o reordená las etapas de cada tipo de
+                    producto. Los insumos se descuentan cuando un producto pasa
+                    a la <strong>segunda</strong> etapa de su cadena.
+                </p>
+            </section>
+
+            <section className="grid gap-6 p-6 md:grid-cols-2 xl:grid-cols-3">
+                {productTypes.map((type) => (
+                    <ProductTypeCard key={type.id} type={type} />
+                ))}
+            </section>
+        </AppLayout>
+    );
+}
+
+function ProductTypeCard({ type }: { type: ProductTypeRow }) {
+    const { move, rename, add } = useStatusActions(type);
+    const [deletableStatus, setDeletableStatus] = useState<StatusRow | null>(
+        null,
+    );
+
+    return (
+        <Card>
+            {deletableStatus && (
+                <DeleteStatusConfirmation
+                    status={deletableStatus}
+                    show={Boolean(deletableStatus)}
+                    onClose={() => setDeletableStatus(null)}
+                />
+            )}
+
+            <CardHeader>
+                <CardTitle className="text-xl">
+                    {capitalize(type.name)}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+                {type.statuses.map((status, index) => (
+                    <StatusItem
+                        key={status.id}
+                        status={status}
+                        isFirst={index === 0}
+                        isLast={index === type.statuses.length - 1}
+                        isOnly={type.statuses.length === 1}
+                        onMoveUp={() => move(index, -1)}
+                        onMoveDown={() => move(index, 1)}
+                        onRename={(name, onSuccess) =>
+                            rename(status.id, name, onSuccess)
+                        }
+                        onDelete={() => setDeletableStatus(status)}
+                    />
+                ))}
+
+                <AddStatusForm onAdd={add} />
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/pages/production-statuses/partials/add-status-form.tsx
+++ b/resources/js/pages/production-statuses/partials/add-status-form.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Plus } from 'lucide-react';
+import { FormEvent, useState } from 'react';
+
+export function AddStatusForm({
+    onAdd,
+}: {
+    onAdd: (name: string, onSuccess: () => void) => void;
+}) {
+    const [name, setName] = useState('');
+
+    const submit = (e: FormEvent) => {
+        e.preventDefault();
+
+        if (!name.trim()) return;
+
+        onAdd(name.trim(), () => setName(''));
+    };
+
+    return (
+        <form onSubmit={submit} className="flex items-center gap-2 pt-2">
+            <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Nueva etapa..."
+                className="h-8"
+            />
+            <Button size="sm" variant="outline" type="submit">
+                <Plus className="h-4 w-4" />
+                Agregar
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/pages/production-statuses/partials/delete-confirmation.tsx
+++ b/resources/js/pages/production-statuses/partials/delete-confirmation.tsx
@@ -1,0 +1,73 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { buttonVariants } from '@/components/ui/button';
+import { useForm } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+export function DeleteStatusConfirmation({
+    status,
+    show,
+    onClose,
+}: {
+    status: ProductionStatus;
+    show: boolean;
+    onClose: CallableFunction;
+}) {
+    const { delete: destroy, processing } = useForm();
+
+    const onDestroy = () => {
+        destroy(
+            route('production-statuses.destroy', {
+                productionStatus: status.id,
+            }),
+            {
+                preserveScroll: true,
+                onSuccess: () =>
+                    toast.success(`Etapa "${status.name}" eliminada`),
+                onError: (errors) =>
+                    toast.error(
+                        Object.values(errors)[0] ??
+                            'No se pudo eliminar la etapa',
+                    ),
+                onFinish: () => onClose(),
+            },
+        );
+    };
+
+    return (
+        <AlertDialog open={show} onOpenChange={() => onClose()}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>
+                        ¿Eliminar la etapa "{status.name}"?
+                    </AlertDialogTitle>
+                </AlertDialogHeader>
+
+                <AlertDialogDescription>
+                    Las etapas siguientes se reordenan automáticamente. No se
+                    puede eliminar una etapa con productos en producción.
+                </AlertDialogDescription>
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+
+                    <AlertDialogAction
+                        className={buttonVariants({ variant: 'destructive' })}
+                        disabled={processing}
+                        onClick={onDestroy}
+                    >
+                        Eliminar etapa
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/resources/js/pages/production-statuses/partials/status-item.tsx
+++ b/resources/js/pages/production-statuses/partials/status-item.tsx
@@ -1,0 +1,131 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ArrowDown, ArrowUp, Check, Pencil, Trash2, X } from 'lucide-react';
+import { FormEvent, useState } from 'react';
+import { StatusRow } from './use-status-actions';
+
+export function StatusItem({
+    status,
+    isFirst,
+    isLast,
+    isOnly,
+    onMoveUp,
+    onMoveDown,
+    onRename,
+    onDelete,
+}: {
+    status: StatusRow;
+    isFirst: boolean;
+    isLast: boolean;
+    isOnly: boolean;
+    onMoveUp: () => void;
+    onMoveDown: () => void;
+    onRename: (name: string, onSuccess: () => void) => void;
+    onDelete: () => void;
+}) {
+    const [editing, setEditing] = useState(false);
+    const [name, setName] = useState(status.name);
+
+    const rename = (e: FormEvent) => {
+        e.preventDefault();
+
+        if (name.trim() === status.name) {
+            setEditing(false);
+            return;
+        }
+
+        onRename(name.trim(), () => setEditing(false));
+    };
+
+    const inUse = status.details_count > 0;
+
+    return (
+        <div className="flex items-center gap-2 rounded-lg border border-gray-200 p-2 dark:border-gray-700">
+            <Badge variant="outline" className="w-8 justify-center">
+                {status.position}
+            </Badge>
+
+            {editing ? (
+                <form
+                    onSubmit={rename}
+                    className="flex flex-1 items-center gap-1"
+                >
+                    <Input
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="h-8"
+                        autoFocus
+                    />
+                    <Button size="sm" variant="ghost" type="submit">
+                        <Check className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        type="button"
+                        onClick={() => {
+                            setName(status.name);
+                            setEditing(false);
+                        }}
+                    >
+                        <X className="h-4 w-4" />
+                    </Button>
+                </form>
+            ) : (
+                <>
+                    <span className="flex-1 text-sm">{status.name}</span>
+                    {inUse && (
+                        <span
+                            className="text-xs text-gray-500"
+                            title="Productos actualmente en esta etapa"
+                        >
+                            {status.details_count} en curso
+                        </span>
+                    )}
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={isFirst}
+                        title="Subir"
+                        onClick={onMoveUp}
+                    >
+                        <ArrowUp className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={isLast}
+                        title="Bajar"
+                        onClick={onMoveDown}
+                    >
+                        <ArrowDown className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        title="Renombrar"
+                        onClick={() => setEditing(true)}
+                    >
+                        <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={isOnly || inUse}
+                        title={
+                            isOnly
+                                ? 'No se puede eliminar la única etapa'
+                                : inUse
+                                  ? 'Hay productos en esta etapa'
+                                  : 'Eliminar'
+                        }
+                        onClick={onDelete}
+                    >
+                        <Trash2 className="h-4 w-4" />
+                    </Button>
+                </>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/production-statuses/partials/use-status-actions.ts
+++ b/resources/js/pages/production-statuses/partials/use-status-actions.ts
@@ -1,0 +1,61 @@
+import { router } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+export type StatusRow = ProductionStatus & { details_count: number };
+export type ProductTypeRow = ProductType & { statuses: StatusRow[] };
+
+const onError = (errors: Record<string, string>) =>
+    toast.error(Object.values(errors)[0] ?? 'No se pudo guardar el cambio');
+
+/**
+ * Mutations for the stages of one product type.
+ */
+export function useStatusActions(type: ProductTypeRow) {
+    const move = (index: number, direction: -1 | 1) => {
+        const orderedIds = type.statuses.map((status) => status.id);
+        const target = index + direction;
+
+        [orderedIds[index], orderedIds[target]] = [
+            orderedIds[target],
+            orderedIds[index],
+        ];
+
+        router.put(
+            route('production-statuses.reorder'),
+            { product_type_id: type.id, ordered_ids: orderedIds },
+            { preserveScroll: true, onError },
+        );
+    };
+
+    const rename = (statusId: number, name: string, onSuccess: () => void) => {
+        router.put(
+            route('production-statuses.update', { productionStatus: statusId }),
+            { name },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    toast.success('Etapa renombrada');
+                    onSuccess();
+                },
+                onError,
+            },
+        );
+    };
+
+    const add = (name: string, onSuccess: () => void) => {
+        router.post(
+            route('production-statuses.store'),
+            { product_type_id: type.id, name },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    toast.success(`Etapa "${name}" agregada`);
+                    onSuccess();
+                },
+                onError,
+            },
+        );
+    };
+
+    return { move, rename, add };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\BO\OrderDraftController;
 use App\Http\Controllers\BO\PaymentController;
 use App\Http\Controllers\BO\PhotoController;
 use App\Http\Controllers\BO\ProductController;
+use App\Http\Controllers\BO\ProductionStatusController;
 use App\Http\Controllers\BO\RecyclingController;
 use App\Http\Controllers\BO\SchoolController;
 use App\Http\Controllers\BO\StockController;
@@ -54,6 +55,15 @@ Route::middleware(['auth', 'role:master,administración,oficina,taller'])->group
     Route::resource('stockables', StockController::class);
     Route::get('/stock-movements', [StockMovementController::class, 'index'])->name('stock-movements.index');
     Route::get('/recycling', [RecyclingController::class, 'index'])->name('recycling.index');
+});
+
+// Etapas de producción por tipo de producto: solo gerencia
+Route::middleware(['auth', 'role:master,administración'])->group(function () {
+    Route::get('/production-statuses', [ProductionStatusController::class, 'index'])->name('production-statuses.index');
+    Route::post('/production-statuses', [ProductionStatusController::class, 'store'])->name('production-statuses.store');
+    Route::put('/production-statuses/reorder', [ProductionStatusController::class, 'reorder'])->name('production-statuses.reorder');
+    Route::put('/production-statuses/{productionStatus}', [ProductionStatusController::class, 'update'])->name('production-statuses.update');
+    Route::delete('/production-statuses/{productionStatus}', [ProductionStatusController::class, 'destroy'])->name('production-statuses.destroy');
 });
 
 // Gestión de usuarios: solo gerencia

--- a/tests/Feature/ProductionStatusTest.php
+++ b/tests/Feature/ProductionStatusTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\ProductionStatus;
+use App\Models\ProductType;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\delete;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+it('renders the stages grouped by product type', function () {
+    actingAsRole(UserRole::Admin);
+
+    get(route('production-statuses.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('production-statuses/index')
+            ->has('productTypes', 7)
+            ->where('productTypes.0.name', 'mural')
+            ->where('productTypes.0.statuses.0.name', 'Sin foto')
+            ->where('productTypes.0.statuses.0.details_count', 0));
+});
+
+it('appends a new stage at the end of the chain', function () {
+    actingAsRole(UserRole::Admin);
+
+    $mural = ProductType::where('name', 'mural')->firstOrFail();
+
+    post(route('production-statuses.store'), [
+        'product_type_id' => $mural->id,
+        'name' => 'Control de calidad',
+    ])->assertSessionHasNoErrors();
+
+    $status = ProductionStatus::where('name', 'Control de calidad')->firstOrFail();
+
+    expect($status->product_type_id)->toBe($mural->id)
+        ->and($status->position)->toBe(7);
+});
+
+it('rejects a duplicated stage name within the same type', function () {
+    actingAsRole(UserRole::Admin);
+
+    $mural = ProductType::where('name', 'mural')->firstOrFail();
+
+    post(route('production-statuses.store'), [
+        'product_type_id' => $mural->id,
+        'name' => 'Impreso',
+    ])->assertSessionHasErrors('name');
+});
+
+it('allows reusing a stage name on a different type', function () {
+    actingAsRole(UserRole::Admin);
+
+    $taza = ProductType::where('name', 'taza')->firstOrFail();
+
+    post(route('production-statuses.store'), [
+        'product_type_id' => $taza->id,
+        'name' => 'Sin foto',
+    ])->assertSessionHasNoErrors();
+});
+
+it('renames a stage', function () {
+    actingAsRole(UserRole::Admin);
+
+    put(route('production-statuses.update', statusFor('mural', 1)), [
+        'name' => 'Sin fotografía',
+    ])->assertSessionHasNoErrors();
+
+    expect(statusFor('mural', 1)->name)->toBe('Sin fotografía');
+});
+
+it('deletes an unused stage and compacts the positions', function () {
+    actingAsRole(UserRole::Admin);
+
+    $status = statusFor('mural', 2);
+
+    delete(route('production-statuses.destroy', $status))
+        ->assertSessionHasNoErrors();
+
+    $positions = ProductionStatus::query()
+        ->where('product_type_id', $status->product_type_id)
+        ->orderBy('position')
+        ->pluck('position')
+        ->all();
+
+    expect($positions)->toBe([1, 2, 3, 4, 5])
+        ->and(statusFor('mural', 2)->name)->toBe('Pegado');
+});
+
+it('refuses to delete a stage with products in it', function () {
+    actingAsRole(UserRole::Admin);
+
+    $product = Product::factory()->mural()->create();
+    $status = statusFor('mural', 2);
+
+    OrderDetail::factory()->create([
+        'product_id' => $product->id,
+        'production_status_id' => $status->id,
+    ]);
+
+    delete(route('production-statuses.destroy', $status))
+        ->assertSessionHasErrors('status');
+
+    expect(ProductionStatus::whereKey($status->id)->exists())->toBeTrue();
+});
+
+it('refuses to delete the only stage of a type', function () {
+    actingAsRole(UserRole::Admin);
+
+    delete(route('production-statuses.destroy', statusFor('foto', 3)))
+        ->assertSessionHasNoErrors();
+    delete(route('production-statuses.destroy', statusFor('foto', 2)))
+        ->assertSessionHasNoErrors();
+
+    delete(route('production-statuses.destroy', statusFor('foto', 1)))
+        ->assertSessionHasErrors('status');
+});
+
+it('reorders the stages of a type', function () {
+    actingAsRole(UserRole::Admin);
+
+    $mural = ProductType::where('name', 'mural')->firstOrFail();
+
+    $orderedIds = ProductionStatus::query()
+        ->where('product_type_id', $mural->id)
+        ->orderBy('position')
+        ->pluck('id')
+        ->reverse()
+        ->values()
+        ->all();
+
+    put(route('production-statuses.reorder'), [
+        'product_type_id' => $mural->id,
+        'ordered_ids' => $orderedIds,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+
+    expect(statusFor('mural', 1)->name)->toBe('Embolsado')
+        ->and(statusFor('mural', 6)->name)->toBe('Sin foto');
+});
+
+it('rejects a reorder that does not include every stage of the type', function () {
+    actingAsRole(UserRole::Admin);
+
+    $mural = ProductType::where('name', 'mural')->firstOrFail();
+
+    put(route('production-statuses.reorder'), [
+        'product_type_id' => $mural->id,
+        'ordered_ids' => [statusFor('mural', 1)->id],
+    ])->assertSessionHasErrors('ordered_ids');
+});

--- a/tests/Feature/RoleAccessTest.php
+++ b/tests/Feature/RoleAccessTest.php
@@ -16,15 +16,18 @@ it('enforces route access by role', function (UserRole $role, string $routeName,
     'master ve pedidos' => [UserRole::Master, 'orders.index', 200],
     'master ve seguimiento' => [UserRole::Master, 'tracking.index', 200],
     'master ve usuarios' => [UserRole::Master, 'users.index', 200],
+    'master ve etapas' => [UserRole::Master, 'production-statuses.index', 200],
 
     // administración: todo el día a día, sin gestión de usuarios
     'administración ve pedidos' => [UserRole::Admin, 'orders.index', 200],
     'administración ve seguimiento' => [UserRole::Admin, 'tracking.index', 200],
+    'administración ve etapas' => [UserRole::Admin, 'production-statuses.index', 200],
     'administración no ve usuarios' => [UserRole::Admin, 'users.index', 403],
 
-    // oficina: como administración
+    // oficina: como administración, sin configuración de etapas
     'oficina ve pedidos' => [UserRole::Office, 'orders.index', 200],
     'oficina ve stock' => [UserRole::Office, 'stockables.index', 200],
+    'oficina no ve etapas' => [UserRole::Office, 'production-statuses.index', 403],
     'oficina no ve usuarios' => [UserRole::Office, 'users.index', 403],
 
     // taller: solo producción y stock
@@ -34,6 +37,7 @@ it('enforces route access by role', function (UserRole $role, string $routeName,
     'taller ve stock' => [UserRole::Worker, 'stockables.index', 200],
     'taller ve movimientos' => [UserRole::Worker, 'stock-movements.index', 200],
     'taller ve reciclaje' => [UserRole::Worker, 'recycling.index', 200],
+    'taller no ve etapas' => [UserRole::Worker, 'production-statuses.index', 403],
     'taller no ve usuarios' => [UserRole::Worker, 'users.index', 403],
 
     // editor: solo fotos (se prueba aparte, requiere un curso)


### PR DESCRIPTION
Pantalla `/production-statuses` (ítem **Etapas** del sidebar) para que gerencia gestione las cadenas de producción sin tocar código. Roles: **master + administración**.

## Qué permite

- **Agregar** una etapa (se agrega al final de la cadena; nombre único por tipo).
- **Renombrar** inline.
- **Reordenar** con flechas ↑↓ (update en dos fases por el unique `(product_type_id, position)`).
- **Eliminar** con confirmación: bloqueado si es la única etapa del tipo o si hay `order_details` apuntándole (el botón se deshabilita mostrando "N en curso"); al eliminar se compactan las posiciones.

## Consideraciones del issue

- Detalles apuntando a una etapa eliminada: **no puede pasar** — la eliminación se bloquea si la etapa está en uso.
- Impacto del descuento de stock (posición ≥ 2): la página lo advierte en el encabezado; el descuento es idempotente por detalle, así que reordenar no genera dobles descuentos.

## Estructura

Sigue las reglas de code quality: controller fino + `FormRequest`s (`Store/Update/ReorderProductionStatus*`) + Actions (`app/Actions/ProductionStatuses/`) + `ProductTypeResource`; frontend dividido en partials con las mutaciones en un hook (`use-status-actions`).

Tests: `ProductionStatusTest` (10 casos: alta con posición, unicidad por tipo, rename, delete con compactación, guardas de última etapa y en-uso, reorder + validación del set de ids), matriz de roles y sidebar actualizados. Suites completas verdes (Pest 78, Vitest 76).

Closes #57