### PR TITLE
fix(orders): autofill solo al llegar desde "guardar y seguir vendiendo"

### DIFF
--- a/resources/js/pages/orders/create.tsx
+++ b/resources/js/pages/orders/create.tsx
@@ -43,11 +43,9 @@ import { ProductOrder } from './form';
 import {
     DraftProp,
     OrderFormData,
-    clearSavedForm,
-    persistSavedForm,
     removeDetailAt,
     replaceDetailAt,
-    resetPersonalData,
+    resetForNextClient,
     resolveInitialOrderForm,
 } from './form-state';
 type SchoolLevel = 'Todos' | 'Jardin' | 'Primaria' | 'Secundaria';
@@ -177,15 +175,11 @@ export default function CreateOrder({
                 onSuccess: () => {
                     toast.success('Pedido guardado con éxito');
                     if (saveAndContinue) {
-                        persistSavedForm(data, selectedSchool);
-                        setData(resetPersonalData(data));
-                        // Reset to first step
-                        setAccordionValue('schools');
+                        setData(resetForNextClient(data));
+                        setAccordionValue('client');
                         toast.info(
-                            'Datos de pedido guardados. Listo para el siguiente cliente.',
+                            'Se conservaron la escuela, las cuotas y el vencimiento. Cargá el cliente y los productos.',
                         );
-                    } else {
-                        clearSavedForm();
                     }
                 },
             },

--- a/resources/js/pages/orders/form-state.test.ts
+++ b/resources/js/pages/orders/form-state.test.ts
@@ -2,13 +2,10 @@ import { format } from 'date-fns';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
     DraftProp,
-    clearSavedForm,
     emptyForm,
-    persistSavedForm,
-    readSavedForm,
     removeDetailAt,
     replaceDetailAt,
-    resetPersonalData,
+    resetForNextClient,
     resolveInitialOrderForm,
 } from './form-state';
 
@@ -47,58 +44,23 @@ describe('emptyForm', () => {
     });
 });
 
