### PR TITLE
build: migrar el build de producción a dockerfile (php 8.5 / node 24)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# VCS / tooling
+.git
+.github
+.gitattributes
+.gitignore
+.claude
+.devcontainer
+.vscode
+.idea
+.editorconfig
+.prettierrc
+.DS_Store
+
+# Never bake local secrets into the image
+.env*
+auth.json
+storage/*.key
+
+# Dependencies and build artifacts (built inside their own stages)
+node_modules
+vendor
+public/build
+public/hot
+# The image creates this symlink itself — keeps local and dokploy builds identical
+public/storage
+
+# Tests and dev-only files (release-notes/ and lang/ are runtime dependencies — keep them)
+tests
+e2e
+coverage
+test-results
+playwright-report
+vibe
+phpunit.xml
+phpstan.neon
+pint.json
+rector.php
+eslint.config.js
+vitest.config.ts
+playwright.config.ts
+.phpunit.result.cache
+.phpunit.cache
+resources/js/**/tests
+**/*.test.ts
+**/*.test.tsx
+nohup.out
+
+# Local dev / this build's own inputs
+docker-compose.yml
+Dockerfile
+.dockerignore
+CLAUDE.md
+storage/pail

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: ⚙️ Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
 
     - name: 📦 npm install

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: ⚙️ PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.4'
+        php-version: '8.5'
         tools: composer:v2
         coverage: none
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules
 /public/build
 /public/hot
