### PR TITLE
test(e2e): add playwright smoke suite with ci job

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,15 @@
+name: Setup Node
+description: Node.js with the npm cache and dependencies installed. Single source of truth for the Node version.
+
+runs:
+  using: composite
+  steps:
+    - name: ⚙️ Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - name: 📦 npm install
+      shell: bash
+      run: npm ci

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,28 @@
+name: Setup PHP
+description: PHP with the composer cache and dependencies installed. Single source of truth for the PHP version.
+
+runs:
+  using: composite
+  steps:
+    - name: ⚙️ PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        tools: composer:v2
+        coverage: none
+
+    - name: 📂 Composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: ♻️ Composer cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: 📦 Composer install
+      shell: bash
+      run: composer install --no-interaction --prefer-dist --optimize-autoloader

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,26 +31,8 @@ jobs:
       - name: 📥 Clone repo
         uses: actions/checkout@v4
 
-      - name: ⚙️ PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          tools: composer:v2
-          coverage: none
-
-      - name: 📂 Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: ♻️ Composer cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: 📦 Install dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: ⚙️ PHP + composer
+        uses: ./.github/actions/setup-php
 
       - name: ⚡ Setup Laravel
         run: |
@@ -79,14 +61,8 @@ jobs:
       - name: 📥 Clone repo
         uses: actions/checkout@v4
 
-      - name: ⚙️ Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: ⚙️ Node.js + npm
+        uses: ./.github/actions/setup-node
 
       - name: ✨ Prettier
         run: npm run format -- --check

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,23 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci_backend:
+  quality_backend:
     runs-on: ubuntu-latest
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: testing
-        ports:
-          - 3306:3306
-        options: >-
-          --tmpfs /var/lib/mysql
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -ppassword"
-          --health-interval=2s
-          --health-timeout=5s
-          --health-retries=15
 
     steps:
       - name: 📥 Clone repo
@@ -45,16 +30,7 @@ jobs:
       - name: 🧹 PhpStan
         run: vendor/bin/phpstan analyse
 
-      - name: 🧪 Tests
-        env:
-          DB_CONNECTION: mysql
-          DB_HOST: 127.0.0.1
-          DB_PORT: 3306
-          DB_USERNAME: root
-          DB_PASSWORD: password
-        run: php artisan test
-
-  ci_frontend:
+  quality_frontend:
     runs-on: ubuntu-latest
 
     steps:
@@ -72,6 +48,3 @@ jobs:
 
       - name: 🛠️ TypeScript checks
         run: npx tsc --noEmit
-
-      - name: 🧪 Vitest
-        run: npm run test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,6 +92,12 @@ jobs:
       - name: 🛠️ Type-check specs
         run: npx tsc -p e2e --noEmit
 
+      # Sessions live in the database, so the app 500s (and Playwright's
+      # webServer never reports ready) until the tables exist. The global
+      # setup reseeds again once the server is up.
+      - name: 🗄️ Prepare database
+        run: php artisan migrate:fresh --seed
+
       - name: 🧪 E2E tests
         env:
           E2E_BASE_URL: http://127.0.0.1:8000

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,107 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: testing
+        ports:
+          - 3306:3306
+        options: >-
+          --tmpfs /var/lib/mysql
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -ppassword"
+          --health-interval=2s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: testing
+      DB_USERNAME: root
+      DB_PASSWORD: password
+      # Assertions match the Spanish UI, but .env.example ships APP_LOCALE=en
+      APP_LOCALE: es
+
+    steps:
+      - name: 📥 Clone repo
+        uses: actions/checkout@v4
+
+      - name: ⚙️ PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: 📂 Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: ♻️ Composer cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: 📦 Composer install
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: ⚡ Setup Laravel
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: ⚙️ Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: 📦 npm install
+        run: npm ci
+
+      - name: 🏗️ Build assets
+        run: npm run build
+
+      - name: ♻️ Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      - name: 🌐 Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: 🛠️ Type-check specs
+        run: npx tsc -p e2e --noEmit
+
+      - name: 🧪 E2E tests
+        env:
+          E2E_BASE_URL: http://127.0.0.1:8000
+          E2E_ARTISAN: php artisan
+        run: npx playwright test
+
+      - name: 📤 Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,43 +41,21 @@ jobs:
       - name: 📥 Clone repo
         uses: actions/checkout@v4
 
