### PR TITLE
feat(payments): render the receipt as an image and share it via whatsapp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
                 "clsx": "^2.1.1",
                 "cmdk": "^1.0.0",
                 "date-fns": "^3.6.0",
-                "jspdf": "^4.2.1",
                 "lucide-react": "^0.468.0",
                 "next-themes": "^0.4.6",
                 "react-day-picker": "^8.10.1",
@@ -3007,25 +3006,12 @@
                 "undici-types": "~6.21.0"
             }
         },
-        "node_modules/@types/pako": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-            "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-            "license": "MIT"
-        },
         "node_modules/@types/prop-types": {
             "version": "15.7.14",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
             "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
             "devOptional": true,
             "license": "MIT"
-        },
-        "node_modules/@types/raf": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-            "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/react": {
             "version": "18.3.14",
@@ -3047,13 +3033,6 @@
             "dependencies": {
                 "@types/react": "^18"
             }
-        },
-        "node_modules/@types/trusted-types": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.18.0",
@@ -3745,16 +3724,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
-        "node_modules/base64-arraybuffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-            "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.6.0"
-            }
-        },
         "node_modules/bidi-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3913,26 +3882,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/canvg": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-            "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "@types/raf": "^3.4.0",
-                "core-js": "^3.8.3",
-                "raf": "^3.4.1",
-                "regenerator-runtime": "^0.13.7",
-                "rgbcolor": "^1.0.1",
-                "stackblur-canvas": "^2.0.0",
-                "svg-pathdata": "^6.0.3"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/chai": {
             "version": "5.3.3",
@@ -4575,18 +4524,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/core-js": {
-            "version": "3.49.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4599,16 +4536,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/css-line-break": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "utrie": "^1.0.2"
             }
         },
         "node_modules/css-tree": {
@@ -4882,16 +4809,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/dompurify": {
-            "version": "3.4.11",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
-            "license": "(MPL-2.0 OR Apache-2.0)",
-            "optional": true,
-            "optionalDependencies": {
-                "@types/trusted-types": "^2.0.7"
-            }
         },
         "node_modules/dunder-proto": {
             "version": "1.0.0",
@@ -5577,17 +5494,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-png": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
-            "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pako": "^2.0.3",
-                "iobuffer": "^5.3.2",
-                "pako": "^2.1.0"
-            }
-        },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -5596,12 +5502,6 @@
             "dependencies": {
                 "reusify": "^1.0.4"
             }
-        },
-        "node_modules/fflate": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-            "license": "MIT"
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -6101,20 +6001,6 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/html2canvas": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "css-line-break": "^2.1.0",
-                "text-segmentation": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6185,12 +6071,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/iobuffer": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
-            "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
-            "license": "MIT"
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.4",
@@ -6774,23 +6654,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jspdf": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
-            "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6",
-                "fast-png": "^6.2.0",
-                "fflate": "^0.8.1"
-            },
-            "optionalDependencies": {
-                "canvg": "^3.0.11",
-                "core-js": "^3.6.0",
-                "dompurify": "^3.3.1",
-                "html2canvas": "^1.0.0-rc.5"
-            }
-        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -7315,22 +7178,6 @@
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "license": "BlueOak-1.0.0"
         },
-        "node_modules/pako": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-            "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "(MIT AND Zlib)"
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7440,13 +7287,6 @@
             "engines": {
                 "node": ">= 14.16"
             }
-        },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -7892,16 +7732,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/raf": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-            "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "performance-now": "^2.1.0"
-            }
-        },
         "node_modules/react": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -8071,13 +7901,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
