### PR TITLE
fix(resources): eager load relations and add page smoke test

### DIFF
--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -18,7 +18,7 @@ class ClassroomController extends Controller
     public function show(Classroom $classroom): \Inertia\Response
     {
         $orders = Order::where('classroom_id', $classroom->id)
-            ->with('client', 'products.type')
+            ->with('client', 'products.type', 'classroom.school')
             ->paginate(20);
 
         return Inertia::render('classrooms/show', [

--- a/app/Http/Controllers/BO/OrderDraftController.php
+++ b/app/Http/Controllers/BO/OrderDraftController.php
@@ -14,7 +14,7 @@ class OrderDraftController extends Controller
 {
     public function index(): \Inertia\Response
     {
-        $drafts = OrderDraft::with('classroom.school')
+        $drafts = OrderDraft::with('classroom.school', 'classroom.teacher')
             ->latest()
             ->paginate(20);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,8 @@ Route::get('/dashboard', [DashboardController::class, 'index'])
 
 // Día a día de ventas: gerencia, administración y oficina
 Route::middleware(['auth', 'role:master,administración,oficina'])->group(function () {
-    Route::resource('products', ProductController::class);
-    Route::resource('combos', ComboController::class);
+    Route::resource('products', ProductController::class)->except(['show']);
+    Route::resource('combos', ComboController::class)->except(['show']);
     Route::resource('orders', OrderController::class);
     Route::post('/orders/{order}/cancel', [OrderController::class, 'cancel'])->name('orders.cancel');
     Route::put('/orders/{order}/delivery', [DeliveryController::class, 'update'])->name('orders.delivery');
@@ -53,7 +53,7 @@ Route::middleware(['auth', 'role:master,administración,oficina,editor'])->group
 Route::middleware(['auth', 'role:master,administración,oficina,taller'])->group(function () {
     Route::get('/tracking', [TrackingController::class, 'index'])->name('tracking.index');
     Route::post('/tracking/batch', [TrackingController::class, 'batchUpdate'])->name('tracking.batch');
-    Route::resource('stockables', StockController::class);
+    Route::resource('stockables', StockController::class)->except(['show']);
     Route::get('/stock-movements', [StockMovementController::class, 'index'])->name('stock-movements.index');
     Route::get('/recycling', [RecyclingController::class, 'index'])->name('recycling.index');
 });

--- a/tests/Feature/PageSmokeTest.php
+++ b/tests/Feature/PageSmokeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Classroom;
+use App\Models\Combo;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\School;
+use App\Models\Stockable;
+use App\Models\User;
+use Database\Seeders\DemoSeeder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Route;
+
+use function Pest\Laravel\get;
+
+/**
+ * Regression net for lazy loading (and any other 5xx): renders every
+ * authenticated GET page with the demo seed, so a resource touching a
+ * relation its controller forgot to eager load fails here instead of
+ * in front of the client. New routes are picked up automatically.
+ */
+it('keeps lazy loading prevention enabled', function () {
+    expect(Model::preventsLazyLoading())->toBeTrue();
+});
+
+it('renders every GET page without errors', function () {
+    $this->seed(DemoSeeder::class);
+    actingAsRole(UserRole::Master);
+
+    $skipped = ['login', 'storage.local', 'sanctum.csrf-cookie', 'pulse'];
+    $failures = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $name = $route->getName();
+
+        if ($name === null || in_array($name, $skipped, true) || str_starts_with($name, 'livewire')) {
+            continue;
+        }
+
+        if (! in_array('GET', $route->methods(), true) || ! in_array('web', $route->gatherMiddleware(), true)) {
+            continue;
+        }
+
+        $parameters = [];
+
+        foreach ($route->parameterNames() as $parameter) {
+            $model = match ($parameter) {
+                'classroom' => Classroom::first(),
+                'combo' => Combo::first() ?? Combo::create([
+                    'name' => 'Combo smoke',
+                    'suggested_price' => 64000,
+                    'suggested_max_payments' => 4,
+                ]),
+                'order' => Order::first(),
+                'product' => Product::first(),
+                'school' => School::first(),
+                'stockable' => Stockable::first(),
+                'user' => User::first(),
+                default => null,
+            };
+
+            if ($model === null) {
+                $failures[] = "{$name}: no demo data for {{$parameter}}";
+
+                continue 2;
+            }
+
+            $parameters[$parameter] = $model;
+        }
+
+        $status = get(route($name, $parameters))->status();
+
+        if ($status >= 400) {
+            $failures[] = "{$name} responded {$status}";
+        }
+    }
+
+    expect($failures)->toBe([]);
+});


### PR DESCRIPTION
Closes #93

## Qué cambia

**Fixes de lazy loading** (con `Model::shouldBeStrict()` activo, cualquier relación no precargada tira `LazyLoadingViolationException` → 500):

- `ClassroomController::show`: los pedidos del curso ahora precargan `classroom.school`, que `OrderResource` accede incondicionalmente (500 del show de curso).
- `OrderDraftController::index`: los borradores ahora precargan `classroom.teacher`, que `ClassroomResource` accede incondicionalmente (el 500 original de /drafts reportado en #93).

**Rutas muertas descubiertas por el smoke test**: `products.show`, `combos.show` y `stockables.show` estaban declaradas por `Route::resource()` pero los controllers nunca implementaron `show()` → 500 garantizado. Se restringen con `->except(['show'])` (mismo patrón que users). Nada en el frontend las linkeaba.

**Red de regresión** (`tests/Feature/PageSmokeTest.php`):
- Guard de que `shouldBeStrict()` siga activo (si alguien lo desactiva, el test lo denuncia).
- Smoke test que enumera las rutas GET del router (autodescubierto: una página nueva entra sola), resuelve los parámetros con el seed demo y falla si alguna responde ≥400. Cualquier relación que falte precargar en el futuro rompe CI en vez de romper una demo.

## Auditoría

Revisados los 10 resources contra cada controller que los construye: fuera de los dos casos corregidos, todos precargan lo que sus resources recorren.

## Verificación

- Revert temporal del fix de classroom (`git stash`) → el smoke test falla con `classrooms.show responded 500`; restaurado → verde. La red atrapa el bug real.
- Pest 88/88 (86 + 2 nuevos), phpstan sin errores, pint limpio. Solo cambios backend.