-      - name: ⚙️ PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          tools: composer:v2
-          coverage: none
-
-      - name: 📂 Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: ♻️ Composer cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: 📦 Composer install
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: ⚙️ PHP + composer
+        uses: ./.github/actions/setup-php
 
       - name: ⚡ Setup Laravel
         run: |
           cp .env.example .env
           php artisan key:generate
 
-      - name: ⚙️ Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
+      - name: ⚙️ Node.js + npm
+        uses: ./.github/actions/setup-node
 
-      - name: 📦 npm install
-        run: npm ci
-
+      # `vite build` directly: the `build` script also runs the root tsc,
+      # which ci_frontend already enforces in parallel
       - name: 🏗️ Build assets
-        run: npm run build
+        run: npx vite build
 
       - name: ♻️ Playwright browser cache
         uses: actions/cache@v4
@@ -86,8 +64,9 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
           restore-keys: ${{ runner.os }}-playwright-
 
+      # No --with-deps: ubuntu-latest already ships the Chromium system deps
       - name: 🌐 Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🛠️ Type-check specs
         run: npx tsc -p e2e --noEmit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: Tests
 
 on:
   pull_request:
@@ -9,6 +9,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  tests_backend:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: testing
+        ports:
+          - 3306:3306
+        options: >-
+          --tmpfs /var/lib/mysql
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -ppassword"
+          --health-interval=2s
+          --health-timeout=5s
+          --health-retries=15
+
+    steps:
+      - name: 📥 Clone repo
+        uses: actions/checkout@v4
+
+      - name: ⚙️ PHP + composer
+        uses: ./.github/actions/setup-php
+
+      - name: ⚡ Setup Laravel
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: 🧪 Pest
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_USERNAME: root
+          DB_PASSWORD: password
+        run: php artisan test
+
+  tests_frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Clone repo
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Node.js + npm
+        uses: ./.github/actions/setup-node
+
+      - name: 🧪 Vitest
+        run: npm run test
+
   e2e:
     runs-on: ubuntu-latest
 
@@ -53,7 +105,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       # `vite build` directly: the `build` script also runs the root tsc,
-      # which ci_frontend already enforces in parallel
+      # which quality_frontend already enforces in parallel
       - name: 🏗️ Build assets
         run: npx vite build
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log
 nohup.out
 /.claude
 /coverage
+/test-results
+/playwright-report
+/e2e/.auth

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+import { USERS, login } from './helpers';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('rejects wrong credentials', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#email').fill(USERS.master);
+    await page.locator('#password').fill('not-the-password');
+    await page.locator('form button').click();
+
+    await expect(page.getByText(/credenciales|records/i)).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe('/');
+});
+
+test('logs in, redirects /settings and logs out', async ({ page }) => {
+    await login(page);
+
+    await page.goto('/settings');
+    await page.waitForURL('/settings/password');
+
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: /Agustín Pérez/ }).click();
+    await page.getByText('Cerrar sesión').click();
+    await page.waitForURL('/');
+});

--- a/e2e/cancel-recycling.spec.ts
+++ b/e2e/cancel-recycling.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+// Order #2 (Bruno Díaz / Thiago): the Clásico was glued, so 2 MDF boards were
+// deducted — cancelling it back to stock must return them; the carpeta goes
+// to the recycling bin.
+test('cancelling returns supplies to stock and lists recycled products', async ({
+    page,
+}) => {
+    await page.goto('/orders/2');
+
+    await page.getByRole('button', { name: 'Cancelar pedido' }).click();
+    const modal = page.getByRole('dialog');
+    await expect(modal.getByText('Cancelar pedido #2')).toBeVisible();
+
+    // Clásico → stock; the carpeta keeps the default (reciclaje)
+    await modal
+        .locator('li')
+        .filter({ hasText: 'Clásico' })
+        .getByRole('combobox')
+        .click();
+    await page.getByRole('option', { name: 'Stock' }).click();
+    await modal.getByRole('button', { name: 'Confirmar cancelación' }).click();
+    await expect(page.getByText('Pedido cancelado').first()).toBeVisible();
+
+    // The carpeta shows up in the recycling module
+    await page.goto('/recycling');
+    await expect(
+        page
+            .getByRole('row')
+            .filter({ hasText: 'Thiago' })
+            .filter({ hasText: 'Carpeta' }),
+    ).toBeVisible();
+
+    // The MDF boards came back as a return movement
+    await page.goto('/stock-movements');
+    await expect(
+        page
+            .getByRole('row')
+            .filter({ hasText: 'Planchas de MDF' })
+            .filter({ hasText: 'Devolución por cancelación' })
+            .first(),
+    ).toBeVisible();
+});

