### PR TITLE
feat(payments): replace transfer proof with unique transaction number

### DIFF
--- a/app/Http/Controllers/BO/PaymentController.php
+++ b/app/Http/Controllers/BO/PaymentController.php
@@ -9,8 +9,6 @@ use App\Http\Requests\BO\StorePaymentRequest;
 use App\Models\Order;
 use App\Models\Payment;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 
 class PaymentController extends Controller
 {
@@ -27,12 +25,6 @@ class PaymentController extends Controller
             return back()->withErrors(['order_id' => 'No se pueden registrar pagos de un pedido cancelado.']);
         }
 
-        $proof = $request->file('proof_of_payment');
-
-        if ($proof instanceof UploadedFile) {
-            $validated['proof_of_payment'] = $proof->store('proofs', 'public');
-        }
-
         unset($validated['order_id']);
         $order->payments()->create($validated);
 
@@ -42,16 +34,6 @@ class PaymentController extends Controller
     public function update(StorePaymentRequest $request, Payment $payment): RedirectResponse
     {
         $validated = $request->validated();
-
-        $proof = $request->file('proof_of_payment');
-
-        if ($proof instanceof UploadedFile) {
-            if ($payment->proof_of_payment !== null) {
-                Storage::disk('public')->delete($payment->proof_of_payment);
-            }
-
-            $validated['proof_of_payment'] = $proof->store('proofs', 'public');
-        }
 
         unset($validated['order_id']);
         $payment->update($validated);

--- a/app/Http/Requests/BO/StorePaymentRequest.php
+++ b/app/Http/Requests/BO/StorePaymentRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\BO;
 
+use App\Models\Payment;
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -12,6 +14,14 @@ class StorePaymentRequest extends FormRequest
     public function authorize(): bool
     {
         return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        // Only transfers carry a transaction number
+        if ($this->input('type') !== 'transferencia') {
+            $this->merge(['transaction_number' => null]);
+        }
     }
 
     /**
@@ -23,7 +33,46 @@ class StorePaymentRequest extends FormRequest
             'order_id' => ['required', 'exists:orders,id'],
             'amount' => ['required', 'numeric', 'min:1'],
             'type' => ['required', 'string', 'max:255'],
-            'proof_of_payment' => ['nullable', 'file', 'mimes:jpg,jpeg,png,webp,pdf', 'max:5120'],
+            'transaction_number' => [
+                'required_if:type,transferencia',
+                'nullable',
+                'string',
+                'alpha_num:ascii',
+                'max:255',
+                $this->uniqueTransactionNumber(...),
+            ],
         ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'transaction_number.required_if' => 'El número de transacción es obligatorio para pagos por transferencia.',
+            'transaction_number.alpha_num' => 'El número de transacción sólo puede contener letras y números.',
+        ];
+    }
+
+    private function uniqueTransactionNumber(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        $query = Payment::query()->where('transaction_number', $value);
+
+        $current = $this->route('payment');
+
+        if ($current instanceof Payment) {
+            $query->whereKeyNot($current->id);
+        }
+
+        $existing = $query->first();
+
+        if ($existing !== null) {
+            $fail("El número de transacción ya está registrado en el pedido #{$existing->order_id}.");
+        }
     }
 }

--- a/app/Http/Resources/OrderResource.php
+++ b/app/Http/Resources/OrderResource.php
@@ -64,9 +64,7 @@ class OrderResource extends JsonResource
                         'id' => $payment->id,
                         'amount' => $payment->amount,
                         'type' => $payment->type,
-                        'proof_of_payment' => $payment->proof_of_payment !== null
-                            ? Storage::url($payment->proof_of_payment)
-                            : null,
+                        'transaction_number' => $payment->transaction_number,
                         'order_id' => $payment->order_id,
                         'paid_at' => $payment->created_at->diffForHumans(), // @phpstan-ignore-line
                         'paid_on' => $payment->created_at->format('d/m/Y'), // @phpstan-ignore-line

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $order_id
  * @property int $amount
  * @property string $type
- * @property string|null $proof_of_payment
+ * @property string|null $transaction_number
  */
 class Payment extends Model
 {

--- a/database/migrations/2025_02_22_162345_create_payments_table.php
+++ b/database/migrations/2025_02_22_162345_create_payments_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
 
             $table->integer('amount');
             $table->string('type');
-            $table->string('proof_of_payment')->nullable();
+            $table->string('transaction_number')->nullable()->unique();
             $table->timestamps();
         });
     }

