### PR TITLE
release: fix de deploy — PHP 8.4 para nixpacks

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: ⚙️ PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.5'
+        php-version: '8.4'
         tools: composer:v2
         coverage: none
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Fototobares: management system for a school photography studio — orders by school/classroom, installment payments with WhatsApp-shareable receipts, staged production with stock consumption, partial deliveries, cancellations with recycling, photo-to-child assignment by number.
 
-- Stack: Laravel 13 (PHP 8.5) + MySQL 8, Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8. The React Compiler is enabled (`vite.config.js`) — do not hand-add `useMemo`/`useCallback`/`memo`; let the compiler memoize. `eslint-plugin-react-hooks` enforces its rules in CI.
+- Stack: Laravel 13 (PHP 8.4) + MySQL 8, Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8. The React Compiler is enabled (`vite.config.js`) — do not hand-add `useMemo`/`useCallback`/`memo`; let the compiler memoize. `eslint-plugin-react-hooks` enforces its rules in CI.
 - Language split: code, branches, commits and code comments in **English**; UI copy and GitHub PRs/issues/comments always in **Spanish**.
 - There is no real production yet: migrations are edited in-place and re-run with `migrate:fresh --seed` instead of adding new migration files; bug fixes may be folded into redesigns.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ parciales, cancelaciones con reciclaje y asignación de fotos por número.
 
 ## Stack
 
-- **Backend**: Laravel 13 (PHP 8.5), MySQL 8.
+- **Backend**: Laravel 13 (PHP 8.4), MySQL 8.
 - **Frontend**: Inertia 3 + React 19 + TypeScript, Tailwind 4 + shadcn/ui, Vite 8.
 - **Entorno de desarrollo**: [Laravel Sail](https://laravel.com/docs/sail)
   (no hace falta PHP ni MySQL locales).
@@ -20,7 +20,7 @@ parciales, cancelaciones con reciclaje y asignación de fotos por número.
 ```bash
 # primera vez (instala vendor/ sin PHP local)
 docker run --rm -v "$(pwd)":/var/www/html -w /var/www/html \
-    laravelsail/php85-composer:latest composer install
+    laravelsail/php84-composer:latest composer install
 
 cp .env.example .env
 ./vendor/bin/sail up -d

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.5",
+        "php": "^8.4",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/framework": "^13.0",
         "laravel/nightwatch": "^1.18",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
     laravel.test:
         build:
-            context: "./vendor/laravel/sail/runtimes/8.5"
+            context: "./vendor/laravel/sail/runtimes/8.4"
             dockerfile: Dockerfile
             args:
                 WWWGROUP: "${WWWGROUP:-1000}"
-        image: "sail-8.5/app"
+        image: "sail-8.4/app"
         extra_hosts:
             - "host.docker.internal:host-gateway"
         ports:


### PR DESCRIPTION
**Mergear con "Create a merge commit"** (nunca squash). El merge redispara el deploy en dokploy — **este es el que arregla el build fallido**.

## Qué incluye

- **#127** — baja el piso de PHP de `^8.5` a `^8.4`. El release anterior quedó en `^8.5` y nixpacks no puede buildear esa versión (cae a 8.3 → parse error de Symfony 8). Con `^8.4`, nixpacks 1.39 sí construye. Detalle en #50.

## Al mergear

1. **Mirá el build de nixpacks**: ahora debería aprovisionar PHP 8.4 (disponible en nixpacks) en vez de caer a 8.3. Ese era el punto que rompía.
2. Post-deploy, migraciones a mano: `php artisan migrate:fresh --seed`.
3. Smoke check: login + assets + un pedido.

## Verificación previa

CI 5/5 verde sobre PHP 8.4 (la versión que buildea nixpacks). Validado además con rebuild de Sail en PHP 8.4.23 real: pint / phpstan / Pest 88 / e2e 13/13.

## Seguimiento

#126 — migrar producción a Dockerfile para dejar de depender del catálogo de versiones de nixpacks (evita que el próximo bump de runtime vuelva a romper acá).