@@ -8153,16 +7976,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rgbcolor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-            "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-            "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.8.15"
             }
         },
         "node_modules/rimraf": {
@@ -8468,16 +8281,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/stackblur-canvas": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-            "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.1.14"
-            }
-        },
         "node_modules/std-env": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -8732,16 +8535,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/svg-pathdata": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-            "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8844,16 +8637,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/text-segmentation": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "utrie": "^1.0.2"
             }
         },
         "node_modules/text-table": {
@@ -9321,16 +9104,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
-        },
-        "node_modules/utrie": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "base64-arraybuffer": "^1.0.2"
-            }
         },
         "node_modules/vite": {
             "version": "5.4.11",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
-        "jspdf": "^4.2.1",
         "lucide-react": "^0.468.0",
         "next-themes": "^0.4.6",
         "react-day-picker": "^8.10.1",

--- a/resources/js/lib/clipboard.test.ts
+++ b/resources/js/lib/clipboard.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyImageToClipboard } from './clipboard';
+
+const blob = new Blob(['png'], { type: 'image/png' });
+
+class FakeClipboardItem {
+    constructor(public readonly data: Record<string, Blob>) {}
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('copyImageToClipboard', () => {
+    it('returns false when the async clipboard api is unavailable', async () => {
+        await expect(copyImageToClipboard(blob)).resolves.toBe(false);
+    });
+
+    it('writes the image and returns true', async () => {
+        vi.stubGlobal('ClipboardItem', FakeClipboardItem);
+        const write = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, { clipboard: { write } });
+
+        await expect(copyImageToClipboard(blob)).resolves.toBe(true);
+
+        const [items] = write.mock.calls[0] as [FakeClipboardItem[]];
+        expect(items[0].data['image/png']).toBe(blob);
+    });
+
+    it('returns false when the write is rejected', async () => {
+        vi.stubGlobal('ClipboardItem', FakeClipboardItem);
+        Object.assign(navigator, {
+            clipboard: { write: vi.fn().mockRejectedValue(new Error('nope')) },
+        });
+
+        await expect(copyImageToClipboard(blob)).resolves.toBe(false);
+    });
+});