--- a/database/seeders/DemoOrderSeeder.php
+++ b/database/seeders/DemoOrderSeeder.php
@@ -56,7 +56,7 @@ class DemoOrderSeeder extends Seeder
         $detail = $this->addDetail($order, $clasico, $this->muralVariant('horizontal', 'black'), 'Thiago - egresados 2026');
         $this->setStatus($detail, $clasico, 3, hoursAgo: 30);
         $this->addDetail($order, $carpeta, null, 'Thiago');
-        $order->payments()->create(['amount' => 20000, 'type' => 'transferencia']);
+        $order->payments()->create(['amount' => 20000, 'type' => 'transferencia', 'transaction_number' => 'MP73920184652']);
 
         // 3. Priority: the mural reached "Corte de moldura" (one strip
         // deducted) and was sent back to "Impreso" (stock stays deducted)
@@ -81,7 +81,7 @@ class DemoOrderSeeder extends Seeder
         $detail = $this->addDetail($order, $carpeta, null, 'Mora');
         $this->setStatus($detail, $carpeta, 3, hoursAgo: 24);
         $this->addDetail($order, $medalla, null, 'Mora');
-        $order->payments()->create(['amount' => 26000, 'type' => 'transferencia']);
+        $order->payments()->create(['amount' => 26000, 'type' => 'transferencia', 'transaction_number' => 'BNA48210937566']);
 
         // 6. Fully delivered and paid: gone from /tracking
         $order = $this->makeOrder($sextoA, 'Facundo Ríos', '3804000006', 'Ciro', 6, 6000, 1, 5);