+/public/storage
 /storage/*.key
 /storage/pail
 /vendor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Everything runs through Laravel Sail (Docker) — there is no local PHP, and a l
 
 ```bash
 ./vendor/bin/sail up -d                          # required for everything below
+./vendor/bin/sail artisan storage:link           # once per clone (public/storage is untracked)
 ./vendor/bin/sail artisan migrate:fresh --seed   # navigable app with demo data
 ./vendor/bin/sail npm run build                  # or `npm run dev` for HMR
 ```
@@ -73,8 +74,9 @@ Underlying tools if you need one directly: `sail composer pint` / `sail composer
 
 - PRs target `develop` and merge with **squash**; never reuse a merged branch.
 - Releases `develop → main` use a **merge commit** (never squash — a squashed release is what caused the recurring main/develop conflicts).
-- Merging to `main` auto-deploys via dokploy.
-- Five required checks on every PR: `quality_backend` (Pint+PhpStan), `quality_frontend` (Prettier+ESLint+tsc), `tests_backend` (Pest), `tests_frontend` (Vitest), `e2e` (Playwright). Shared setup lives in `.github/actions/setup-php|setup-node` — the single source of PHP/Node versions. Renaming a CI job requires updating the branch rulesets or PRs get blocked.
+- Merging to `main` auto-deploys via dokploy, which builds the repo `Dockerfile` (Build Type = Dockerfile). The production image creates the `public/storage` symlink and builds Laravel caches at container start (`docker/entrypoint.sh`); migrations stay manual post-deploy.
+- Five required checks on every PR: `quality_backend` (Pint+PhpStan), `quality_frontend` (Prettier+ESLint+tsc), `tests_backend` (Pest), `tests_frontend` (Vitest), `e2e` (Playwright). Renaming a CI job requires updating the branch rulesets or PRs get blocked.
+- PHP/Node versions are pinned in `.github/actions/setup-php|setup-node`, `docker-compose.yml` (Sail runtime) and the production `Dockerfile` — bump all of them together.
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+# Production image for dokploy (Build Type = Dockerfile). Replaces Nixpacks
+# so the runtime is pinned here instead of chosen by a builder (#126, #134).
+# PHP/Node versions must stay in sync with .github/actions/setup-php|setup-node
+# and docker-compose.yml (Sail) — bump them together.
+
+########## base: php-fpm + nginx + extensions, shared by build and runtime ##########
+FROM php:8.5-fpm AS base
+
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions pdo_mysql gd bcmath intl zip opcache pcntl redis \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nginx gettext-base curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+COPY docker/php.ini "$PHP_INI_DIR/conf.d/zz-app.ini"
+COPY docker/php-fpm.d/zz-app.conf /usr/local/etc/php-fpm.d/zz-app.conf
+
+# The dokploy persistent volume mounts at /app/storage/app — the app root
+# must be /app for that mount to keep working.
+WORKDIR /app
+
+########## composer: PHP dependencies on the exact runtime platform ##########
+FROM base AS composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-scripts --prefer-dist --no-interaction --no-progress
+
+# package:discover (post-autoload-dump) needs the full app source present.
+COPY . .
+RUN composer dump-autoload --optimize --no-dev
+
+########## assets: Vite build ##########
+FROM node:24-bookworm-slim AS assets
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY vite.config.js postcss.config.js tsconfig.json ./
+COPY resources/ resources/
+# Plain `vite build`, not `npm run build`: the tsc step needs
+# vendor/tightenco/ziggy and type-checking is CI's job anyway.
+RUN npx vite build
+
+########## runtime ##########
+FROM base AS runtime
+
+COPY . .
+# The image owns the symlink (relative, like Laravel's storage:link --relative);
+# the entrypoint creates the target dir after the volume mounts.
+RUN ln -sfn ../storage/app/public public/storage
+
+COPY --from=composer /app/vendor ./vendor
+COPY --from=composer /app/bootstrap/cache ./bootstrap/cache
+COPY --from=assets /app/public/build ./public/build
+
+COPY docker/nginx.conf.template /etc/nginx/nginx.conf.template
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+    CMD curl -fsS "http://127.0.0.1:${PORT:-80}/up" || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ parciales, cancelaciones con reciclaje y asignación de fotos por número.
 ## Desarrollo
 
 ```bash
-# primera vez (instala vendor/ sin PHP local)
+# primera vez (instala vendor/ sin PHP local; el ignore es solo para el
+# bootstrap: todavía no hay imagen php85-composer de Sail)
 docker run --rm -v "$(pwd)":/var/www/html -w /var/www/html \
-    laravelsail/php84-composer:latest composer install
+    laravelsail/php84-composer:latest composer install --ignore-platform-req=php
 
 cp .env.example .env
 ./vendor/bin/sail up -d
 ./vendor/bin/sail artisan key:generate
+./vendor/bin/sail artisan storage:link             # una sola vez por clon
 ./vendor/bin/sail artisan migrate:fresh --seed   # deja la app navegable con datos demo
 ./vendor/bin/sail npm ci
 ./vendor/bin/sail npm run build                  # o `npm run dev` para HMR
@@ -78,5 +80,6 @@ Los cinco checks son requeridos para mergear. El setup compartido vive en
 ## Flujo de trabajo
 
 - PRs a `develop` con squash; releases `develop → main` con merge commit.
-- El merge a `main` deploya automáticamente (dokploy).
+- El merge a `main` deploya automáticamente (dokploy, Build Type = Dockerfile:
+  la imagen de producción se construye con el `Dockerfile` del repo).
 - Convención de commits: `<type>(<scope>): <description>` (ver `CLAUDE.md`).

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/framework": "^13.0",
         "laravel/nightwatch": "^1.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25eb662b187daadfc7c88ea2ec240df3",
+    "content-hash": "e9b3946a8a51a2f208c5a856ce543bc9",
     "packages": [
         {
             "name": "brick/math",
@@ -11481,7 +11481,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
     laravel.test:
         build:
-            context: "./vendor/laravel/sail/runtimes/8.4"
+            context: "./vendor/laravel/sail/runtimes/8.5"
             dockerfile: Dockerfile
             args:
                 WWWGROUP: "${WWWGROUP:-1000}"
-        image: "sail-8.4/app"
+        image: "sail-8.5/app"
         extra_hosts:
             - "host.docker.internal:host-gateway"
         ports:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+cd /app
+
+# One-off commands (e.g. `docker run <image> php artisan ...`) run as-is,
+# without booting the web server or touching caches.
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+# The dokploy volume mounted at /app/storage/app shadows the image's skeleton;
+# recreate what the app expects. storage/app/public must exist or the baked-in
+# public/storage symlink dangles. Never run `artisan storage:link` here.
+mkdir -p \
+    storage/app/public \
+    storage/framework/cache/data \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/logs \
+    bootstrap/cache
+
+# storage/app is the uploads volume — never chown it recursively.
+chown -R www-data:www-data storage/framework storage/logs bootstrap/cache
+chown www-data:www-data storage/app storage/app/public
+
+# Env is injected by dokploy at runtime (no .env in the image), so caches are
+# built at container start, not image build. No route:cache: routes/settings.php
+# registers a closure route, which cannot be serialized. No migrations, ever.
+php artisan config:cache
+php artisan view:cache
+chown -R www-data:www-data bootstrap/cache storage/framework/views
+
+# Same process model Nixpacks used: php-fpm daemonized, nginx in foreground
+# as PID 1. A dead php-fpm surfaces as 502s and a failing HEALTHCHECK (/up).
+export PORT="${PORT:-80}"
+envsubst '${PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+php-fpm -D
+exec nginx -c /etc/nginx/nginx.conf -g 'daemon off;'

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,0 +1,62 @@
+# Rendered to /etc/nginx/nginx.conf by entrypoint.sh; envsubst replaces
+# only ${PORT} (nginx's own $variables must survive untouched).
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    server_tokens off;
+    sendfile on;
+    tcp_nopush on;
+    keepalive_timeout 65;
+
+    gzip on;
+    gzip_vary on;
+    gzip_types text/plain text/css application/json application/javascript text/javascript image/svg+xml;
+
+    server {
+        listen ${PORT} default_server;
+        server_name _;
+        root /app/public;
+        index index.php;
+
+        # Matches post_max_size/upload_max_filesize (photo uploads)
+        client_max_body_size 100M;
+
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        # Hashed Vite assets are immutable
+        location /build/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        location ~ \.php$ {
+            try_files $uri =404;
+            include fastcgi_params;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+            # Response headers can outgrow the 4k default — that caused 502s
+            # on /orders/create once (see the note in bootstrap/app.php).
+            fastcgi_buffer_size 16k;
+            fastcgi_buffers 32 16k;
+            fastcgi_busy_buffers_size 32k;
+        }
+
+        location ~ /\.(?!well-known) {
+            deny all;
+        }
+    }
+}

--- a/docker/php-fpm.d/zz-app.conf
+++ b/docker/php-fpm.d/zz-app.conf
@@ -1,0 +1,14 @@
+[www]
+; Config comes from container env vars (no .env in the image) — keep them
+; visible to workers.
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no
+
+; Sized for a small VPS: 10 workers x memory_limit 256M ~ 2.5G worst case.
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 4
+pm.max_requests = 500

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,17 @@
+; App overrides layered on top of php.ini-production.
+
+; Code is immutable inside the image — never stat files for changes.
+opcache.enable=1
+opcache.validate_timestamps=0
+opcache.memory_consumption=192
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+
+realpath_cache_size=4096K
+realpath_cache_ttl=600
+
+memory_limit=256M
+
+; Sail parity (vendor/laravel/sail/runtimes/*/php.ini): photo uploads
+post_max_size=100M
+upload_max_filesize=100M

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
                 "vitest": "^4.1.10"
             },
             "engines": {
-                "node": ">=22.12.0"
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "type": "module",
     "engines": {
-        "node": ">=22.12.0"
+        "node": ">=24.0.0"
     },
     "scripts": {
         "build": "tsc && vite build",

--- a/public/storage
+++ b/public/storage
@@ -1,1 +1,0 @@
-../storage/app/public


### PR DESCRIPTION
Closes #126. Closes #134.

## Qué cambia

**Runtimes estandarizados en PHP 8.5 y Node 24** para dev, CI y producción:

- Sail pasa al runtime `8.5` (`docker-compose.yml`), CI a `php-version: 8.5` y `node-version: 24` (`.github/actions/setup-php|setup-node`), y los pisos se actualizan: `composer.json` → `php ^8.5`, `package.json` → `node >=24`.

**Dockerfile de producción multi-stage** (reemplaza a nixpacks, que hoy ni siquiera buildea — ver #134):

- `base`: `php:8.5-fpm` + extensiones (`pdo_mysql`, `gd`, `bcmath`, `intl`, `zip`, `opcache`, `pcntl`, `redis`) + nginx.
- `composer`: `composer install --no-dev` sobre la misma base 8.5 (paridad exacta de plataforma); `dump-autoload --optimize` corre `package:discover` con el código completo.
- `assets`: `node:24` + `npm ci` + `vite build` — los assets quedan dentro de la imagen.
- `runtime`: opcache prod (`validate_timestamps=0`), subidas de 100M (paridad con Sail), `HEALTHCHECK` contra `/up`, y `entrypoint.sh` que arma los caches de Laravel al arrancar (el env lo inyecta dokploy en runtime) y levanta php-fpm + nginx — el mismo modelo de procesos que usaba nixpacks. Sin `route:cache` (hay una ruta con closure en `routes/settings.php`). **Nunca corre migraciones.**
- Los buffers fastcgi de nginx van en 16k para no regresionar los 502 de `/orders/create` (ver nota en `bootstrap/app.php`).

**`public/storage` deja de estar commiteado**: la imagen crea el symlink en el build y el entrypoint garantiza el target tras montar el volumen. En dev es un `sail artisan storage:link` una única vez por clon (documentado en el README).

## Verificación

- Suites completas en verde sobre 8.5/24: Pest (103), Vitest (93), Playwright e2e (13), Pint, PhpStan, Prettier, ESLint, tsc.
- `docker build` local exitoso + smoke sobre la imagen con MySQL 8: `/up` 200, `migrate --force` manual OK, login sirve assets hasheados de Vite desde la imagen, extensiones y opcache verificados, symlink resuelve.

## Pasos manuales post-merge (dokploy)

Después del release a `main`:

1. Application → **Build Type: `Dockerfile`** (Docker File: `./Dockerfile`, contexto: `.`).
2. Conservar las env vars actuales y el volumen persistente en `/app/storage/app`. Puerto del contenedor: 80 (o setear `PORT`).
3. Redeploy y, si el release trae migraciones, `php artisan migrate --force` desde la consola del contenedor.
4. Smoke: `/up`, login, un pedido, y una foto existente bajo `/storage/...`. Si las subidas fallan por permisos (uid distinto de la era nixpacks), correr una única vez `chown -R www-data:www-data /app/storage/app`.

Fuera de alcance: workers de cola / scheduler (nixpacks tampoco los corría), observabilidad, `.env.example`.