### PR TITLE
fix(dashboard): keep stock alert badge on one line in narrow viewports

### DIFF
--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -100,7 +100,7 @@ export default function Dashboard({
                     />
                 </div>
 
-                <div className="grid gap-6 xl:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
                     <Card>
                         <CardHeader>
                             <CardTitle className="text-xl">
@@ -159,13 +159,16 @@ export default function Dashboard({
                                     {stockAlerts.map((stockable) => (
                                         <li
                                             key={stockable.id}
-                                            className="flex items-center justify-between rounded-md border border-input px-3 py-2 text-sm"
+                                            className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 rounded-md border border-input px-3 py-2 text-sm"
                                         >
                                             <span>{stockable.name}</span>
-                                            <Badge variant="destructive">
-                                                {stockable.quantity} (
-                                                {stockable.unit}) — alerta en{' '}
-                                                {stockable.alert_at}
+                                            <Badge
+                                                variant="destructive"
+                                                className="min-w-0 max-w-full"
+                                            >
+                                                <span className="truncate">
+                                                    {`${stockable.quantity} (${stockable.unit}) — alerta en ${stockable.alert_at}`}
+                                                </span>
                                             </Badge>
                                         </li>
                                     ))}


### PR DESCRIPTION
Fixes #92

The stock alert badge on the dashboard wrapped its text mid-pill on narrow viewports, rendering as a deformed red blob (see issue screenshot).

## Changes

- The alert `<li>` is now `flex-wrap`: when the name and badge don't fit side by side, the badge drops to its own line below the name instead of getting squeezed.
- The badge gets `min-w-0 max-w-full` with an inner `truncate` span: it always renders as a single-line pill, degrading to an ellipsis with absurdly long data instead of breaking the layout.
- Explicit `grid-cols-1` on the dashboard grid. Root cause found while probing edge cases: without a base column definition, the implicit mobile grid track is sized by min-content, so nowrap content inside the cards inflated the track and caused page-level horizontal scroll. Tailwind's `grid-cols-1` compiles to `minmax(0, 1fr)`, which stops that propagation (same reason `xl:grid-cols-2` was never affected on desktop).

## Verification

- Headless browser against the running app at 320px, 351px (issue viewport) and 1280px: badge renders as a single-line pill in all cases, `document.scrollWidth === innerWidth` (no page-level horizontal scroll), desktop layout unchanged.
- Worst-case probe with a temporary stockable (`9999 (Paquete) — alerta en 10000`, long name): no overflow, badge truncates cleanly. Record removed afterwards.
- eslint, prettier, tsc and Vitest (99/99) green.