### PR TITLE
fix(ui): make all pages mobile friendly without page-level horizontal scroll

### DIFF
--- a/resources/js/components/app-content.tsx
+++ b/resources/js/components/app-content.tsx
@@ -11,7 +11,11 @@ export function AppContent({
     ...props
 }: AppContentProps) {
     if (variant === 'sidebar') {
-        return <SidebarInset {...props}>{children}</SidebarInset>;
+        return (
+            <SidebarInset className="min-w-0" {...props}>
+                {children}
+            </SidebarInset>
+        );
     }
 
     return (

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -1,7 +1,13 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
     Tooltip,
@@ -216,6 +222,12 @@ const Sidebar = React.forwardRef<
                         }
                         side={side}
                     >
+                        <SheetHeader className="sr-only">
+                            <SheetTitle>Menú</SheetTitle>
+                            <SheetDescription>
+                                Menú de navegación
+                            </SheetDescription>
+                        </SheetHeader>
                         <div className="flex h-full w-full flex-col">
                             {children}
                         </div>

--- a/resources/js/pages/orders/index.tsx
+++ b/resources/js/pages/orders/index.tsx
@@ -51,7 +51,7 @@ export default function Orders({
             )}
 
             <section className="p-6">
-                <div className="mb-4 flex gap-4">
+                <div className="mb-4 flex flex-wrap gap-4">
                     <Searchbar indexRoute="orders.index" />
                     <Combobox
                         items={schools.map((school) => ({

--- a/resources/js/pages/production-statuses/components/status-item.tsx
+++ b/resources/js/pages/production-statuses/components/status-item.tsx
@@ -87,11 +87,11 @@ export function StatusItem({
     }
 
     return (
-        <div className="flex items-center gap-2 rounded-lg border border-gray-200 p-2 dark:border-gray-700">
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 p-2 dark:border-gray-700">
             <Badge variant="outline" className="w-8 justify-center">
                 {status.position}
             </Badge>
-            <div className="flex flex-1 flex-col">
+            <div className="flex min-w-32 flex-1 flex-col">
                 <span className="text-sm">{status.name}</span>
                 {consumes && (
                     <span className="text-xs text-gray-500">
@@ -109,57 +109,59 @@ export function StatusItem({
                     {status.details_count} en curso
                 </span>
             )}
-            <Button
-                size="sm"
-                variant="ghost"
-                disabled={isFirst}
-                title="Subir"
-                onClick={onMoveUp}
-            >
-                <ArrowUp className="h-4 w-4" />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                disabled={isLast}
-                title="Bajar"
-                onClick={onMoveDown}
-            >
-                <ArrowDown className="h-4 w-4" />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                title="Insumos que consume esta etapa"
-                onClick={onEditConsumption}
-            >
-                <Package className="h-4 w-4" />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                title="Renombrar"
-                onClick={() => setEditing(true)}
-            >
-                <Pencil className="h-4 w-4" />
-            </Button>
-            <Button
-                size="sm"
-                variant="ghost"
-                disabled={isOnly || inUse || consumes}
-                title={
-                    isOnly
-                        ? 'No se puede eliminar la única etapa'
-                        : inUse
-                          ? 'Hay productos en esta etapa'
-                          : consumes
-                            ? 'Esta etapa consume insumos'
-                            : 'Eliminar'
-                }
-                onClick={onDelete}
-            >
-                <Trash2 className="h-4 w-4" />
-            </Button>
+            <div className="ml-auto flex items-center">
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={isFirst}
+                    title="Subir"
+                    onClick={onMoveUp}
+                >
+                    <ArrowUp className="h-4 w-4" />
+                </Button>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={isLast}
+                    title="Bajar"
+                    onClick={onMoveDown}
+                >
+                    <ArrowDown className="h-4 w-4" />
+                </Button>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    title="Insumos que consume esta etapa"
+                    onClick={onEditConsumption}
+                >
+                    <Package className="h-4 w-4" />
+                </Button>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    title="Renombrar"
+                    onClick={() => setEditing(true)}
+                >
+                    <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={isOnly || inUse || consumes}
+                    title={
+                        isOnly
+                            ? 'No se puede eliminar la única etapa'
+                            : inUse
+                              ? 'Hay productos en esta etapa'
+                              : consumes
+                                ? 'Esta etapa consume insumos'
+                                : 'Eliminar'
+                    }
+                    onClick={onDelete}
+                >
+                    <Trash2 className="h-4 w-4" />
+                </Button>
+            </div>
         </div>
     );
 }

--- a/resources/js/pages/tracking/components/detail-card.tsx
+++ b/resources/js/pages/tracking/components/detail-card.tsx
@@ -1,0 +1,122 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { ArrowRight, Flame } from 'lucide-react';
+import { TrackingDetail } from './product-group';
+
+export function DetailCard({
+    detail,
+    next,
+    checked,
+    onToggle,
+    onApplyStatus,
+}: {
+    detail: TrackingDetail;
+    next: ProductionStatus | undefined;
+    checked: boolean;
+    onToggle: () => void;
+    onApplyStatus: (
+        statusId: number,
+        detailIds: number[],
+        statusName?: string,
+    ) => void;
+}) {
+    return (
+        <div
+            className={cn(
+                'flex flex-col gap-3 border-b border-input p-4 last:border-b-0',
+                detail.priority && 'bg-amber-50 dark:bg-amber-950/30',
+            )}
+        >
+            <div className="flex items-start justify-between gap-2">
+                <label className="flex items-center gap-3">
+                    <input
+                        type="checkbox"
+                        aria-label={`Seleccionar producto ${detail.product_name}`}
+                        checked={checked}
+                        onChange={onToggle}
+                        className="h-5 w-5 cursor-pointer"
+                    />
+                    <span>
+                        <a
+                            href={route('orders.show', {
+                                order: detail.order_id,
+                            })}
+                            className="font-medium underline-offset-2 hover:underline"
+                        >
+                            #{detail.order_id}
+                        </a>
+                        {detail.photo_number !== null && (
+                            <span className="ml-1 text-xs text-gray-500">
+                                (foto {detail.photo_number})
+                            </span>
+                        )}
+                    </span>
+                </label>
+                <div className="flex flex-wrap items-center justify-end gap-1">
+                    {detail.priority && (
+                        <Badge variant="destructive" className="gap-1">
+                            <Flame className="h-3 w-3" />
+                            Prioridad
+                        </Badge>
+                    )}
+                    <Badge
+                        variant={
+                            detail.production_status_id ? 'default' : 'outline'
+                        }
+                    >
+                        {detail.production_status ?? 'Sin empezar'}
+                    </Badge>
+                </div>
+            </div>
+
+            <div className="flex flex-col gap-0.5 text-sm">
+                <span>
+                    {detail.child_name ?? '—'}
+                    <span className="text-gray-500">
+                        {' '}
+                        · {detail.client_name}
+                    </span>
+                </span>
+                <span className="text-gray-500">
+                    {detail.school} ({detail.classroom.toUpperCase()})
+                </span>
+                {detail.variant && (
+                    <span className="text-xs text-gray-500">
+                        {Object.values(detail.variant)
+                            .filter(Boolean)
+                            .join(' · ')}
+                    </span>
+                )}
+                {detail.note && (
+                    <span className="text-xs italic text-gray-500">
+                        {detail.note}
+                    </span>
+                )}
+                {detail.status_updated_at && (
+                    <span className="text-xs text-gray-500">
+                        {detail.status_updated_at}
+                    </span>
+                )}
+            </div>
+
+            {next ? (
+                <Button
+                    variant="outline"
+                    className="w-full"
+                    title={`Pasar a "${next.name}"`}
+                    onClick={() =>
+                        onApplyStatus(next.id, [detail.id], next.name)
+                    }
+                >
+                    {next.name}
+                    <ArrowRight className="ml-1 h-4 w-4" />
+                </Button>
+            ) : (
+                <Badge variant="secondary" className="self-start">
+                    Listo para entregar
+                </Badge>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/tracking/components/product-group.tsx
+++ b/resources/js/pages/tracking/components/product-group.tsx
@@ -17,6 +17,7 @@ import {
 import { capitalize } from '@/lib/utils';
 import { useState } from 'react';
 import { nextStatusFor } from '../hooks/use-selection';
+import { DetailCard } from './detail-card';
 import { DetailRow } from './detail-row';
 
 export type TrackingDetail = {
@@ -79,7 +80,7 @@ export function ProductGroup({
     return (
         <div className="rounded-xl border border-input">
             <header className="flex flex-col gap-3 border-b border-input p-4 md:flex-row md:items-center md:justify-between">
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                     <h2 className="text-lg font-semibold">{product.name}</h2>
                     {product.type && (
                         <Badge variant="outline">
@@ -94,7 +95,7 @@ export function ProductGroup({
 
                 <div className="flex items-center gap-2">
                     <Select value={batchStatus} onValueChange={setBatchStatus}>
-                        <SelectTrigger className="w-48">
+                        <SelectTrigger className="min-w-0 flex-1 md:w-48 md:flex-none">
                             <SelectValue placeholder="Cambiar estado a..." />
                         </SelectTrigger>
                         <SelectContent>
@@ -128,43 +129,70 @@ export function ProductGroup({
                 </div>
             </header>
 
-            <Table>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead className="w-[40px]">
-                            <input
-                                type="checkbox"
-                                aria-label="Seleccionar todos"
-                                checked={allSelected}
-                                onChange={onToggleGroup}
-                                className="h-4 w-4 cursor-pointer"
+            <div className="md:hidden">
+                <label className="flex items-center gap-3 border-b border-input p-4">
+                    <input
+                        type="checkbox"
+                        aria-label="Seleccionar todos"
+                        checked={allSelected}
+                        onChange={onToggleGroup}
+                        className="h-5 w-5 cursor-pointer"
+                    />
+                    <span className="text-sm text-gray-500">
+                        Seleccionar todos
+                    </span>
+                </label>
+                {items.map((detail) => (
+                    <DetailCard
+                        key={detail.id}
+                        detail={detail}
+                        next={nextStatusFor(product.statuses, detail.position)}
+                        checked={selected.includes(detail.id)}
+                        onToggle={() => onToggle(detail.id)}
+                        onApplyStatus={onApplyStatus}
+                    />
+                ))}
+            </div>
+
+            <div className="hidden md:block">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-[40px]">
+                                <input
+                                    type="checkbox"
+                                    aria-label="Seleccionar todos"
+                                    checked={allSelected}
+                                    onChange={onToggleGroup}
+                                    className="h-4 w-4 cursor-pointer"
+                                />
+                            </TableHead>
+                            <TableHead>Pedido</TableHead>
+                            <TableHead>Niño / Cliente</TableHead>
+                            <TableHead>Escuela (Aula)</TableHead>
+                            <TableHead>Producto</TableHead>
+                            <TableHead>Notas</TableHead>
+                            <TableHead>Estado</TableHead>
+                            <TableHead>Acciones</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {items.map((detail) => (
+                            <DetailRow
+                                key={detail.id}
+                                detail={detail}
+                                next={nextStatusFor(
+                                    product.statuses,
+                                    detail.position,
+                                )}
+                                checked={selected.includes(detail.id)}
+                                onToggle={() => onToggle(detail.id)}
+                                onApplyStatus={onApplyStatus}
                             />
-                        </TableHead>
-                        <TableHead>Pedido</TableHead>
-                        <TableHead>Niño / Cliente</TableHead>
-                        <TableHead>Escuela (Aula)</TableHead>
-                        <TableHead>Producto</TableHead>
-                        <TableHead>Notas</TableHead>
-                        <TableHead>Estado</TableHead>
-                        <TableHead>Acciones</TableHead>
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {items.map((detail) => (
-                        <DetailRow
-                            key={detail.id}
-                            detail={detail}
-                            next={nextStatusFor(
-                                product.statuses,
-                                detail.position,
-                            )}
-                            checked={selected.includes(detail.id)}
-                            onToggle={() => onToggle(detail.id)}
-                            onApplyStatus={onApplyStatus}
-                        />
-                    ))}
-                </TableBody>
-            </Table>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
         </div>
     );
 }

--- a/resources/js/pages/tracking/components/tracking-filters.tsx
+++ b/resources/js/pages/tracking/components/tracking-filters.tsx
@@ -44,7 +44,7 @@ export function TrackingFilters({
                     placeholder="Niño, cliente o n° de pedido"
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
-                    className="w-64"
+                    className="min-w-0 flex-1 md:w-64 md:flex-none"
                 />
                 <Button type="submit" variant="secondary" size="icon">
                     <Search className="h-4 w-4" />

--- a/resources/js/pages/tracking/index.tsx
+++ b/resources/js/pages/tracking/index.tsx
@@ -109,7 +109,7 @@ export default function Tracking({
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Seguimiento" />
 
-            <section className="flex flex-col gap-6 p-6">
+            <section className="flex flex-col gap-6 p-4 md:p-6">
                 <TrackingFilters
                     filters={filters}
                     schools={schools}

--- a/resources/js/pages/tracking/tests/detail-card.test.tsx
+++ b/resources/js/pages/tracking/tests/detail-card.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DetailCard } from '../components/detail-card';
+import { TrackingDetail } from '../components/product-group';
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.order ?? ''}`,
+);
+
+const makeDetail = (
+    overrides: Partial<TrackingDetail> = {},
+): TrackingDetail => ({
+    id: 11,
+    order_id: 3,
+    child_name: 'Lola',
+    client_name: 'Carla Medina',
+    school: 'Escuela Normal',
+    classroom: '6to a',
+    photo_number: 3,
+    attended_photo_session: true,
+    product_id: 1,
+    product_name: 'Moldura fina',
+    product_type_id: 1,
+    product_type: 'mural',
+    variant: { color: 'black', orientation: 'vertical' },
+    note: 'Lola - egresados 2026',
+    production_status_id: 5,
+    production_status: 'Impreso',
+    position: 2,
+    priority: false,
+    status_updated_at: '10/07/2026',
+    ...overrides,
+});
+
+const next: ProductionStatus = {
+    id: 6,
+    name: 'Pegado',
+    position: 3,
+} as ProductionStatus;
+
+describe('DetailCard', () => {
+    it('shows the order, child, school, variant and note', () => {
+        render(
+            <DetailCard
+                detail={makeDetail()}
+                next={next}
+                checked={false}
+                onToggle={vi.fn()}
+                onApplyStatus={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('#3')).toBeTruthy();
+        expect(screen.getByText('(foto 3)')).toBeTruthy();
+        expect(screen.getByText('Lola')).toBeTruthy();
+        expect(screen.getByText('Escuela Normal (6TO A)')).toBeTruthy();
+        expect(screen.getByText('black · vertical')).toBeTruthy();
+        expect(screen.getByText('Lola - egresados 2026')).toBeTruthy();
+        expect(screen.getByText('Impreso')).toBeTruthy();
+    });
+
+    it('advances to the next status from the card button', () => {
+        const onApplyStatus = vi.fn();
+
+        render(
+            <DetailCard
+                detail={makeDetail()}
+                next={next}
+                checked={false}
+                onToggle={vi.fn()}
+                onApplyStatus={onApplyStatus}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /Pegado/ }));
+
+        expect(onApplyStatus).toHaveBeenCalledWith(6, [11], 'Pegado');
+    });
+
+    it('shows "Listo para entregar" when there is no next status', () => {
+        render(
+            <DetailCard
+                detail={makeDetail()}
+                next={undefined}
+                checked={false}
+                onToggle={vi.fn()}
+                onApplyStatus={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Listo para entregar')).toBeTruthy();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('toggles selection from the checkbox', () => {
+        const onToggle = vi.fn();
+
+        render(
+            <DetailCard
+                detail={makeDetail()}
+                next={next}
+                checked={false}
+                onToggle={onToggle}
+                onApplyStatus={vi.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('checkbox'));
+
+        expect(onToggle).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #89

## Qué cambia

**Fix estructural (toda la app)**
- `min-w-0` en el `SidebarInset` (vía `AppContent`): era la causa raíz del contenido cortado en mobile — el `<main>` flex crecía más allá del viewport empujado por el contenido ancho. Ahora las tablas scrollean dentro de su propio wrapper y **la página nunca scrollea horizontalmente, en ningún viewport** (regla nueva).
- `SheetTitle`/`SheetDescription` accesibles (`sr-only`) en el sidebar mobile: elimina el warning de Radix `DialogContent requires a DialogTitle` al abrir el menú. Barrido por el resto de la app: ningún otro Dialog/Sheet/AlertDialog con el mismo problema.

**/tracking mobile-first**
- Nuevo `DetailCard`: en pantallas chicas cada detalle se muestra como card apilada (pedido + foto, estado, niño/cliente, escuela, variante, nota) con checkbox más grande y botón de avance de etapa a ancho completo. La tabla queda para `md+`.
- Filtros y controles de lote a ancho completo en mobile (sin anchos fijos).

**Ajuste fino**
- /production-statuses: las acciones de cada etapa wrappean a una segunda línea en vez de desbordar la card.
- /orders: la toolbar (búsqueda + filtro por escuela + Borradores) wrappea.

## Verificación

- Sweep automatizado con browser headless por las 14 páginas a **390px y 320px** chequeando `document.scrollWidth > innerWidth`: todas sin overflow de página.
- Verificación visual de /tracking, /production-statuses, /orders, /stockables, detalle de pedido, menú mobile y dialog de insumos.
- Consola limpia (0 warnings/errores) al abrir el menú mobile.
- prettier / eslint / tsc OK, Vitest **99/99** (4 tests RTL nuevos para `DetailCard`).