--- a/resources/js/lib/clipboard.ts
+++ b/resources/js/lib/clipboard.ts
@@ -1,0 +1,23 @@
+/**
+ * Copies an image blob to the system clipboard. Returns false when the
+ * Async Clipboard API is unavailable or the write is not allowed, so
+ * callers can degrade to another strategy.
+ */
+export async function copyImageToClipboard(blob: Blob): Promise<boolean> {
+    if (
+        typeof ClipboardItem === 'undefined' ||
+        typeof navigator.clipboard?.write !== 'function'
+    ) {
+        return false;
+    }
+
+    try {
+        await navigator.clipboard.write([
+            new ClipboardItem({ [blob.type]: blob }),
+        ]);
+
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/resources/js/lib/receipt.test.ts
+++ b/resources/js/lib/receipt.test.ts
@@ -1,38 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { downloadPaymentReceipt } from './receipt';
-
-const pdf = vi.hoisted(() => ({
-    texts: [] as string[],
-    saved: [] as string[],
-}));
-
-vi.mock('jspdf', () => ({
-    jsPDF: class {
-        internal = { pageSize: { getWidth: () => 148 } };
-
-        setFont() {}
-
-        setFontSize() {}
-
-        setDrawColor() {}
-
-        setFillColor() {}
-
-        setTextColor() {}
-
-        line() {}
-
-        rect() {}
-
-        text(value: string | string[]) {
-            pdf.texts.push(String(value));
-        }
-
-        save(filename: string) {
-            pdf.saved.push(filename);
-        }
-    },
-}));
+import { describe, expect, it } from 'vitest';
+import { receiptContent, receiptShareText } from './receipt';
 
 const order = {
     id: 3,
@@ -54,43 +21,56 @@ const payment = {
     proof_of_payment: null,
 } as Payment;
 
-beforeEach(() => {
-    pdf.texts.length = 0;
-    pdf.saved.length = 0;
-});
+describe('receiptContent', () => {
+    it('describes the receipt with the payment and order data', () => {
+        const content = receiptContent({ payment, order });
 
-describe('downloadPaymentReceipt', () => {
-    it('renders the receipt data and downloads it with a descriptive name', () => {
-        downloadPaymentReceipt({ payment, order });
+        expect(content.title).toBe('Fototobares');
+        expect(content.subtitle).toBe('Comprobante de pago N° 12');
+        expect(content.rows).toContainEqual(['Cliente', 'Carla López']);
+        expect(content.rows).toContainEqual(['Pedido', '#3']);
+        expect(content.rows).toContainEqual(['Escuela', 'Escuela Test (a 5)']);
+        expect(content.rows).toContainEqual(['Niño/a', 'Luca']);
+        expect(content.rows).toContainEqual(['Fecha', '06/07/2026']);
+        expect(content.fileName).toBe('comprobante-pago-12-pedido-3.png');
+    });
 
-        const content = pdf.texts.join('\n');
+    it('omits the child row when the order has no child name', () => {
+        const content = receiptContent({
+            payment,
+            order: { ...order, child_name: undefined } as Order,
+        });
 
-        expect(content).toContain('Fototobares');
-        expect(content).toContain('Comprobante de pago N° 12');
-        expect(content).toContain('Carla López');
-        expect(content).toContain('#3');
-        expect(content).toContain('Escuela Test (a 5)');
-        expect(content).toContain('Luca');
-        expect(content).toContain('06/07/2026');
-        expect(pdf.saved).toEqual(['comprobante-pago-12-pedido-3.pdf']);
+        expect(content.rows.map(([label]) => label)).not.toContain('Niño/a');
     });
 
     it('shows the pending balance when the order is not fully paid', () => {
-        downloadPaymentReceipt({ payment, order });
+        const content = receiptContent({ payment, order });
 
-        const balanceLine = pdf.texts.find((text) =>
-            text.startsWith('Saldo pendiente:'),
-        );
-
-        expect(balanceLine).toContain('7.000');
+        expect(content.balance.pending).toBe(true);
+        expect(content.balance.text).toContain('7.000');
     });
 
     it('reports no pending balance when the order is fully paid', () => {
-        downloadPaymentReceipt({
+        const content = receiptContent({
             payment,
             order: { ...order, paid_total: 12000 } as Order,
         });
 
-        expect(pdf.texts).toContain('Pedido cancelado (sin saldo pendiente)');
+        expect(content.balance.pending).toBe(false);
+        expect(content.balance.text).toBe(
+            'Pedido cancelado (sin saldo pendiente)',
+        );
+    });
+});
+
+describe('receiptShareText', () => {
+    it('builds the WhatsApp message with the receipt summary', () => {
+        const text = receiptShareText({ payment, order });
+
+        expect(text).toContain('Comprobante de pago N° 12 — Fototobares');
+        expect(text).toContain('Cliente: Carla López');
+        expect(text).toContain('Importe abonado: ');
+        expect(text).toContain('Saldo pendiente: ');
     });
 });

--- a/resources/js/lib/receipt.ts
+++ b/resources/js/lib/receipt.ts
@@ -1,95 +1,203 @@
 import { formatPrice } from '@/lib/utils';
-import { jsPDF } from 'jspdf';
 
-/**
- * Generates and downloads the Fototobares payment receipt as a PDF,
- * built entirely client-side.
- */
-export function downloadPaymentReceipt({
-    payment,
-    order,
-}: {
+type ReceiptInput = {
     payment: Payment;
     order: Order;
-}) {
-    const doc = new jsPDF({ unit: 'mm', format: 'a5' });
-    const pageWidth = doc.internal.pageSize.getWidth();
-    const margin = 14;
-    let y = 20;
+};
 
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(20);
-    doc.text('Fototobares', margin, y);
+type ReceiptContent = {
+    title: string;
+    subtitle: string;
+    rows: Array<[string, string]>;
+    amountLabel: string;
+    amount: string;
+    totals: string[];
+    balance: { text: string; pending: boolean };
+    footer: string;
+    fileName: string;
+};
 
-    doc.setFontSize(11);
-    doc.setFont('helvetica', 'normal');
-    doc.text(`Comprobante de pago N° ${payment.id}`, pageWidth - margin, y, {
-        align: 'right',
-    });
-
-    y += 6;
-    doc.setDrawColor(180);
-    doc.line(margin, y, pageWidth - margin, y);
-
-    y += 10;
-    doc.setFontSize(11);
-
-    const rows: Array<[string, string]> = [
-        ['Fecha', payment.paid_on ?? payment.paid_at],
-        ['Cliente', order.client.name],
-        ['Pedido', `#${order.id}`],
-        ['Escuela', `${order.school.name} (${order.classroom.name})`],
-        ...(order.child_name
-            ? [['Niño/a', order.child_name] as [string, string]]
-            : []),
-        ['Medio de pago', payment.type],
-    ];
-
-    rows.forEach(([label, value]) => {
-        doc.setFont('helvetica', 'bold');
-        doc.text(`${label}:`, margin, y);
-        doc.setFont('helvetica', 'normal');
-        doc.text(value, margin + 35, y);
-        y += 7;
-    });
-
-    y += 4;
-    doc.setFillColor(240, 240, 240);
-    doc.rect(margin, y - 5, pageWidth - margin * 2, 12, 'F');
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(13);
-    doc.text('Importe abonado', margin + 2, y + 2.5);
-    doc.text(formatPrice(payment.amount), pageWidth - margin - 2, y + 2.5, {
-        align: 'right',
-    });
-
-    y += 16;
-    doc.setFontSize(10);
-    doc.setFont('helvetica', 'normal');
-
+/**
+ * Pure description of the Fototobares payment receipt; the canvas
+ * renderer and the WhatsApp share text derive from it.
+ */
+export function receiptContent({
+    payment,
+    order,
+}: ReceiptInput): ReceiptContent {
     const paidTotal = order.paid_total ?? 0;
     const balance = order.total_price - paidTotal;
 
-    doc.text(`Total del pedido: ${formatPrice(order.total_price)}`, margin, y);
-    y += 6;
-    doc.text(`Total abonado a la fecha: ${formatPrice(paidTotal)}`, margin, y);
-    y += 6;
-    doc.setFont('helvetica', balance > 0 ? 'bold' : 'normal');
-    doc.text(
-        balance > 0
-            ? `Saldo pendiente: ${formatPrice(balance)}`
-            : 'Pedido cancelado (sin saldo pendiente)',
-        margin,
-        y,
-    );
+    return {
+        title: 'Fototobares',
+        subtitle: `Comprobante de pago N° ${payment.id}`,
+        rows: [
+            ['Fecha', payment.paid_on ?? payment.paid_at],
+            ['Cliente', order.client.name],
+            ['Pedido', `#${order.id}`],
+            ['Escuela', `${order.school.name} (${order.classroom.name})`],
+            ...(order.child_name
+                ? [['Niño/a', order.child_name] as [string, string]]
+                : []),
+            ['Medio de pago', payment.type],
+        ],
+        amountLabel: 'Importe abonado',
+        amount: formatPrice(payment.amount),
+        totals: [
+            `Total del pedido: ${formatPrice(order.total_price)}`,
+            `Total abonado a la fecha: ${formatPrice(paidTotal)}`,
+        ],
+        balance: {
+            text:
+                balance > 0
+                    ? `Saldo pendiente: ${formatPrice(balance)}`
+                    : 'Pedido cancelado (sin saldo pendiente)',
+            pending: balance > 0,
+        },
+        footer: 'Gracias por confiar en Fototobares.',
+        fileName: `comprobante-pago-${payment.id}-pedido-${order.id}.png`,
+    };
+}
 
-    y += 14;
-    doc.setFont('helvetica', 'italic');
-    doc.setFontSize(9);
-    doc.setTextColor(120);
-    doc.text('Gracias por confiar en Fototobares.', pageWidth / 2, y, {
-        align: 'center',
+/**
+ * Plain-text version of the receipt for the WhatsApp message body.
+ */
+export function receiptShareText(input: ReceiptInput): string {
+    const content = receiptContent(input);
+
+    return [
+        `${content.subtitle} — ${content.title}`,
+        ...content.rows.map(([label, value]) => `${label}: ${value}`),
+        `${content.amountLabel}: ${content.amount}`,
+        ...content.totals,
+        content.balance.text,
+    ].join('\n');
+}
+
+/* Layout constants, in canvas points (A5-ish, 2x for sharpness) */
+const WIDTH = 740;
+const HEIGHT = 1050;
+const SCALE = 2;
+const MARGIN = 70;
+
+const font = (size: number, style = '') =>
+    `${style ? `${style} ` : ''}${size}px -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif`;
+
+/**
+ * Renders the receipt to a PNG, built entirely client-side.
+ */
+export function renderReceiptImage(input: ReceiptInput): Promise<Blob> {
+    const content = receiptContent(input);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = WIDTH * SCALE;
+    canvas.height = HEIGHT * SCALE;
+
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+        return Promise.reject(new Error('Canvas 2D context unavailable'));
+    }
+
+    ctx.scale(SCALE, SCALE);
+    draw(ctx, content);
+
+    return new Promise((resolve, reject) => {
+        canvas.toBlob((blob) => {
+            if (blob) {
+                resolve(blob);
+            } else {
+                reject(new Error('Could not export the receipt image'));
+            }
+        }, 'image/png');
     });
+}
 
-    doc.save(`comprobante-pago-${payment.id}-pedido-${order.id}.pdf`);
+function draw(ctx: CanvasRenderingContext2D, content: ReceiptContent) {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    ctx.textBaseline = 'alphabetic';
+
+    let y = 110;
+
+    ctx.fillStyle = '#111111';
+    ctx.font = font(48, 'bold');
+    ctx.fillText(content.title, MARGIN, y);
+
+    ctx.font = font(26);
+    ctx.textAlign = 'right';
+    ctx.fillText(content.subtitle, WIDTH - MARGIN, y);
+    ctx.textAlign = 'left';
+
+    y += 30;
+    ctx.strokeStyle = '#b4b4b4';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(MARGIN, y);
+    ctx.lineTo(WIDTH - MARGIN, y);
+    ctx.stroke();
+
+    y += 60;
+
+    for (const [label, value] of content.rows) {
+        ctx.font = font(26, 'bold');
+        ctx.fillText(`${label}:`, MARGIN, y);
+        ctx.font = font(26);
+        ctx.fillText(value, MARGIN + 220, y);
+        y += 44;
+    }
+
+    y += 20;
+    ctx.fillStyle = '#f0f0f0';
+    ctx.fillRect(MARGIN, y - 38, WIDTH - MARGIN * 2, 62);
+    ctx.fillStyle = '#111111';
+    ctx.font = font(30, 'bold');
+    ctx.fillText(content.amountLabel, MARGIN + 12, y + 4);
+    ctx.textAlign = 'right';
+    ctx.fillText(content.amount, WIDTH - MARGIN - 12, y + 4);
+    ctx.textAlign = 'left';
+
+    y += 90;
+    ctx.font = font(24);
+
+    for (const total of content.totals) {
+        ctx.fillText(total, MARGIN, y);
+        y += 38;
+    }
+
+    ctx.font = font(24, content.balance.pending ? 'bold' : '');
+    ctx.fillText(content.balance.text, MARGIN, y);
+
+    y += 80;
+    ctx.fillStyle = '#787878';
+    ctx.font = font(22, 'italic');
+    ctx.textAlign = 'center';
+    ctx.fillText(content.footer, WIDTH / 2, y);
+    ctx.textAlign = 'left';
+}
+
+/**
+ * Triggers a browser download for an already-rendered receipt blob.
+ */
+export function downloadBlob(blob: Blob, fileName: string): void {
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+
+    URL.revokeObjectURL(url);
+}
+
+/**
+ * Generates and downloads the receipt as a PNG.
+ */
+export async function downloadPaymentReceipt(
+    input: ReceiptInput,
+): Promise<void> {
+    downloadBlob(
+        await renderReceiptImage(input),
+        receiptContent(input).fileName,
+    );
 }

--- a/resources/js/lib/whatsapp.test.ts
+++ b/resources/js/lib/whatsapp.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeArPhone, waShareUrl } from './whatsapp';
+
+describe('normalizeArPhone', () => {
+    it('prefixes local numbers with the mobile country code', () => {
+        expect(normalizeArPhone('3804123456')).toBe('5493804123456');
+    });
+
+    it('strips separators and spaces', () => {
+        expect(normalizeArPhone('380 412-3456')).toBe('5493804123456');
+    });
+
+    it('drops the leading zero of area codes', () => {
+        expect(normalizeArPhone('03804123456')).toBe('5493804123456');
+    });
+
+    it('keeps numbers already in international format', () => {
+        expect(normalizeArPhone('5493804123456')).toBe('5493804123456');
+        expect(normalizeArPhone('+54 9 380 412-3456')).toBe('5493804123456');
+    });
+
+    it('adds the mobile 9 to numbers with a bare country code', () => {
+        expect(normalizeArPhone('543804123456')).toBe('5493804123456');
+    });
+
+    it('returns null for numbers too short to dial', () => {
+        expect(normalizeArPhone('1234')).toBe(null);
+        expect(normalizeArPhone('')).toBe(null);
+        expect(normalizeArPhone('sin teléfono')).toBe(null);
+    });
+});
+
+describe('waShareUrl', () => {
+    it('targets the client phone with the message prefilled', () => {
+        const url = waShareUrl('3804123456', 'Hola!');
+
+        expect(url).toBe('https://wa.me/5493804123456?text=Hola!');
+    });
+
+    it('encodes the message', () => {
+        const url = waShareUrl('3804123456', 'Saldo: $ 7.000\nGracias');
+
+        expect(url).toContain('text=Saldo%3A%20%24%207.000%0AGracias');
+    });
+
+    it('opens the chat picker when the phone is missing or invalid', () => {
+        expect(waShareUrl(null, 'Hola')).toBe('https://wa.me/?text=Hola');
+        expect(waShareUrl('1234', 'Hola')).toBe('https://wa.me/?text=Hola');
+    });
+});

--- a/resources/js/lib/whatsapp.ts
+++ b/resources/js/lib/whatsapp.ts
@@ -1,0 +1,43 @@
+/**
+ * Normalizes a locally-stored Argentine phone number to the
+ * international digits-only format WhatsApp links expect (549...).
+ * Returns null when the number is too short to be dialable.
+ */
+export function normalizeArPhone(phone: string): string | null {
+    let digits = phone.replace(/\D/g, '');
+
+    if (digits.startsWith('549')) {
+        return digits.length >= 11 ? digits : null;
+    }
+
+    if (digits.startsWith('54')) {
+        digits = digits.slice(2);
+    }
+
+    if (digits.startsWith('0')) {
+        digits = digits.slice(1);
+    }
+
+    if (digits.length < 8) {
+        return null;
+    }
+
+    return `549${digits}`;
+}
+
+/**
+ * wa.me link with the message prefilled. Without a valid phone it
+ * opens WhatsApp's chat picker instead. Note: wa.me cannot attach
+ * files — the image must go via the Web Share API or by hand.
+ */
+export function waShareUrl(
+    phone: string | null | undefined,
+    text: string,
+): string {
+    const normalized = phone ? normalizeArPhone(phone) : null;
+    const encoded = encodeURIComponent(text);
+
+    return normalized
+        ? `https://wa.me/${normalized}?text=${encoded}`
+        : `https://wa.me/?text=${encoded}`;
+}

--- a/resources/js/pages/orders/hooks/use-share-receipt.ts
+++ b/resources/js/pages/orders/hooks/use-share-receipt.ts
@@ -1,0 +1,77 @@
+import { copyImageToClipboard } from '@/lib/clipboard';
+import {
+    downloadBlob,
+    receiptContent,
+    receiptShareText,
+    renderReceiptImage,
+} from '@/lib/receipt';
+import { waShareUrl } from '@/lib/whatsapp';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Shares the payment receipt image. Strategy, best first:
+ * 1. Native share sheet with the PNG attached (mobile): the user picks
+ *    WhatsApp and the image arrives as a photo.
+ * 2. Copy the PNG to the clipboard and open the WhatsApp chat: the
+ *    user pastes it with Ctrl+V (modern desktop browsers).
+ * 3. Download the PNG and open the chat: the user attaches it by hand.
+ */
+export function useShareReceipt() {
+    const [sharing, setSharing] = useState(false);
+
+    const share = async ({
+        payment,
+        order,
+    }: {
+        payment: Payment;
+        order: Order;
+    }) => {
+        setSharing(true);
+
+        try {
+            const input = { payment, order };
+            const blob = await renderReceiptImage(input);
+            const fileName = receiptContent(input).fileName;
+            const text = receiptShareText(input);
+            const file = new File([blob], fileName, { type: 'image/png' });
+
+            if (navigator.canShare?.({ files: [file] })) {
+                await navigator.share({ files: [file], text });
+                return;
+            }
+
+            const openChat = () =>
+                window.open(
+                    waShareUrl(order.client.phone, text),
+                    '_blank',
+                    'noopener',
+                );
+
+            if (await copyImageToClipboard(blob)) {
+                openChat();
+                toast.info(
+                    'Comprobante copiado: pegalo con Ctrl+V en el chat de WhatsApp',
+                );
+                return;
+            }
+
+            downloadBlob(blob, fileName);
+            openChat();
+            toast.info(
+                'Se descargó la imagen del comprobante: adjuntala en el chat de WhatsApp',
+            );
+        } catch (error) {
+            // The user closed the native share sheet: not an error
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                return;
+            }
+
+            toast.error('No se pudo compartir el comprobante');
+        } finally {
+            setSharing(false);
+        }
+    };
+
+    return { share, sharing };
+}

--- a/resources/js/pages/orders/payment-history.tsx
+++ b/resources/js/pages/orders/payment-history.tsx
@@ -14,8 +14,15 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { downloadPaymentReceipt } from '@/lib/receipt';
 import { capitalize, formatPrice } from '@/lib/utils';
-import { Edit, EllipsisVertical, FileDown, Paperclip } from 'lucide-react';
+import {
+    Edit,
+    EllipsisVertical,
+    ImageDown,
+    Paperclip,
+    Share2,
+} from 'lucide-react';
 import { useState } from 'react';
+import { useShareReceipt } from './hooks/use-share-receipt';
 import { CreatePaymentModal } from './payments/create-payment-modal';
 import { EditPaymentModal } from './payments/edit-payment-modal';
 
@@ -104,6 +111,8 @@ function PaymentItem({
     order: Order;
     onEdit: CallableFunction;
 }) {
+    const { share, sharing } = useShareReceipt();
+
     return (
         <div className="flex items-center justify-between border-b border-gray-200 py-4 last:border-0 dark:border-gray-700">
             <div className="flex items-center space-x-4">
@@ -135,10 +144,22 @@ function PaymentItem({
                 <Button
                     size="icon"
                     variant="ghost"
-                    title="Descargar comprobante de Fototobares (PDF)"
-                    onClick={() => downloadPaymentReceipt({ payment, order })}
+                    title="Descargar comprobante de Fototobares (imagen)"
+                    onClick={() =>
+                        void downloadPaymentReceipt({ payment, order })
+                    }
                 >
-                    <FileDown className="h-5 w-5" />
+                    <ImageDown className="h-5 w-5" />
+                </Button>
+
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    title="Compartir comprobante por WhatsApp"
+                    disabled={sharing}
+                    onClick={() => void share({ payment, order })}
+                >
+                    <Share2 className="h-5 w-5" />
                 </Button>
 
                 <DropdownMenu>

--- a/resources/js/pages/orders/tests/use-share-receipt.test.tsx
+++ b/resources/js/pages/orders/tests/use-share-receipt.test.tsx
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useShareReceipt } from '../hooks/use-share-receipt';
+
+const receipt = vi.hoisted(() => ({
+    blob: new Blob(['png'], { type: 'image/png' }),
+    download: vi.fn(),
+}));
+
+vi.mock('@/lib/receipt', () => ({
+    renderReceiptImage: vi.fn().mockResolvedValue(receipt.blob),
+    receiptContent: vi
+        .fn()
+        .mockReturnValue({ fileName: 'comprobante-pago-12-pedido-3.png' }),
+    receiptShareText: vi.fn().mockReturnValue('Comprobante de pago N° 12'),
+    downloadBlob: receipt.download,
+}));
+
+const clipboard = vi.hoisted(() => ({ copy: vi.fn() }));
+
+vi.mock('@/lib/clipboard', () => ({ copyImageToClipboard: clipboard.copy }));
+
+const toast = vi.hoisted(() => ({ info: vi.fn(), error: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast }));
+
+const order = {
+    id: 3,
+    client: { name: 'Carla López', phone: '3804123456' },
+} as Order;
+
+const payment = { id: 12 } as Payment;
+
+describe('useShareReceipt', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clipboard.copy.mockResolvedValue(false);
+        vi.stubGlobal('open', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        Reflect.deleteProperty(navigator, 'canShare');
+        Reflect.deleteProperty(navigator, 'share');
+    });
+
+    it('shares the image through the native share sheet when available', async () => {
+        const share = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, {
+            canShare: vi.fn().mockReturnValue(true),
+            share,
+        });
+
+        const { result } = renderHook(() => useShareReceipt());
+
+        await act(() => result.current.share({ payment, order }));
+
+        const shared = share.mock.calls[0][0] as ShareData;
+        expect(shared.text).toBe('Comprobante de pago N° 12');
+        expect(shared.files?.[0].name).toBe('comprobante-pago-12-pedido-3.png');
+        expect(clipboard.copy).not.toHaveBeenCalled();
+        expect(receipt.download).not.toHaveBeenCalled();
+        expect(window.open).not.toHaveBeenCalled();
+    });
+
+    it('copies the image and opens the chat when there is no native share', async () => {
+        clipboard.copy.mockResolvedValue(true);
+
+        const { result } = renderHook(() => useShareReceipt());
+
+        await act(() => result.current.share({ payment, order }));
+
+        expect(clipboard.copy).toHaveBeenCalledWith(receipt.blob);
+        expect(window.open).toHaveBeenCalledWith(
+            expect.stringContaining('https://wa.me/5493804123456?text='),
+            '_blank',
+            'noopener',
+        );
+        expect(receipt.download).not.toHaveBeenCalled();
+        expect(toast.info).toHaveBeenCalledWith(
+            expect.stringContaining('pegalo'),
+        );
+    });
+
+    it('falls back to downloading when the clipboard is unavailable', async () => {
+        const { result } = renderHook(() => useShareReceipt());
+
+        await act(() => result.current.share({ payment, order }));
+
+        expect(receipt.download).toHaveBeenCalledWith(
+            receipt.blob,
+            'comprobante-pago-12-pedido-3.png',
+        );
+        expect(window.open).toHaveBeenCalledWith(
+            expect.stringContaining('https://wa.me/5493804123456?text='),
+            '_blank',
+            'noopener',
+        );
+        expect(toast.info).toHaveBeenCalledWith(
+            expect.stringContaining('adjuntala'),
+        );
+    });
+
+    it('stays quiet when the user closes the share sheet', async () => {
+        Object.assign(navigator, {
+            canShare: vi.fn().mockReturnValue(true),
+            share: vi
+                .fn()
+                .mockRejectedValue(new DOMException('cancel', 'AbortError')),
+        });
+
+        const { result } = renderHook(() => useShareReceipt());
+
+        await act(() => result.current.share({ payment, order }));
+
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('reports unexpected failures', async () => {
+        Object.assign(navigator, {
+            canShare: vi.fn().mockReturnValue(true),
+            share: vi.fn().mockRejectedValue(new Error('boom')),
+        });
+
+        const { result } = renderHook(() => useShareReceipt());
+
+        await act(() => result.current.share({ payment, order }));
+
+        expect(toast.error).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
El comprobante de Fototobares pasa de PDF a **imagen PNG** (mismo layout A5, dibujado en canvas, 100% client-side) y suma un botón para **compartirlo por WhatsApp** desde el historial de pagos.

## Compartir: tres escalones, del mejor al peor

1. **Share sheet nativo** (`navigator.share` con el archivo): en el celular el usuario elige WhatsApp y la imagen llega adjunta como foto.
2. **Portapapeles** (`navigator.clipboard.write` + `ClipboardItem`): en desktop copia el PNG y abre `wa.me/<teléfono>` con el resumen precargado — se pega con Ctrl+V en el chat. Soportado por Chrome/Edge, Safari 13.1+ y Firefox 127+.
3. **Descarga** + `wa.me`: último recurso si el navegador no permite copiar imágenes (wa.me no acepta adjuntos, el toast avisa adjuntar a mano).

Cerrar el share sheet no muestra error (AbortError silencioso); cada escalón degrada solo al siguiente.

## Detalles

- `lib/receipt.ts` reescrito: `receiptContent()` separa la descripción pura del comprobante (testeable) del dibujo en canvas; el render se hace **una sola vez** y el blob se reutiliza en los tres caminos.
- `lib/whatsapp.ts`: normaliza teléfonos locales a formato internacional (`3804123456` → `5493804123456`; maneja 0 inicial, +54/549, y abre el selector de chats si el número no es marcable).
- `lib/clipboard.ts`: copia de imágenes con feature-detection y degradación (`false` en vez de excepción).
- Lógica de compartir en `pages/orders/hooks/use-share-receipt.ts` con su test en `pages/orders/tests/` (estructura nueva de CLAUDE.md).
- **jsPDF eliminado** (junto con html2canvas del bundle: ~600 kB menos).

## Verificación

Cambio 100% frontend: vitest **95/95** (19 tests nuevos: contenido del comprobante, teléfonos, wa.me, clipboard y los caminos del hook), eslint, prettier, tsc y build de producción en verde. El dibujo del canvas no tiene verificación visual automatizada (llega con #56): probar a mano descargando un comprobante desde un pedido con pago.

Closes #51