--- a/e2e/delivery-payment.spec.ts
+++ b/e2e/delivery-payment.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+
+// Order #8 (Hernán Luna / Isabella): overdue with a $9.000 balance — receipt
+// download, partial payment and the ignorable delivery warning.
+test('receipt PNG, partial payment and delivery despite balance', async ({
+    page,
+}) => {
+    await page.goto('/orders/8');
+
+    // The receipt downloads as a rendered PNG (jsPDF is gone, see #51)
+    const downloadPromise = page.waitForEvent('download');
+    await page
+        .getByRole('button', { name: /Descargar comprobante/ })
+        .first()
+        .click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(
+        /^comprobante-pago-\d+-pedido-8\.png$/,
+    );
+
+    // Register a partial payment
+    await page.getByRole('button', { name: 'Registrar pago' }).click();
+    const modal = page.getByRole('dialog');
+    await modal.locator('#amount').fill('4000');
+    await modal.getByRole('button', { name: 'Registrar pago' }).click();
+    await expect(page.getByText(/5\.000/).first()).toBeVisible(); // new balance
+
+    // Delivering with a balance warns, but the warning is ignorable
+    await page.getByRole('button', { name: 'Entregar todo' }).click();
+    const warning = page.getByRole('dialog');
+    await expect(
+        warning.getByText('Este pedido no está pagado al 100%'),
+    ).toBeVisible();
+    await warning.getByRole('button', { name: 'Entregar igualmente' }).click();
+    await expect(page.getByText('Entrega registrada')).toBeVisible();
+    await expect(page.getByText('Pendientes de entrega')).toHaveCount(0);
+    await expect(page.getByText('Entregados', { exact: true })).toBeVisible();
+});
+
+// Order #4 (Diego Farías / Benjamín): finished and fully paid — no warning.
+test('fully paid order delivers without warning, undo works', async ({
+    page,
+}) => {
+    await page.goto('/orders/4');
+
+    await page.getByRole('button', { name: 'Entregar todo' }).click();
+    await expect(page.getByText('Entrega registrada')).toBeVisible();
+    await expect(
+        page.getByText('Este pedido no está pagado al 100%'),
+    ).toHaveCount(0);
+    await expect(page.getByText('Pendientes de entrega')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Deshacer entrega' }).click();
+    await expect(page.getByText('Entrega deshecha')).toBeVisible();
+    await expect(page.getByText('Pendientes de entrega')).toBeVisible();
+    await expect(page.getByText('Entregados', { exact: true })).toHaveCount(0);
+});

--- a/e2e/drafts.spec.ts
+++ b/e2e/drafts.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import {
+    addSimpleProduct,
+    fillClientStep,
+    fillSchoolStep,
+    nextStep,
+    stepTriggers,
+} from './helpers';
+
+// Full draft round-trip through the UI: save a partial order as draft,
+// preload it via "Ver" and turn it into a real order, which consumes it.
+test('draft: save, preload via "Ver", saving the order consumes it', async ({
+    page,
+}) => {
+    await page.goto('/orders/create');
+    await fillSchoolStep(page);
+    await fillClientStep(page, {
+        name: 'Cliente Borrador E2E',
+        phone: '3804888888',
+        child: 'Guada',
+    });
+    // Skip products; drafts can be partial
+    await nextStep(page);
+    await page.locator('#total_price').fill('30000');
+    await page.locator('#payment_plan').fill('1');
+    await page.getByRole('button', { name: 'Guardar como borrador' }).click();
+
+    await page.waitForURL('/drafts');
+    const row = page
+        .getByRole('row')
+        .filter({ hasText: 'Cliente Borrador E2E' });
+    await expect(row).toBeVisible();
+
+    // "Ver" preloads everything into the create form
+    await row.getByRole('button', { name: 'Ver', exact: true }).click();
+    await page.waitForURL(/\/orders\/create/);
+    await expect(page.getByText(/Borrador #\d+ cargado/)).toBeVisible();
+    await expect(
+        stepTriggers(page).filter({ hasText: 'Escuela Normal' }).first(),
+    ).toBeVisible();
+
+    await stepTriggers(page).filter({ hasText: 'Cliente' }).first().click();
+    await expect(page.locator('#name')).toHaveValue('Cliente Borrador E2E');
+
+    // Complete it and save for real
+    await stepTriggers(page).filter({ hasText: 'Productos' }).first().click();
+    await addSimpleProduct(page, 'Taza', 'Taza de Guada');
+    await stepTriggers(page).filter({ hasText: 'Pedido' }).first().click();
+    await expect(page.locator('#total_price')).toHaveValue('30000');
+    await page.getByRole('button', { name: 'Guardar', exact: true }).click();
+    await page.waitForURL('/orders');
+
+    // The draft was consumed
+    await page.goto('/drafts');
+    await expect(
+        page.getByRole('row').filter({ hasText: 'Cliente Borrador E2E' }),
+    ).toHaveCount(0);
+});

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,0 +1,17 @@
+import { test as setup } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import { USERS, login } from './helpers';
+
+// One fresh demo database per run. Every spec relies on the DemoSeeder
+// dataset and mutates only orders no other spec touches, so a single reset
+// is enough with workers: 1.
+setup('reset the database and sign in as master', async ({ page }) => {
+    const artisan = process.env.E2E_ARTISAN ?? './vendor/bin/sail artisan';
+    execSync(`${artisan} migrate:fresh --seed`, {
+        stdio: 'inherit',
+        timeout: 300_000,
+    });
+
+    await login(page, USERS.master);
+    await page.context().storageState({ path: 'e2e/.auth/master.json' });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,84 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export const PASSWORD = 'contraseña';
+
+export const USERS = {
+    master: 'agustin@fototobares.com',
+    oficina: 'oficina@fototobares.com',
+    editor: 'editor@fototobares.com',
+    taller: 'taller@fototobares.com',
+} as const;
+
+/** The login page is `/` — there is no /login route. */
+export async function login(page: Page, email: string = USERS.master) {
+    await page.goto('/');
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(PASSWORD);
+    await page.locator('form button').click();
+    await page.waitForURL('/dashboard');
+}
+
+/** Open a Radix select and pick an option by text. */
+export async function pickOption(
+    page: Page,
+    trigger: Locator,
+    option: string | RegExp,
+) {
+    await trigger.click();
+    await page.getByRole('option', { name: option }).first().click();
+}
+
+/**
+ * Step triggers of the create-order accordion. School/classroom names and the
+ * "N productos" count render there as badges — assert on these instead of
+ * page text: the Radix Select keeps a visually-hidden native <select> whose
+ * options pollute text lookups.
+ */
+export function stepTriggers(page: Page) {
+    return page.locator('button[data-state]');
+}
+
+/**
+ * Click the "Siguiente" of the currently-open accordion step. While the
+ * accordion animates between steps two of them are visible at once, so the
+ * lookup must be scoped to the open region.
+ */
+export async function nextStep(page: Page) {
+    await page
+        .locator('[role="region"][data-state="open"]')
+        .getByRole('button', { name: 'Siguiente' })
+        .click();
+}
+
+/** Fill step 1 (school + classroom) of the create-order form. */
+export async function fillSchoolStep(page: Page) {
+    const combos = page.locator('button[role="combobox"]');
+    await pickOption(page, combos.first(), /Escuela Normal/);
+    await pickOption(page, combos.nth(1), /6TO A/i);
+    await nextStep(page);
+}
+
+/** Fill step 2 (client) of the create-order form and move on. */
+export async function fillClientStep(
+    page: Page,
+    client: { name: string; phone: string; child: string },
+) {
+    await page.locator('#name').fill(client.name);
+    await page.locator('#phone').fill(client.phone);
+    await page.locator('#child_name').fill(client.child);
+    await page
+        .locator('input[name="attended_photo_session"][value="true"]')
+        .click();
+    await nextStep(page);
+}
+
+/**
+ * Add a product without variants in step 3. The cmdk search input filters by
+ * item value (the numeric id), so click the item by text instead of typing.
+ */
+export async function addSimpleProduct(page: Page, name: string, note: string) {
+    await page.getByRole('button', { name: 'Añadir producto' }).click();
+    await page.locator('[cmdk-item]', { hasText: name }).first().click();
+    await page.locator('#note').fill(note);
+    await page.getByRole('button', { name: 'Agregar 1 producto' }).click();
+}

--- a/e2e/order-lifecycle.spec.ts
+++ b/e2e/order-lifecycle.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test';
+import {
+    addSimpleProduct,
+    fillClientStep,
+    fillSchoolStep,
+    nextStep,
+    stepTriggers,
+} from './helpers';
+
+// Covers issue #101's regression surface: the in-memory reset of "guardar y
+// seguir vendiendo" (school/installments kept, client/products/price cleared)
+// and that fresh entries never autofill. Creates real orders for a client no
+// seeder uses.
+test('full order + "guardar y seguir vendiendo" resets in memory only', async ({
+    page,
+}) => {
+    await page.goto('/orders/create');
+
+    await fillSchoolStep(page);
+    await fillClientStep(page, {
+        name: 'Cliente E2E',
+        phone: '3804999999',
+        child: 'Bruno',
+    });
+    await addSimpleProduct(page, 'Taza', 'Taza de Bruno');
+    await expect(
+        stepTriggers(page).filter({ hasText: '1 productos' }),
+    ).toBeVisible();
+    await nextStep(page);
+
+    await page.locator('#total_price').fill('12000');
+    await page.locator('#payment_plan').fill('2');
+    await page
+        .getByRole('button', { name: 'Guardar y seguir vendiendo' })
+        .click();
+    await expect(page.getByText(/Se conservaron la escuela/)).toBeVisible();
+
+    // Client step reopened and empty, school/installments kept, price at 0
+    await expect(page.locator('#name')).toBeVisible();
+    await expect(page.locator('#name')).toHaveValue('');
+    await expect(page.locator('#phone')).toHaveValue('');
+    await expect(page.locator('#child_name')).toHaveValue('');
+    await expect(
+        stepTriggers(page).filter({ hasText: 'Escuela Normal' }).first(),
+    ).toBeVisible();
+    await expect(
+        stepTriggers(page).filter({ hasText: '0 productos' }),
+    ).toBeVisible();
+
+    await stepTriggers(page).filter({ hasText: 'Pedido' }).first().click();
+    await expect(page.locator('#total_price')).toHaveValue('0');
+    await expect(page.locator('#payment_plan')).toHaveValue('2');
+
+    // The legacy localStorage persistence must stay dead (PR #118)
+    expect(
+        await page.evaluate(() => localStorage.getItem('orderFormData')),
+    ).toBeNull();
+
+    // Reload right after: nothing survives, no autofill toast
+    await page.reload();
+    await expect(
+        stepTriggers(page).filter({ hasText: '0 productos' }),
+    ).toBeVisible();
+    await expect(
+        stepTriggers(page).filter({ hasText: 'Escuela Normal' }),
+    ).toHaveCount(0);
+    await expect(page.getByText(/cargado/)).toHaveCount(0);
+});
+
+test('a fresh entry from the index starts empty', async ({ page }) => {
+    await page.goto('/orders');
+    await page.locator('a[href*="/orders/create"]').first().click();
+    await page.waitForURL('/orders/create');
+
+    await expect(
+        stepTriggers(page).filter({ hasText: '0 productos' }),
+    ).toBeVisible();
+    await expect(
+        stepTriggers(page).filter({ hasText: 'Escuela Normal' }),
+    ).toHaveCount(0);
+
+    await stepTriggers(page).filter({ hasText: 'Pedido' }).first().click();
+    await expect(page.locator('#total_price')).toHaveValue('0');
+    await expect(page.locator('#payment_plan')).toHaveValue('0');
+});

--- a/e2e/roles.spec.ts
+++ b/e2e/roles.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import { USERS, login } from './helpers';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const CASES = [
+    {
+        role: 'oficina',
+        sees: ['Pedidos', 'Seguimiento'],
+        hidden: ['Etapas', 'Usuarios'],
+        forbidden: '/users',
+    },
+    {
+        role: 'editor',
+        sees: ['Dashboard'],
+        hidden: ['Pedidos', 'Seguimiento', 'Usuarios'],
+        forbidden: '/tracking',
+    },
+    {
+        role: 'taller',
+        sees: ['Seguimiento', 'Stockeables', 'Reciclaje'],
+        hidden: ['Pedidos', 'Etapas', 'Usuarios'],
+        forbidden: '/orders',
+    },
+] as const;
+
+for (const { role, sees, hidden, forbidden } of CASES) {
+    test(`${role}: sidebar matches the role and ${forbidden} is a 403`, async ({
+        page,
+    }) => {
+        await login(page, USERS[role]);
+
+        const sidebar = page.locator('[data-sidebar="sidebar"]').first();
+        for (const item of sees) {
+            await expect(
+                sidebar.getByRole('link', { name: item }),
+            ).toBeVisible();
+        }
+        for (const item of hidden) {
+            await expect(sidebar.getByRole('link', { name: item })).toHaveCount(
+                0,
+            );
+        }
+
+        const response = await page.goto(forbidden);
+        expect(response?.status()).toBe(403);
+    });
+}

--- a/e2e/tracking.spec.ts
+++ b/e2e/tracking.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+// Smoke over the per-product tracking board, on order #1's details (Ana
+// Suárez / Valentina — nothing produced yet, untouched by other specs).
+// Priority stays a read-only assertion: #108 will replace the automatic
+// backtrack priority with a manual one.
+test('quick advance, batch update and priority badge', async ({ page }) => {
+    await page.goto('/tracking');
+
+    // Seeded priority: Lola's mural was sent back to an earlier stage
+    await expect(
+        page
+            .getByRole('row')
+            .filter({ hasText: 'Lola' })
+            .getByText('Prioridad'),
+    ).toBeVisible();
+
+    // Quick advance: Valentina's carpeta jumps to its next stage
+    await page
+        .getByRole('row')
+        .filter({ hasText: 'Valentina' })
+        .filter({ hasText: 'Carpeta' })
+        .locator('button[title^="Pasar a"]')
+        .click();
+    await expect(page.getByText(/Estado actualizado/).first()).toBeVisible();
+
+    // Batch: select Valentina's medalla and apply a stage to the selection
+    const group = page
+        .locator('div.rounded-xl')
+        .filter({ has: page.getByRole('heading', { name: 'Medalla' }) });
+    await group
+        .getByRole('row')
+        .filter({ hasText: 'Valentina' })
+        .getByRole('checkbox')
+        .check();
+    await group.getByRole('combobox').click();
+    await page.getByRole('option').first().click();
+    await group.getByRole('button', { name: 'Aplicar a 1' }).click();
+    await expect(page.getByText(/Estado actualizado a/)).toBeVisible();
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "types": ["node"]
+    },
+    "include": ["./**/*.ts", "../playwright.config.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
             "devDependencies": {
                 "@headlessui/react": "^2.0.0",
                 "@inertiajs/react": "^1.0.0",
+                "@playwright/test": "^1.61.1",
                 "@tailwindcss/forms": "^0.5.3",
                 "@testing-library/react": "^16.3.2",
                 "@types/node": "^22.20.0",
@@ -1471,6 +1472,22 @@
             },
             "funding": {
                 "url": "https://opencollective.com/unts"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -7322,6 +7339,53 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
         "build": "tsc && vite build",
         "dev": "vite",
         "lint": "eslint resources/js --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore --fix",
-        "format": "prettier --write \"resources/{js,css}/**/*.{js,jsx,ts,tsx,css}\"",
-        "test": "vitest run"
+        "format": "prettier --write \"resources/{js,css}/**/*.{js,jsx,ts,tsx,css}\" \"e2e/**/*.ts\" \"playwright.config.ts\"",
+        "test": "vitest run",
+        "test:e2e": "playwright test"
     },
     "devDependencies": {
         "@headlessui/react": "^2.0.0",
         "@inertiajs/react": "^1.0.0",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/forms": "^0.5.3",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.20.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Local runs hit the Sail server at http://localhost and reset the database
+// through `./vendor/bin/sail artisan` (see e2e/global.setup.ts). CI overrides
+// both via E2E_BASE_URL / E2E_ARTISAN and lets Playwright boot
+// `php artisan serve` itself.
+export default defineConfig({
+    testDir: './e2e',
+    // Specs share one freshly-seeded database per run and each one mutates
+    // orders no other spec touches — keep them sequential.
+    workers: 1,
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI ? 'line' : 'list',
+    use: {
+        baseURL: process.env.E2E_BASE_URL ?? 'http://localhost',
+        screenshot: 'only-on-failure',
+        trace: 'retain-on-failure',
+    },
+    projects: [
+        { name: 'setup', testMatch: /global\.setup\.ts/ },
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                storageState: 'e2e/.auth/master.json',
+            },
+            dependencies: ['setup'],
+        },
+    ],
+    webServer: process.env.CI
+        ? {
+              command: 'php artisan serve --host=127.0.0.1 --port=8000',
+              url: 'http://127.0.0.1:8000',
+              timeout: 60_000,
+          }
+        : undefined,
+});


### PR DESCRIPTION
Closes #56

Phase 2 of the test plan: 7 spec files / 13 tests, green in ~35s locally against Sail, repeatable across consecutive runs. The spec list was re-scoped first (details in the [issue comment](https://github.com/sntlln93/fototobares/issues/56#issuecomment-4934154664)): the localStorage spec died with #101/PR #118, receipts are PNGs since #51, and backtrack priority is only asserted read-only because #108 replaces it.

## Setup

- `@playwright/test` runs on the host (browsers via `npx playwright install chromium`); the server is Sail locally, `php artisan serve` in CI (Playwright `webServer`).
- A `setup` project resets the database (`migrate:fresh --seed`) once per run and signs in as master, persisting the session as `storageState` — no per-spec logins.
- `workers: 1`; each spec mutates only demo orders no other spec touches (tracking uses order 1, cancellation order 2, deliveries orders 4/8, drafts creates its own).
- Local vs CI parameterized via `E2E_ARTISAN` / `E2E_BASE_URL`. CI pins `APP_LOCALE=es` (assertions match the Spanish UI; `.env.example` ships `en`).
- E2E job in the new `tests.yml` workflow: MySQL on tmpfs, composer/npm/browser caches, traces uploaded only on failure.

## The 13 tests

**e2e/global.setup.ts**
1. **reset the database and sign in as master** — reseeds the demo dataset and saves the master session every run; every other test depends on it.

**e2e/auth.spec.ts**
2. **rejects wrong credentials** — bad password stays on `/` and shows the validation error.
3. **logs in, redirects /settings and logs out** — full session round-trip; `/settings` lands on `/settings/password`; logout from the sidebar user menu returns to the login page.

**e2e/order-lifecycle.spec.ts**
4. **full order + "guardar y seguir vendiendo" resets in memory only** — creates a real order through all four steps (school/classroom selects, client, cmdk product picker, price/installments), saves with "continue selling" and asserts the reset: client step reopened and empty, school/classroom and installments kept, products at 0, price back to 0, `localStorage` empty (regression guard for #101), and a reload right after starts blank with no autofill toast.
5. **a fresh entry from the index starts empty** — navigating to the create form via the orders index never preloads anything; price and installments start at 0.

**e2e/drafts.spec.ts**
6. **draft: save, preload via "Ver", saving the order consumes it** — saves a partial order (no products) as draft, finds it on /drafts, preloads it with "Ver" (toast + school badge + client fields restored), completes it with a product and saves for real, then verifies the draft is gone.

**e2e/tracking.spec.ts**
7. **quick advance, batch update and priority badge** — on the per-product board: the seeded backtracked mural shows the "Prioridad" badge; the row-level quick-advance button moves a detail to its next stage; selecting a detail and applying a stage through the group's batch select updates it.

**e2e/delivery-payment.spec.ts**
8. **receipt PNG, partial payment and delivery despite balance** — on the overdue order: downloads the receipt and asserts the `comprobante-pago-*-pedido-8.png` filename (canvas PNG, #51), registers a partial payment through the modal (balance updates), then delivers everything through the ignorable "not 100% paid" warning.
9. **fully paid order delivers without warning, undo works** — "Entregar todo" on a fully paid order never shows the warning; undo brings the product back to pending.

**e2e/cancel-recycling.spec.ts**
10. **cancelling returns supplies to stock and lists recycled products** — cancels the order whose mural already consumed 2 MDF boards, sending the mural to stock and the folder to recycling; asserts the folder appears in /recycling and the boards come back as a "Devolución por cancelación" movement in /stock-movements.

**e2e/roles.spec.ts**
11. **oficina: sidebar matches the role and /users is a 403** — sees Pedidos/Seguimiento, no Etapas/Usuarios.
12. **editor: sidebar matches the role and /tracking is a 403** — sees only Dashboard.
13. **taller: sidebar matches the role and /orders is a 403** — sees Seguimiento/Stockeables/Reciclaje, no sales modules.

## Notes for reviewers

- Two "Siguiente" buttons coexist while the accordion animates between steps — form helpers scope the click to the open region (`nextStep` in `e2e/helpers.ts`).
- Delivery assertions target the "Pendientes de entrega"/"Entregados" sections instead of counting "Entregado" text, which also matches badges elsewhere.
- Frontend quality suites green: prettier, eslint, tsc, Vitest 90. No backend changes.