--- a/lang/es/validation.php
+++ b/lang/es/validation.php
@@ -193,6 +193,7 @@ return [
         'suggested_max_payments' => 'cantidad máxima de cuotas',
         'max_payments' => 'cantidad máxima de cuotas',
         'payment_plan' => 'cuotas',
+        'transaction_number' => 'número de transacción',
         'due_date' => 'vencimiento',
         'total_price' => 'precio final',
         'order_details' => 'productos',

--- a/resources/js/lib/receipt.test.ts
+++ b/resources/js/lib/receipt.test.ts
@@ -18,7 +18,7 @@ const payment = {
     type: 'transferencia',
     paid_at: 'hace 2 días',
     paid_on: '06/07/2026',
-    proof_of_payment: null,
+    transaction_number: null,
 } as Payment;
 
 describe('receiptContent', () => {

--- a/resources/js/pages/orders/components/create-payment-modal.test.tsx
+++ b/resources/js/pages/orders/components/create-payment-modal.test.tsx
@@ -1,23 +1,71 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatePaymentModal } from './create-payment-modal';
 
-const post = vi.hoisted(() => vi.fn());
+type FormData = Record<string, unknown>;
 
-vi.mock('@inertiajs/react', () => ({
-    useForm: (initial: Record<string, unknown>) => ({
-        data: initial,
-        setData: vi.fn(),
-        post,
-        processing: false,
-        errors: {},
-    }),
+const inertia = vi.hoisted(() => ({
+    post: vi.fn(),
+    errors: {} as Record<string, string>,
+    form: null as { setData: (key: string, value: unknown) => void } | null,
 }));
 
-vi.stubGlobal('route', (name: string) => `http://localhost/${name}`);
+vi.mock('@inertiajs/react', async () => {
+    const { useState } = await import('react');
+
+    // Stateful stand-in: the transaction number field only appears after
+    // setData re-renders with type = transferencia
+    function useForm(initial: FormData) {
+        const [data, setData] = useState(initial);
+
+        const form = {
+            data,
+            setData: (
+                keyOrUpdater:
+                    string | FormData | ((current: FormData) => FormData),
+                value?: unknown,
+            ) => {
+                if (typeof keyOrUpdater === 'string') {
+                    setData((prev) => ({ ...prev, [keyOrUpdater]: value }));
+                } else {
+                    setData(keyOrUpdater);
+                }
+            },
+            post: inertia.post,
+            processing: false,
+            errors: inertia.errors,
+        };
+
+        inertia.form = form;
+
+        return form;
+    }
+
+    const Link = ({
+        href,
+        children,
+    }: {
+        href: string;
+        children?: ReactNode;
+    }) => <a href={href}>{children}</a>;
+
+    return { useForm, Link };
+});
+
+vi.stubGlobal('route', (name: string, params?: Record<string, unknown>) =>
+    params?.order !== undefined
+        ? `http://localhost/${name}/${params.order}`
+        : `http://localhost/${name}`,
+);
+
+const switchToTransfer = () =>
+    act(() => inertia.form?.setData('type', 'transferencia'));
 
 beforeEach(() => {
-    post.mockReset();
+    inertia.post.mockReset();
+    inertia.errors = {};
+    inertia.form = null;
 });
 
 describe('CreatePaymentModal', () => {
@@ -36,14 +84,55 @@ describe('CreatePaymentModal', () => {
         );
     });
 
-    it('submits as multipart to support the optional proof file', () => {
+    it('posts the payment to payments.store', () => {
         render(<CreatePaymentModal orderId={1} show onClose={vi.fn()} />);
 
         fireEvent.click(screen.getByText('Registrar pago'));
 
-        expect(post).toHaveBeenCalledWith(
+        expect(inertia.post).toHaveBeenCalledWith(
             'http://localhost/payments.store',
-            expect.objectContaining({ forceFormData: true }),
+            expect.anything(),
+        );
+    });
+
+    it('hides the transaction number field for cash payments', () => {
+        render(<CreatePaymentModal orderId={1} show onClose={vi.fn()} />);
+
+        expect(screen.queryByLabelText('Número de transacción')).toBeNull();
+    });
+
+    it('asks for the transaction number on transfers', () => {
+        render(<CreatePaymentModal orderId={1} show onClose={vi.fn()} />);
+
+        switchToTransfer();
+
+        fireEvent.change(screen.getByLabelText('Número de transacción'), {
+            target: { value: 'MP12345678' },
+        });
+
+        expect(
+            screen.getByLabelText<HTMLInputElement>('Número de transacción')
+                .value,
+        ).toBe('MP12345678');
+    });
+
+    it('links the duplicate error to the order that already has the number', () => {
+        inertia.errors = {
+            transaction_number:
+                'El número de transacción ya está registrado en el pedido #12.',
+        };
+
+        render(<CreatePaymentModal orderId={1} show onClose={vi.fn()} />);
+
+        switchToTransfer();
+
+        const link = screen.getByRole('link', { name: 'pedido #12' });
+
+        expect(link.getAttribute('href')).toBe(
+            'http://localhost/orders.show/12',
+        );
+        expect(link.parentElement?.textContent).toBe(
+            'El número de transacción ya está registrado en el pedido #12.',
         );
     });
 });

--- a/resources/js/pages/orders/components/create-payment-modal.tsx
+++ b/resources/js/pages/orders/components/create-payment-modal.tsx
@@ -15,6 +15,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { capitalize } from '@/lib/utils';
 import { useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import { TransactionNumberError } from './transaction-number-error';
 
 const PAYMENT_TYPES = ['efectivo', 'transferencia'] as const;
 
@@ -33,19 +34,18 @@ export function CreatePaymentModal({
         amount: number;
         type: (typeof PAYMENT_TYPES)[number];
         order_id: Order['id'];
-        proof_of_payment: File | null;
+        transaction_number: string;
     }>({
         amount: initialAmount ?? 0,
         type: PAYMENT_TYPES[0],
         order_id: orderId,
-        proof_of_payment: null,
+        transaction_number: '',
     });
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
 
         post(route('payments.store'), {
-            forceFormData: true,
             onSuccess: () => onClose(),
         });
     };
@@ -84,10 +84,10 @@ export function CreatePaymentModal({
                             setData((current) => ({
                                 ...current,
                                 type,
-                                proof_of_payment:
+                                transaction_number:
                                     type === 'transferencia'
-                                        ? current.proof_of_payment
-                                        : null,
+                                        ? current.transaction_number
+                                        : '',
                             }));
                         }}
                     >
@@ -107,27 +107,29 @@ export function CreatePaymentModal({
 
                 {data.type === 'transferencia' && (
                     <div className="mt-2">
-                        <Label htmlFor="proof_of_payment">
-                            Comprobante de transferencia (opcional)
+                        <Label htmlFor="transaction_number">
+                            Número de transacción
                         </Label>
                         <InputHint
                             className="text-xs"
-                            message="Imagen o PDF de hasta 5MB (MercadoPago, banco, etc.)"
+                            message="El número de referencia de la transferencia (MercadoPago, banco, etc.)"
                         />
                         <Input
-                            id="proof_of_payment"
-                            type="file"
-                            name="proof_of_payment"
-                            accept="image/jpeg,image/png,image/webp,application/pdf"
+                            id="transaction_number"
+                            type="text"
+                            name="transaction_number"
+                            value={data.transaction_number}
                             onChange={(event) =>
                                 setData(
-                                    'proof_of_payment',
-                                    event.target.files?.[0] ?? null,
+                                    'transaction_number',
+                                    event.target.value,
                                 )
                             }
                             className="mt-1 block w-full"
                         />
-                        <InputError message={errors.proof_of_payment} />
+                        <TransactionNumberError
+                            message={errors.transaction_number}
+                        />
                     </div>
                 )}
 

--- a/resources/js/pages/orders/components/edit-payment-modal.test.tsx
+++ b/resources/js/pages/orders/components/edit-payment-modal.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditPaymentModal } from './edit-payment-modal';
+
+const inertia = vi.hoisted(() => ({
+    put: vi.fn(),
+    errors: {} as Record<string, string>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    useForm: (initial: Record<string, unknown>) => ({
+        data: initial,
+        setData: vi.fn(),
+        put: inertia.put,
+        processing: false,
+        errors: inertia.errors,
+    }),
+    Link: ({ href, children }: { href: string; children?: ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.stubGlobal('route', (name: string, params?: unknown) => {
+    if (typeof params === 'number') {
+        return `http://localhost/${name}/${params}`;
+    }
+
+    const order = (params as Record<string, unknown> | undefined)?.order;
+
+    return order !== undefined
+        ? `http://localhost/${name}/${order}`
+        : `http://localhost/${name}`;
+});
+
+const makePayment = (overrides: Partial<Payment> = {}): Payment => ({
+    id: 3,
+    order_id: 1,
+    amount: 5000,
+    type: 'transferencia',
+    transaction_number: 'MP12345678',
+    paid_at: 'hace 2 días',
+    ...overrides,
+});
+
+beforeEach(() => {
+    inertia.put.mockReset();
+    inertia.errors = {};
+});
+
+describe('EditPaymentModal', () => {
+    it('prefills the transfer with its transaction number', () => {
+        render(
+            <EditPaymentModal payment={makePayment()} show onClose={vi.fn()} />,
+        );
+
+        expect(
+            screen.getByLabelText<HTMLInputElement>('Número de transacción')
+                .value,
+        ).toBe('MP12345678');
+    });
+
+    it('hides the transaction number field for cash payments', () => {
+        render(
+            <EditPaymentModal
+                payment={makePayment({
+                    type: 'efectivo',
+                    transaction_number: null,
+                })}
+                show
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByLabelText('Número de transacción')).toBeNull();
+    });
+
+    it('puts the changes to payments.update', () => {
+        render(
+            <EditPaymentModal payment={makePayment()} show onClose={vi.fn()} />,
+        );
+
+        fireEvent.click(screen.getByText('Modificar pago'));
+
+        expect(inertia.put).toHaveBeenCalledWith(
+            'http://localhost/payments.update/3',
+            expect.anything(),
+        );
+    });
+
+    it('links the duplicate error to the order that already has the number', () => {
+        inertia.errors = {
+            transaction_number:
+                'El número de transacción ya está registrado en el pedido #12.',
+        };
+
+        render(
+            <EditPaymentModal payment={makePayment()} show onClose={vi.fn()} />,
+        );
+
+        const link = screen.getByRole('link', { name: 'pedido #12' });
+
+        expect(link.getAttribute('href')).toBe(
+            'http://localhost/orders.show/12',
+        );
+    });
+});

--- a/resources/js/pages/orders/components/edit-payment-modal.tsx
+++ b/resources/js/pages/orders/components/edit-payment-modal.tsx
@@ -15,6 +15,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { capitalize } from '@/lib/utils';
 import { useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
+import { TransactionNumberError } from './transaction-number-error';
 
 const PAYMENT_TYPES = ['efectivo', 'transferencia'] as const;
 
@@ -27,26 +28,22 @@ export function EditPaymentModal({
     show: boolean;
     onClose: () => void;
 }) {
-    const { post, data, setData, processing, errors } = useForm<{
+    const { put, data, setData, processing, errors } = useForm<{
         amount: number;
         type: string;
         order_id: number;
-        proof_of_payment: File | null;
-        _method: 'put';
+        transaction_number: string;
     }>({
         amount: payment.amount,
         type: payment.type,
         order_id: payment.order_id,
-        proof_of_payment: null,
-        _method: 'put',
+        transaction_number: payment.transaction_number ?? '',
     });
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
 
-        // Method spoofing: multipart/form-data does not work with PUT
-        post(route('payments.update', payment.id), {
-            forceFormData: true,
+        put(route('payments.update', payment.id), {
             onSuccess: () => onClose(),
         });
     };
@@ -85,10 +82,10 @@ export function EditPaymentModal({
                             setData((current) => ({
                                 ...current,
                                 type,
-                                proof_of_payment:
+                                transaction_number:
                                     type === 'transferencia'
-                                        ? current.proof_of_payment
-                                        : null,
+                                        ? current.transaction_number
+                                        : '',
                             }));
                         }}
                     >
@@ -108,31 +105,29 @@ export function EditPaymentModal({
 
                 {data.type === 'transferencia' && (
                     <div className="mt-2">
-                        <Label htmlFor="proof_of_payment">
-                            Comprobante de transferencia (opcional)
+                        <Label htmlFor="transaction_number">
+                            Número de transacción
                         </Label>
                         <InputHint
                             className="text-xs"
-                            message={
-                                payment.proof_of_payment
-                                    ? 'Si adjuntás un archivo nuevo, reemplaza al actual'
-                                    : 'Imagen o PDF de hasta 5MB (MercadoPago, banco, etc.)'
-                            }
+                            message="El número de referencia de la transferencia (MercadoPago, banco, etc.)"
                         />
                         <Input
-                            id="proof_of_payment"
-                            type="file"
-                            name="proof_of_payment"
-                            accept="image/jpeg,image/png,image/webp,application/pdf"
+                            id="transaction_number"
+                            type="text"
+                            name="transaction_number"
+                            value={data.transaction_number}
                             onChange={(event) =>
                                 setData(
-                                    'proof_of_payment',
-                                    event.target.files?.[0] ?? null,
+                                    'transaction_number',
+                                    event.target.value,
                                 )
                             }
                             className="mt-1 block w-full"
                         />
-                        <InputError message={errors.proof_of_payment} />
+                        <TransactionNumberError
+                            message={errors.transaction_number}
+                        />
                     </div>
                 )}
 

--- a/resources/js/pages/orders/components/payment-history.tsx
+++ b/resources/js/pages/orders/components/payment-history.tsx
@@ -14,13 +14,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { downloadPaymentReceipt } from '@/lib/receipt';
 import { capitalize, formatPrice } from '@/lib/utils';
-import {
-    Edit,
-    EllipsisVertical,
-    ImageDown,
-    Paperclip,
-    Share2,
-} from 'lucide-react';
+import { Edit, EllipsisVertical, ImageDown, Share2 } from 'lucide-react';
 import { useState } from 'react';
 import { useShareReceipt } from '../hooks/use-share-receipt';
 import { CreatePaymentModal } from './create-payment-modal';
@@ -117,19 +111,17 @@ function PaymentItem({
         <div className="flex items-center justify-between border-b border-gray-200 py-4 last:border-0 dark:border-gray-700">
             <div className="flex items-center space-x-4">
                 <div>
-                    <div className="flex items-center gap-1 font-semibold text-black dark:text-white">
+                    <div className="font-semibold text-black dark:text-white">
                         {capitalize(payment.type)}
-                        {payment.proof_of_payment && (
-                            <a
-                                href={payment.proof_of_payment}
-                                target="_blank"
-                                rel="noreferrer"
-                                title="Ver comprobante de transferencia adjunto"
-                            >
-                                <Paperclip className="h-4 w-4 text-gray-400 hover:text-gray-600" />
-                            </a>
-                        )}
                     </div>
+                    {payment.transaction_number && (
+                        <div
+                            className="text-xs text-gray-500 dark:text-gray-400"
+                            title="Número de transacción"
+                        >
+                            N° {payment.transaction_number}
+                        </div>
+                    )}
                     <div className="text-sm text-gray-500 dark:text-gray-400">
                         {payment.paid_at}
                     </div>

--- a/resources/js/pages/orders/components/transaction-number-error.test.tsx
+++ b/resources/js/pages/orders/components/transaction-number-error.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TransactionNumberError } from './transaction-number-error';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({
+        href,
+        children,
+        className,
+    }: {
+        href: string;
+        children?: ReactNode;
+        className?: string;
+    }) => (
+        <a href={href} className={className}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.order ?? ''}`,
+);
+
+describe('TransactionNumberError', () => {
+    it('renders nothing without a message', () => {
+        const { container } = render(<TransactionNumberError />);
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders other validation errors as plain text', () => {
+        render(
+            <TransactionNumberError message="El número de transacción sólo puede contener letras y números." />,
+        );
+
+        expect(
+            screen.getByText(
+                'El número de transacción sólo puede contener letras y números.',
+            ),
+        ).not.toBeNull();
+        expect(screen.queryByRole('link')).toBeNull();
+    });
+
+    it('links to the order that already has the number', () => {
+        render(
+            <TransactionNumberError message="El número de transacción ya está registrado en el pedido #7." />,
+        );
+
+        const link = screen.getByRole('link', { name: 'pedido #7' });
+
+        expect(link.getAttribute('href')).toBe(
+            'http://localhost/orders.show/7',
+        );
+        expect(link.parentElement?.textContent).toBe(
+            'El número de transacción ya está registrado en el pedido #7.',
+        );
+    });
+});

--- a/resources/js/pages/orders/components/transaction-number-error.tsx
+++ b/resources/js/pages/orders/components/transaction-number-error.tsx
@@ -1,0 +1,35 @@
+import InputError from '@/components/input-error';
+import { Link } from '@inertiajs/react';
+
+const ORDER_REFERENCE = /pedido #(\d+)/;
+
+/**
+ * Renders the transaction number validation error; when the backend
+ * reports a duplicate ("... en el pedido #N"), the order becomes a link.
+ */
+export function TransactionNumberError({ message }: { message?: string }) {
+    if (!message) {
+        return null;
+    }
+
+    const match = message.match(ORDER_REFERENCE);
+
+    if (!match || match.index === undefined) {
+        return <InputError message={message} />;
+    }
+
+    const orderId = Number(match[1]);
+
+    return (
+        <p className="text-sm text-red-600 dark:text-red-400">
+            {message.slice(0, match.index)}
+            <Link
+                href={route('orders.show', { order: orderId })}
+                className="font-medium underline"
+            >
+                pedido #{orderId}
+            </Link>
+            {message.slice(match.index + match[0].length)}
+        </p>
+    );
+}

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -184,7 +184,7 @@ declare global {
         order_id: number;
         amount: number;
         type: string;
-        proof_of_payment: string | null;
+        transaction_number: string | null;
         paid_at: string;
         paid_on?: string;
     }

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 use App\Models\Order;
 use App\Models\Payment;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
 
-it('registers a payment without a proof of payment', function () {
+it('registers a cash payment without a transaction number', function () {
     actingAsRole();
 
     $order = Order::factory()->create();
@@ -24,11 +22,10 @@ it('registers a payment without a proof of payment', function () {
     $payment = $order->payments()->first();
 
     expect($payment?->amount)->toBe(5000)
-        ->and($payment?->proof_of_payment)->toBeNull();
+        ->and($payment?->transaction_number)->toBeNull();
 });
 
-it('stores the attached proof of payment', function () {
-    Storage::fake('public');
+it('registers a transfer payment with its transaction number', function () {
     actingAsRole();
 
     $order = Order::factory()->create();
@@ -37,47 +34,157 @@ it('stores the attached proof of payment', function () {
         'order_id' => $order->id,
         'amount' => 5000,
         'type' => 'transferencia',
-        'proof_of_payment' => UploadedFile::fake()->image('comprobante.jpg'),
+        'transaction_number' => 'MP12345678',
     ])->assertSessionHasNoErrors();
 
-    $payment = $order->payments()->first();
-
-    expect($payment?->proof_of_payment)->not->toBeNull();
-    Storage::disk('public')->assertExists($payment->proof_of_payment);
+    expect($order->payments()->first()?->transaction_number)->toBe('MP12345678');
 });
 
-it('replaces the previous proof when a new one is uploaded', function () {
-    Storage::fake('public');
+it('requires the transaction number on transfer payments', function () {
     actingAsRole();
 
-    $oldPath = UploadedFile::fake()->image('viejo.jpg')->store('proofs', 'public');
-    $payment = Payment::factory()->create(['proof_of_payment' => $oldPath]);
+    $order = Order::factory()->create();
+
+    post(route('payments.store'), [
+        'order_id' => $order->id,
+        'amount' => 5000,
+        'type' => 'transferencia',
+    ])->assertSessionHasErrors([
+        'transaction_number' => 'El número de transacción es obligatorio para pagos por transferencia.',
+    ]);
+
+    expect($order->payments()->count())->toBe(0);
+});
+
+it('rejects a non-alphanumeric transaction number', function (string $invalid) {
+    actingAsRole();
+
+    $order = Order::factory()->create();
+
+    post(route('payments.store'), [
+        'order_id' => $order->id,
+        'amount' => 5000,
+        'type' => 'transferencia',
+        'transaction_number' => $invalid,
+    ])->assertSessionHasErrors([
+        'transaction_number' => 'El número de transacción sólo puede contener letras y números.',
+    ]);
+})->with(['MP-1234', 'MP 1234', '1234!', 'ñ1234']);
+
+it('rejects a duplicate transaction number pointing to the order that has it', function () {
+    actingAsRole();
+
+    $existing = Payment::factory()->create([
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ]);
+
+    $order = Order::factory()->create();
+
+    post(route('payments.store'), [
+        'order_id' => $order->id,
+        'amount' => 5000,
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ])->assertSessionHasErrors([
+        'transaction_number' => "El número de transacción ya está registrado en el pedido #{$existing->order_id}.",
+    ]);
+
+    expect($order->payments()->count())->toBe(0);
+});
+
+it('detects duplicate transaction numbers regardless of case', function () {
+    actingAsRole();
+
+    Payment::factory()->create([
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ]);
+
+    $order = Order::factory()->create();
+
+    post(route('payments.store'), [
+        'order_id' => $order->id,
+        'amount' => 5000,
+        'type' => 'transferencia',
+        'transaction_number' => 'mp12345678',
+    ])->assertSessionHasErrors('transaction_number');
+});
+
+it('ignores the transaction number sent with a cash payment', function () {
+    actingAsRole();
+
+    $order = Order::factory()->create();
+
+    post(route('payments.store'), [
+        'order_id' => $order->id,
+        'amount' => 5000,
+        'type' => 'efectivo',
+        'transaction_number' => 'MP12345678',
+    ])->assertSessionHasNoErrors();
+
+    expect($order->payments()->first()?->transaction_number)->toBeNull();
+});
+
+it('lets a payment keep its own transaction number on update', function () {
+    actingAsRole();
+
+    $payment = Payment::factory()->create([
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ]);
 
     put(route('payments.update', $payment), [
         'order_id' => $payment->order_id,
         'amount' => 7000,
         'type' => 'transferencia',
-        'proof_of_payment' => UploadedFile::fake()->image('nuevo.jpg'),
+        'transaction_number' => 'MP12345678',
     ])->assertSessionHasNoErrors();
 
     $payment->refresh();
 
-    expect($payment->proof_of_payment)->not->toBe($oldPath)
-        ->and($payment->amount)->toBe(7000);
-
-    Storage::disk('public')->assertMissing($oldPath);
-    Storage::disk('public')->assertExists($payment->proof_of_payment);
+    expect($payment->amount)->toBe(7000)
+        ->and($payment->transaction_number)->toBe('MP12345678');
 });
 
-it('rejects an invalid proof file', function () {
+it('rejects reusing another payment transaction number on update', function () {
     actingAsRole();
 
-    $order = Order::factory()->create();
-
-    post(route('payments.store'), [
-        'order_id' => $order->id,
-        'amount' => 5000,
+    $existing = Payment::factory()->create([
         'type' => 'transferencia',
-        'proof_of_payment' => UploadedFile::fake()->create('malicioso.exe', 100),
-    ])->assertSessionHasErrors('proof_of_payment');
+        'transaction_number' => 'MP12345678',
+    ]);
+
+    $payment = Payment::factory()->create([
+        'type' => 'transferencia',
+        'transaction_number' => 'MP87654321',
+    ]);
+
+    put(route('payments.update', $payment), [
+        'order_id' => $payment->order_id,
+        'amount' => $payment->amount,
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ])->assertSessionHasErrors([
+        'transaction_number' => "El número de transacción ya está registrado en el pedido #{$existing->order_id}.",
+    ]);
+
+    expect($payment->refresh()->transaction_number)->toBe('MP87654321');
+});
+
+it('clears the transaction number when a transfer becomes a cash payment', function () {
+    actingAsRole();
+
+    $payment = Payment::factory()->create([
+        'type' => 'transferencia',
+        'transaction_number' => 'MP12345678',
+    ]);
+
+    put(route('payments.update', $payment), [
+        'order_id' => $payment->order_id,
+        'amount' => $payment->amount,
+        'type' => 'efectivo',
+    ])->assertSessionHasNoErrors();
+
+    expect($payment->refresh()->transaction_number)->toBeNull();
 });


### PR DESCRIPTION
## Resumen

- Reemplaza el adjunto de comprobante de transferencia por un **número de transacción** alfanumérico y único (decisión post-reunión 9/7).
- El número es obligatorio para pagos por transferencia; para efectivo se ignora y se limpia (una transferencia editada a efectivo pierde su número).
- Si el número ya existe, el error indica **qué pedido lo tiene, con link**: "El número de transacción ya está registrado en el pedido #N." (al editar, el propio pago queda excluido del chequeo).
- La unicidad es case-insensitive (collation de MySQL) y hay índice único en la tabla como red de seguridad.
- El historial de pagos muestra el número en lugar del clip de adjunto. El comprobante de pago al cliente (#51) se mantiene.
- Migración de `payments` editada in-place según convención del repo (requiere `migrate:fresh --seed`).

## Tests

- **Pest (13)**: número guardado en transferencias, obligatoriedad, rechazo de no-alfanuméricos, duplicado con mensaje exacto apuntando al pedido en conflicto, duplicado case-insensitive, update conservando el propio número / rechazando el de otro pago, limpieza al pasar a efectivo.
- **Vitest (12 en 3 archivos)**: campo condicional en ambos modales, y el error de duplicado renderizando el link al pedido.
- Suites completas verdes: pest 112, vitest 166, e2e 13/13, pint/phpstan/prettier/eslint/tsc.

Closes #109
