### PR TITLE
fix(deploy): bajar PHP a 8.4 para que nixpacks pueda buildear

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: ⚙️ PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.5'
+        php-version: '8.4'
         tools: composer:v2
         coverage: none
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Fototobares: management system for a school photography studio — orders by school/classroom, installment payments with WhatsApp-shareable receipts, staged production with stock consumption, partial deliveries, cancellations with recycling, photo-to-child assignment by number.
 
-- Stack: Laravel 13 (PHP 8.5) + MySQL 8, Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8. The React Compiler is enabled (`vite.config.js`) — do not hand-add `useMemo`/`useCallback`/`memo`; let the compiler memoize. `eslint-plugin-react-hooks` enforces its rules in CI.
+- Stack: Laravel 13 (PHP 8.4) + MySQL 8, Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8. The React Compiler is enabled (`vite.config.js`) — do not hand-add `useMemo`/`useCallback`/`memo`; let the compiler memoize. `eslint-plugin-react-hooks` enforces its rules in CI.
 - Language split: code, branches, commits and code comments in **English**; UI copy and GitHub PRs/issues/comments always in **Spanish**.
 - There is no real production yet: migrations are edited in-place and re-run with `migrate:fresh --seed` instead of adding new migration files; bug fixes may be folded into redesigns.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ parciales, cancelaciones con reciclaje y asignación de fotos por número.
 
 ## Stack
 
-- **Backend**: Laravel 13 (PHP 8.5), MySQL 8.
+- **Backend**: Laravel 13 (PHP 8.4), MySQL 8.
 - **Frontend**: Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8.
 - **Entorno de desarrollo**: [Laravel Sail](https://laravel.com/docs/sail)
   (no hace falta PHP ni MySQL locales).
@@ -20,7 +20,7 @@ parciales, cancelaciones con reciclaje y asignación de fotos por número.
 ```bash
 # primera vez (instala vendor/ sin PHP local)
 docker run --rm -v "$(pwd)":/var/www/html -w /var/www/html \
-    laravelsail/php85-composer:latest composer install
+    laravelsail/php84-composer:latest composer install
 
 cp .env.example .env
 ./vendor/bin/sail up -d

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.5",
+        "php": "^8.4",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/framework": "^13.0",
         "laravel/nightwatch": "^1.18",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
     laravel.test:
         build:
-            context: "./vendor/laravel/sail/runtimes/8.5"
+            context: "./vendor/laravel/sail/runtimes/8.4"
             dockerfile: Dockerfile
             args:
                 WWWGROUP: "${WWWGROUP:-1000}"
-        image: "sail-8.5/app"
+        image: "sail-8.4/app"
         extra_hosts:
             - "host.docker.internal:host-gateway"
         ports:


### PR DESCRIPTION
El deploy del release del stack falló porque **nixpacks no tiene provider de PHP 8.5** y cayó a 8.3, incompatible con Laravel 13 / Symfony 8 (parse error en `symfony/http-foundation`). Detalle completo en #50.

## Fix

Bajar el piso de PHP de `^8.5` a `^8.4`:

- La app necesita 8.4+ igual (Symfony 8), así que **no se pierde nada funcional** — 8.5 era solo "lo último".
- nixpacks 1.39 (el de dokploy) **sí** provee PHP 8.4 → el build va a funcionar sin tocar el server.
- Ningún paquete del lock **requiere** 8.5; la única línea nueva del upgrade (`Pdo\Mysql::ATTR_SSL_CA`) existe desde 8.4.

Alineado en los 3 lados para que se pruebe lo que se deploya: `composer.json` (`^8.4`), runtime de Sail (`docker-compose.yml` → 8.4), CI (`setup-php` → 8.4) y docs.

## Verificación

Rebuild de Sail sobre **PHP 8.4.23 real** + suite completa: pint / phpstan (0) / Pest 88 / **e2e 13/13**. (La app boot-eaba con un 500 por `platform_check.php` viejo que exigía 8.5 — se regeneró con `composer install`; el lockfile ya estaba en `^8.4`, sin cambios.)

## Seguimiento

- #50: causa raíz documentada.
- #126: migrar producción a Dockerfile para no volver a depender del catálogo de versiones de nixpacks.