### PR TITLE
ci: drop xdebug, cache composer and speed up mysql boot

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [develop, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci_backend:
     runs-on: ubuntu-latest
@@ -17,10 +21,11 @@ jobs:
         ports:
           - 3306:3306
         options: >-
+          --tmpfs /var/lib/mysql
           --health-cmd="mysqladmin ping -h 127.0.0.1 -ppassword"
-          --health-interval=10s
+          --health-interval=2s
           --health-timeout=5s
-          --health-retries=5
+          --health-retries=15
 
     steps:
       - name: 📥 Clone repo
@@ -31,7 +36,18 @@ jobs:
         with:
           php-version: '8.4'
           tools: composer:v2
-          coverage: xdebug
+          coverage: none
+
+      - name: 📂 Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: ♻️ Composer cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: 📦 Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader


### PR DESCRIPTION
Closes #48

## Baseline (before)

Wall clock ~1.4 min: `ci_backend` ~80s (container init 26s, composer install 10s, Pint 17s, PhpStan 7s, tests 9s), `ci_frontend` ~50s.

## Changes

- **`coverage: xdebug` → `coverage: none`**: nothing consumes coverage and xdebug slows down every PHP process in the job (Pint's 17s is the main suspect).
- **MySQL on tmpfs + health-check every 2s** (was 10s): container init spent up to 10s idle just waiting for the next health probe, plus disk-bound datadir init. Retries raised to 15 to keep the total startup window generous.
- **Composer cache** keyed by `composer.lock` (the frontend job already cached npm).
- **Workflow-level `concurrency` with `cancel-in-progress`**: a new push to a PR cancels the superseded run instead of burning runner minutes.

## Considered and rejected (measured)

- **`pest --parallel`**: measured via Sail — 18.9s parallel vs 13.5s sequential. At 88 tests, per-process database migration dominates. Revisit when the suite grows.
- **PhpStan result cache**: the step takes 7s; cache restore/save would cost about the same.
- **Path filters / splitting lint and tests into separate jobs**: risk of false skips on required checks, and duplicated setup (~20s) eats the parallelism gain.