-describe('readSavedForm', () => {
-    it('returns null when nothing was saved', () => {
-        expect(readSavedForm()).toBeNull();
+describe('resolveInitialOrderForm', () => {
+    it('starts empty without a draft', () => {
+        const initial = resolveInitialOrderForm(null);
+
+        expect(initial.form).toEqual(emptyForm());
+        expect(initial.selectedSchool).toBe(0);
+        expect(initial.message).toBeNull();
     });
 
-    it('returns null on corrupted JSON', () => {
-        localStorage.setItem('orderFormData', '{not json');
-
-        expect(readSavedForm()).toBeNull();
-    });
-
-    it('restores the saved order data leaving personal data blank', () => {
+    // Regression for #101: "guardar y seguir vendiendo" used to persist
+    // the order in localStorage and every fresh visit restored it.
+    it('ignores the legacy localStorage key', () => {
         localStorage.setItem(
             'orderFormData',
-            JSON.stringify({
-                classroom_id: 3,
-                order_details: [{ product_id: 5, note: 'nota' }],
-                total_price: '12000',
-                payment_plan: '2',
-                due_date: '2026-09-01',
-                selectedSchool: 9,
-            }),
+            JSON.stringify({ classroom_id: 3, selectedSchool: 9 }),
         );
 
-        const saved = readSavedForm();
-
-        expect(saved?.selectedSchool).toBe(9);
-        expect(saved?.form).toMatchObject({
-            classroom_id: 3,
-            order_details: [{ product_id: 5, note: 'nota' }],
-            total_price: '12000',
-            payment_plan: '2',
-            due_date: '2026-09-01',
-            name: '',
-            phone: '',
-            child_name: '',
-        });
-    });
-
-    it('fills defaults for missing keys', () => {
-        localStorage.setItem('orderFormData', JSON.stringify({}));
-
-        const saved = readSavedForm();
-
-        expect(saved?.form.classroom_id).toBe(0);
-        expect(saved?.form.order_details).toEqual([]);
-        expect(saved?.selectedSchool).toBe(0);
-    });
-});
-
-describe('resolveInitialOrderForm', () => {
-    it('starts empty without a draft or saved data', () => {
         const initial = resolveInitialOrderForm(null);
 
         expect(initial.form).toEqual(emptyForm());
@@ -123,52 +85,6 @@ describe('resolveInitialOrderForm', () => {
         });
         expect(initial.selectedSchool).toBe(9);
         expect(initial.message).toBe('Borrador #7 cargado');
-    });
-
-    it('prefers the draft over saved data', () => {
-        localStorage.setItem(
-            'orderFormData',
-            JSON.stringify({ classroom_id: 99, selectedSchool: 99 }),
-        );
-
-        const initial = resolveInitialOrderForm(draft);
-
-        expect(initial.form.classroom_id).toBe(3);
-        expect(initial.selectedSchool).toBe(9);
-    });
-
-    it('falls back to saved data without a draft', () => {
-        localStorage.setItem(
-            'orderFormData',
-            JSON.stringify({ classroom_id: 3, selectedSchool: 9 }),
-        );
-
-        const initial = resolveInitialOrderForm(null);
-
-        expect(initial.form.classroom_id).toBe(3);
-        expect(initial.selectedSchool).toBe(9);
-        expect(initial.message).toBe('Datos de pedido anterior cargados');
-    });
-
-    it('drops saved details whose product no longer exists', () => {
-        localStorage.setItem(
-            'orderFormData',
-            JSON.stringify({
-                classroom_id: 3,
-                selectedSchool: 9,
-                order_details: [
-                    { product_id: 5, note: 'vigente' },
-                    { product_id: 99, note: 'ya no existe' },
-                ],
-            }),
-        );
-
-        const initial = resolveInitialOrderForm(null, [5, 6]);
-
-        expect(initial.form.order_details).toEqual([
-            { product_id: 5, note: 'vigente' },
-        ]);
-        expect(initial.droppedProducts).toBe(1);
     });
 
     it('drops draft details whose product no longer exists', () => {
@@ -197,64 +113,15 @@ describe('resolveInitialOrderForm', () => {
     });
 });
 
-describe('persistSavedForm', () => {
-    const filledForm = () => ({
-        ...emptyForm(),
-        classroom_id: 3,
-        order_details: [{ product_id: 5, note: 'nota' }],
-        total_price: '12000',
-        payment_plan: '2',
-        due_date: '2026-09-01',
-        name: 'Carla López',
-        phone: '3804000003',
-        child_name: 'Luca',
-        attended_photo_session: true,
-        draft_id: 7,
-    });
-
-    it('persists only the order data, never the personal data', () => {
-        persistSavedForm(filledForm(), 9);
-
-        const stored = JSON.parse(localStorage.getItem('orderFormData')!);
-
-        expect(stored).toEqual({
+describe('resetForNextClient', () => {
+    it('blanks client, products and price, keeps school and payment terms', () => {
+        const reset = resetForNextClient({
+            ...emptyForm(),
             classroom_id: 3,
-            order_details: [{ product_id: 5, note: 'nota' }],
+            order_details: [{ product_id: 5, note: 'Taza de Luca' }],
             total_price: '12000',
             payment_plan: '2',
             due_date: '2026-09-01',
-            selectedSchool: 9,
-        });
-    });
-
-    it('round-trips through readSavedForm', () => {
-        persistSavedForm(filledForm(), 9);
-
-        const saved = readSavedForm();
-
-        expect(saved?.form.order_details).toEqual([
-            { product_id: 5, note: 'nota' },
-        ]);
-        expect(saved?.form.name).toBe('');
-        expect(saved?.selectedSchool).toBe(9);
-    });
-
-    it('clearSavedForm removes the persisted data', () => {
-        persistSavedForm(filledForm(), 9);
-
-        clearSavedForm();
-
-        expect(readSavedForm()).toBeNull();
-    });
-});
-
-describe('resetPersonalData', () => {
-    it('blanks the client fields and keeps the order fields', () => {
-        const reset = resetPersonalData({
-            ...emptyForm(),
-            classroom_id: 3,
-            order_details: [{ product_id: 5, note: 'nota' }],
-            total_price: '12000',
             name: 'Carla López',
             phone: '3804000003',
             child_name: 'Luca',
@@ -262,10 +129,12 @@ describe('resetPersonalData', () => {
             draft_id: 7,
         });
 
-        expect(reset).toMatchObject({
+        expect(reset).toEqual({
             classroom_id: 3,
-            order_details: [{ product_id: 5, note: 'nota' }],
-            total_price: '12000',
+            order_details: [],
+            total_price: '0',
+            payment_plan: '2',
+            due_date: '2026-09-01',
             name: '',
             phone: '',
             child_name: '',

--- a/resources/js/pages/orders/form-state.ts
+++ b/resources/js/pages/orders/form-state.ts
@@ -50,70 +50,19 @@ export const emptyForm = (): OrderFormData => ({
 });
 
 /**
- * Restores the "save and keep selling" data persisted in localStorage.
- * Personal data is intentionally left blank.
+ * Blank slate for the next client of a continuous sale ("guardar y seguir
+ * vendiendo"): keeps the school and the payment terms, clears the client
+ * and the products (detail notes carry the previous child's name), and
+ * zeroes the price so re-adding a combo doesn't sum over the old total.
  */
-export const readSavedForm = (): {
-    form: OrderFormData;
-    selectedSchool: number;
-} | null => {
-    const savedData = localStorage.getItem('orderFormData');
-
-    if (!savedData) return null;
-
-    try {
-        const parsed = JSON.parse(savedData);
-
-        return {
-            form: {
-                ...emptyForm(),
-                classroom_id: parsed.classroom_id ?? 0,
-                order_details: parsed.order_details ?? [],
-                total_price: parsed.total_price ?? '0',
-                payment_plan: parsed.payment_plan ?? '0',
-                due_date: parsed.due_date ?? format(new Date(), 'yyyy-MM-dd'),
-            },
-            selectedSchool: parsed.selectedSchool ?? 0,
-        };
-    } catch {
-        return null;
-    }
-};
-
-/**
- * Persists the order data for "save and keep selling", excluding the
- * client's personal data on purpose.
- */
-export const persistSavedForm = (
-    form: OrderFormData,
-    selectedSchool: number,
-): void => {
-    localStorage.setItem(
-        'orderFormData',
-        JSON.stringify({
-            classroom_id: form.classroom_id,
-            order_details: form.order_details,
-            total_price: form.total_price,
-            payment_plan: form.payment_plan,
-            due_date: form.due_date,
-            selectedSchool,
-        }),
-    );
-};
-
-export const clearSavedForm = (): void => {
-    localStorage.removeItem('orderFormData');
-};
-
-/**
- * Blank slate for the next client, keeping the order data.
- */
-export const resetPersonalData = (form: OrderFormData): OrderFormData => ({
+export const resetForNextClient = (form: OrderFormData): OrderFormData => ({
     ...form,
     name: '',
     phone: '',
     child_name: '',
     attended_photo_session: null,
+    order_details: [],
+    total_price: '0',
     draft_id: null,
 });
 
@@ -153,9 +102,12 @@ const keepExistingProducts = (
 };
 
 /**
- * Initial values for the order form: a draft ("Ver" in borradores) wins
- * over localStorage. Must be resolved before useForm: setting them with
- * setData in an effect gets lost.
+ * Initial values for the order form: a draft ("Ver" in borradores) fills
+ * the form, any other entry starts blank. Continuous selling never gets
+ * here: Inertia preserves the component state through the POST redirect
+ * (no remount), so that reset happens in memory via resetForNextClient.
+ * Must be resolved before useForm: setting them with setData in an
+ * effect gets lost.
  */
 export const resolveInitialOrderForm = (
     draft?: DraftProp | null,
@@ -185,22 +137,6 @@ export const resolveInitialOrderForm = (
             },
             selectedSchool: draft.classroom.school_id,
             message: `Borrador #${draft.id} cargado`,
-            droppedProducts: dropped,
-        };
-    }
-
-    const saved = readSavedForm();
-
-    if (saved) {
-        const { details, dropped } = keepExistingProducts(
-            saved.form.order_details,
-            validProductIds,
-        );
-
-        return {
-            ...saved,
-            form: { ...saved.form, order_details: details },
-            message: 'Datos de pedido anterior cargados',
             droppedProducts: dropped,
         };
     }


### PR DESCRIPTION
Closes #101

## Problema

El formulario de crear pedido restauraba el pedido anterior sin importar por dónde se llegara: "Guardar y seguir vendiendo" persistía el pedido en `localStorage`, cada mount fresco de `/orders/create` lo restauraba, y solo se limpiaba después de un "Guardar" normal. Si el vendedor no volvía a guardar normal, el autofill quedaba pegado para siempre.

## Fix

Se elimina `localStorage` por completo. Inertia v1 envía los forms con `preserveState: true`, así que tras el POST que redirige de vuelta a `orders.create` el componente **no** se remonta — la venta continua se sostiene solo con el reset en memoria del `onSuccess` (`resetForNextClient`). Cualquier otra entrada (sidebar, botón del índice, URL directa, refresh) es un mount fresco y arranca vacía.

Según lo discutido en el issue, el reset ahora:

- **conserva** escuela/curso, cuotas y primer vencimiento;
- **limpia** cliente (nombre, teléfono, niño, asistencia) **y productos**;
- **resetea el precio a 0** — con los productos limpios, conservarlo haría que `handleAddCombo` duplique el total al sumar sobre el precio viejo;
- salta al paso **Cliente** (la escuela ya está cargada y visible en su badge).

## Investigación: "qué pasa con los nombres"

Los datos del cliente nunca fueron parte del autofill (ya se excluían a propósito). Lo que sí viajaba eran los `order_details`, cuyas `note` llevan el nombre del niño anterior (ej. "Taza de Luca") — por eso aparecían nombres ajenos en pedidos nuevos. Limpiar los productos en la venta continua lo resuelve de raíz.

## Tests

- `form-state.test.ts` actualizado; incluye test de regresión que verifica que la key legacy `orderFormData` de `localStorage` se ignora.
- Vitest 90 verdes; eslint, prettier y `tsc --noEmit` limpios. Sin cambios de backend.
- E2E en browser (17/17 checks, headless): pedido completo + guardar-y-seguir conserva escuela/cuotas y limpia cliente/productos/precio con el paso Cliente abierto y nada en `localStorage`; el refresh y la navegación normal arrancan vacíos y sin toast de autofill; el flujo "Ver" de borradores sigue autorellenando.