### PR TITLE
feat(combos): precio del pedido = combo + extras, con valor de resta y cuotas por defecto

### DIFF
--- a/app/Actions/Orders/UpdateOrder.php
+++ b/app/Actions/Orders/UpdateOrder.php
@@ -40,17 +40,29 @@ class UpdateOrder implements ActionContract
             /** @var array<int, array<string, mixed>> $orderDetails */
             $orderDetails = $data['order_details'];
 
-            $order->products()->sync(
-                collect($orderDetails)->mapWithKeys(function (array $product) {
-                    /** @var int $productId */
-                    $productId = $product['product_id'];
+            // Details are addressed row by row, never keyed by product: an
+            // order may repeat a product (two mugs with different names, or a
+            // combo carrying several units of the same one) and syncing by
+            // product_id collapsed those rows into a single one
+            foreach ($orderDetails as $detail) {
+                $attributes = [
+                    'variant' => $detail['variant'] ?? [],
+                    'note' => $detail['note'],
+                ];
 
-                    return [$productId => [
-                        'variant' => $product['variant'] ?? [],
-                        'note' => $product['note'],
-                    ]];
-                })->toArray()
-            );
+                if (! isset($detail['id'])) {
+                    $order->products()->attach($detail['product_id'], $attributes);
+
+                    continue;
+                }
+
+                // Scoped to the order: an id from another order matches nothing.
+                // Updated through the model so the variant cast applies
+                $order->details()
+                    ->whereKey($detail['id'])
+                    ->first()
+                    ?->update($attributes);
+            }
         });
     }
 }

--- a/app/Http/Controllers/BO/ComboController.php
+++ b/app/Http/Controllers/BO/ComboController.php
@@ -43,7 +43,7 @@ class ComboController extends Controller
         $combo = Combo::create([
             'name' => $validated['name'],
             'suggested_price' => $validated['suggested_price'],
-            'suggested_max_payments' => $validated['suggested_max_payments'],
+            'default_payments' => $validated['default_payments'],
         ]);
 
         $combo->products()->attach($this->pivotData($validated['products']));
@@ -68,7 +68,7 @@ class ComboController extends Controller
         $combo->update([
             'name' => $validated['name'],
             'suggested_price' => $validated['suggested_price'],
-            'suggested_max_payments' => $validated['suggested_max_payments'],
+            'default_payments' => $validated['default_payments'],
         ]);
 
         $combo->products()->sync($this->pivotData($validated['products']));

--- a/app/Http/Controllers/BO/ComboController.php
+++ b/app/Http/Controllers/BO/ComboController.php
@@ -46,14 +46,7 @@ class ComboController extends Controller
             'suggested_max_payments' => $validated['suggested_max_payments'],
         ]);
 
-        $combo->products()->attach(
-            (new Collection($validated['products']))->mapWithKeys(function ($product) {
-                return [$product['id'] => [
-                    'quantity' => $product['quantity'],
-                    'variants' => $product['variants'] ?? null,
-                ]];
-            })
-        );
+        $combo->products()->attach($this->pivotData($validated['products']));
 
         return redirect()->route('combos.index');
     }
@@ -78,14 +71,7 @@ class ComboController extends Controller
             'suggested_max_payments' => $validated['suggested_max_payments'],
         ]);
 
-        $combo->products()->sync(
-            (new Collection($validated['products']))->mapWithKeys(function ($product) {
-                return [$product['id'] => [
-                    'quantity' => $product['quantity'],
-                    'variants' => $product['variants'] ?? null,
-                ]];
-            })
-        );
+        $combo->products()->sync($this->pivotData($validated['products']));
 
         return redirect()->route('combos.index');
     }
@@ -95,5 +81,20 @@ class ComboController extends Controller
         $action->handle(['combo' => $combo]);
 
         return redirect()->route('combos.index');
+    }
+
+    /**
+     * @param  array<int, array{id: int, quantity: int, subtract_value: int, variants?: string}>  $products
+     * @return Collection<int, array{quantity: int, subtract_value: int, variants: string|null}>
+     */
+    private function pivotData(array $products): Collection
+    {
+        return (new Collection($products))->mapWithKeys(function (array $product) {
+            return [$product['id'] => [
+                'quantity' => $product['quantity'],
+                'subtract_value' => $product['subtract_value'],
+                'variants' => $product['variants'] ?? null,
+            ]];
+        });
     }
 }

--- a/app/Http/Requests/BO/StoreComboRequest.php
+++ b/app/Http/Requests/BO/StoreComboRequest.php
@@ -27,7 +27,7 @@ class StoreComboRequest extends FormRequest
         return [
             'name' => ['required'],
             'suggested_price' => ['required', 'numeric', 'min:1'],
-            'suggested_max_payments' => ['required', 'numeric', 'min:1'],
+            'default_payments' => ['required', 'numeric', 'min:1'],
             'products' => ['required', 'array'],
             'products.*.id' => ['required', 'exists:products,id'],
             'products.*.quantity' => ['required', 'integer', 'min:1'],
@@ -44,7 +44,7 @@ class StoreComboRequest extends FormRequest
      * @return array{
      *     name: string,
      *     suggested_price: float,
-     *     suggested_max_payments: int,
+     *     default_payments: int,
      *     products: array<int, array{
      *         id: int,
      *         quantity: int,
@@ -58,7 +58,7 @@ class StoreComboRequest extends FormRequest
         /** @var array{
          *     name: string,
          *     suggested_price: float,
-         *     suggested_max_payments: int,
+         *     default_payments: int,
          *     products: array<int, array{
          *         id: int,
          *         quantity: int,

--- a/app/Http/Requests/BO/StoreComboRequest.php
+++ b/app/Http/Requests/BO/StoreComboRequest.php
@@ -31,6 +31,7 @@ class StoreComboRequest extends FormRequest
             'products' => ['required', 'array'],
             'products.*.id' => ['required', 'exists:products,id'],
             'products.*.quantity' => ['required', 'integer', 'min:1'],
+            'products.*.subtract_value' => ['required', 'integer', 'min:0'],
             'products.*.variants' => ['sometimes'],
         ];
     }
@@ -47,6 +48,7 @@ class StoreComboRequest extends FormRequest
      *     products: array<int, array{
      *         id: int,
      *         quantity: int,
+     *         subtract_value: int,
      *         variants?: string,
      *     }>
      * }
@@ -60,6 +62,7 @@ class StoreComboRequest extends FormRequest
          *     products: array<int, array{
          *         id: int,
          *         quantity: int,
+         *         subtract_value: int,
          *         variants?: string,
          *     }>
          * }

--- a/app/Http/Requests/BO/StoreOrderRequest.php
+++ b/app/Http/Requests/BO/StoreOrderRequest.php
@@ -37,6 +37,9 @@ class StoreOrderRequest extends FormRequest
             'draft_id' => ['nullable', 'integer', 'exists:order_drafts,id'],
 
             'order_details' => ['required', 'array'],
+            // Existing rows carry their id on update: details are addressed one
+            // by one, since an order may repeat a product
+            'order_details.*.id' => ['nullable', 'integer', 'exists:order_details,id'],
             'order_details.*.product_id' => ['required', 'integer', 'exists:products,id'],
             'order_details.*.note' => ['nullable', 'string'],
             'order_details.*.variant' => ['sometimes', 'array'],
@@ -63,6 +66,7 @@ class StoreOrderRequest extends FormRequest
      *     attended_photo_session?: bool|null,
      *     draft_id?: int|null,
      *     order_details: array<int, array{
+     *         id?: int|null,
      *         product_id: int,
      *         note: string|null,
      *         variant?: array{
@@ -87,6 +91,7 @@ class StoreOrderRequest extends FormRequest
          *     attended_photo_session?: bool|null,
          *     draft_id?: int|null,
          *     order_details: array<int, array{
+         *         id?: int|null,
          *         product_id: int,
          *         note: string|null,
          *         variant?: array{

--- a/app/Http/Resources/ComboResource.php
+++ b/app/Http/Resources/ComboResource.php
@@ -22,7 +22,7 @@ class ComboResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'suggested_price' => $this->suggested_price,
-            'suggested_max_payments' => $this->suggested_max_payments,
+            'default_payments' => $this->default_payments,
             'products' => ProductResource::collection($this->products),
         ];
     }

--- a/app/Http/Resources/EditableComboResource.php
+++ b/app/Http/Resources/EditableComboResource.php
@@ -25,7 +25,7 @@ class EditableComboResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'suggested_price' => $this->suggested_price,
-            'suggested_max_payments' => $this->suggested_max_payments,
+            'default_payments' => $this->default_payments,
             'products' => $this->products->map(function (Product $p) {
                 return [
                     'id' => $p->id,

--- a/app/Http/Resources/EditableComboResource.php
+++ b/app/Http/Resources/EditableComboResource.php
@@ -32,6 +32,8 @@ class EditableComboResource extends JsonResource
                     /* @phpstan-ignore-next-line */
                     'quantity' => $p->getRelationValue('pivot')->quantity,
                     /* @phpstan-ignore-next-line */
+                    'subtract_value' => $p->getRelationValue('pivot')->subtract_value,
+                    /* @phpstan-ignore-next-line */
                     'variants' => $p->getRelationValue('pivot')->variants,
                 ];
             }),

--- a/app/Models/Combo.php
+++ b/app/Models/Combo.php
@@ -24,6 +24,6 @@ class Combo extends Model
         return $this->belongsToMany(Product::class)
             ->using(ComboProduct::class)
             ->as('pivot')
-            ->withPivot(['variants', 'quantity']);
+            ->withPivot(['variants', 'quantity', 'subtract_value']);
     }
 }

--- a/app/Models/ComboProduct.php
+++ b/app/Models/ComboProduct.php
@@ -10,5 +10,7 @@ class ComboProduct extends Pivot
 {
     protected $casts = [
         'variants' => 'array',
+        'quantity' => 'integer',
+        'subtract_value' => 'integer',
     ];
 }

--- a/database/migrations/2025_02_22_162323_create_combos_table.php
+++ b/database/migrations/2025_02_22_162323_create_combos_table.php
@@ -17,8 +17,9 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->integer('suggested_price');
-            $table->integer('suggested_max_payments');
-            $table->integer('suggested_financed_price')->nullable();
+            // Seeds the order's installments when the combo is added; the
+            // seller can still change them
+            $table->integer('default_payments');
             $table->softDeletes();
             $table->timestamps();
         });

--- a/database/migrations/2025_02_22_180015_create_combo_product_table.php
+++ b/database/migrations/2025_02_22_180015_create_combo_product_table.php
@@ -23,6 +23,10 @@ return new class extends Migration
 
             $table->json('variants')->nullable();
             $table->integer('quantity')->default(1);
+
+            // How much the combo price drops when this product is taken out of
+            // the order: set per combo, unrelated to the product list price
+            $table->integer('subtract_value')->default(0);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_23_035820_insert_into_combos_table.php
+++ b/database/migrations/2025_07_23_035820_insert_into_combos_table.php
@@ -24,8 +24,7 @@ return new class extends Migration
 
         $combo1 = Combo::create([
             'name' => 'Combo 1 (M.A)',
-            'suggested_financed_price' => 64000,
-            'suggested_max_payments' => 4,
+            'default_payments' => 4,
             'suggested_price' => 60000,
         ]);
 
@@ -37,8 +36,7 @@ return new class extends Migration
 
         $combo2 = Combo::create([
             'name' => 'Combo 2 (CLA)',
-            'suggested_financed_price' => 60000,
-            'suggested_max_payments' => 4,
+            'default_payments' => 4,
             'suggested_price' => 56000,
         ]);
 
@@ -50,8 +48,7 @@ return new class extends Migration
 
         $combo3 = Combo::create([
             'name' => 'Combo 3 (M.F)',
-            'suggested_financed_price' => 56000,
-            'suggested_max_payments' => 4,
+            'default_payments' => 4,
             'suggested_price' => 52000,
         ]);
 
@@ -63,8 +60,7 @@ return new class extends Migration
 
         $combo4 = Combo::create([
             'name' => 'Combo 3 (M.F) con taza',
-            'suggested_financed_price' => 68000,
-            'suggested_max_payments' => 4,
+            'default_payments' => 4,
             'suggested_price' => 64000,
         ]);
 

--- a/database/migrations/2025_07_23_035820_insert_into_combos_table.php
+++ b/database/migrations/2025_07_23_035820_insert_into_combos_table.php
@@ -30,9 +30,9 @@ return new class extends Migration
         ]);
 
         $combo1->products()->attach([
-            $products->firstWhere('name', 'Moldura ancha')?->id => ['quantity' => 1, 'variants' => json_encode($variants)],
-            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'variants' => null],
-            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'variants' => null],
+            $products->firstWhere('name', 'Moldura ancha')?->id => ['quantity' => 1, 'subtract_value' => 30000, 'variants' => json_encode($variants)],
+            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'subtract_value' => 8000, 'variants' => null],
+            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'subtract_value' => 2000, 'variants' => null],
         ]);
 
         $combo2 = Combo::create([
@@ -43,9 +43,9 @@ return new class extends Migration
         ]);
 
         $combo2->products()->attach([
-            $products->firstWhere('name', 'Clásico')?->id => ['quantity' => 1, 'variants' => json_encode($variants)],
-            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'variants' => null],
-            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'variants' => null],
+            $products->firstWhere('name', 'Clásico')?->id => ['quantity' => 1, 'subtract_value' => 28000, 'variants' => json_encode($variants)],
+            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'subtract_value' => 8000, 'variants' => null],
+            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'subtract_value' => 2000, 'variants' => null],
         ]);
 
         $combo3 = Combo::create([
@@ -56,9 +56,9 @@ return new class extends Migration
         ]);
 
         $combo3->products()->attach([
-            $products->firstWhere('name', 'Moldura fina')?->id => ['quantity' => 1, 'variants' => json_encode($variants)],
-            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'variants' => null],
-            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'variants' => null],
+            $products->firstWhere('name', 'Moldura fina')?->id => ['quantity' => 1, 'subtract_value' => 26000, 'variants' => json_encode($variants)],
+            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'subtract_value' => 8000, 'variants' => null],
+            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'subtract_value' => 2000, 'variants' => null],
         ]);
 
         $combo4 = Combo::create([
@@ -69,10 +69,10 @@ return new class extends Migration
         ]);
 
         $combo4->products()->attach([
-            $products->firstWhere('name', 'Moldura fina')?->id => ['quantity' => 1, 'variants' => json_encode($variants)],
-            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'variants' => null],
-            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'variants' => null],
-            $products->firstWhere('name', 'Taza')?->id => ['quantity' => 1, 'variants' => null],
+            $products->firstWhere('name', 'Moldura fina')?->id => ['quantity' => 1, 'subtract_value' => 26000, 'variants' => json_encode($variants)],
+            $products->firstWhere('name', 'Carpeta 2 fotos')?->id => ['quantity' => 1, 'subtract_value' => 8000, 'variants' => null],
+            $products->firstWhere('name', 'Medalla')?->id => ['quantity' => 1, 'subtract_value' => 2000, 'variants' => null],
+            $products->firstWhere('name', 'Taza')?->id => ['quantity' => 1, 'subtract_value' => 5000, 'variants' => null],
         ]);
     }
 

--- a/e2e/drafts.spec.ts
+++ b/e2e/drafts.spec.ts
@@ -46,7 +46,9 @@ test('draft: save, preload via "Ver", saving the order consumes it', async ({
     await stepTriggers(page).filter({ hasText: 'Productos' }).first().click();
     await addSimpleProduct(page, 'Taza', 'Taza de Guada');
     await stepTriggers(page).filter({ hasText: 'Pedido' }).first().click();
-    await expect(page.locator('#total_price')).toHaveValue('30000');
+    // The draft price was typed by hand with an empty cart: adding the taza
+    // recalculates the total from the cart (#96), so it becomes its list price
+    await expect(page.locator('#total_price')).toHaveValue('12000');
     await page.getByRole('button', { name: 'Guardar', exact: true }).click();
     await page.waitForURL('/orders');
 

--- a/lang/es/validation.php
+++ b/lang/es/validation.php
@@ -191,7 +191,7 @@ return [
         'products' => 'productos',
         'suggested_price' => 'precio',
         'subtract_value' => 'valor de resta',
-        'suggested_max_payments' => 'cantidad máxima de cuotas',
+        'default_payments' => 'cuotas por defecto',
         'max_payments' => 'cantidad máxima de cuotas',
         'payment_plan' => 'cuotas',
         'paid_on' => 'fecha de pago',

--- a/lang/es/validation.php
+++ b/lang/es/validation.php
@@ -190,6 +190,7 @@ return [
         'unit' => 'unidad',
         'products' => 'productos',
         'suggested_price' => 'precio',
+        'subtract_value' => 'valor de resta',
         'suggested_max_payments' => 'cantidad máxima de cuotas',
         'max_payments' => 'cantidad máxima de cuotas',
         'payment_plan' => 'cuotas',

--- a/resources/js/pages/combos/components/add-product.test.tsx
+++ b/resources/js/pages/combos/components/add-product.test.tsx
@@ -104,6 +104,7 @@ describe('AddProduct', () => {
         expect(addProduct).toHaveBeenCalledWith({
             id: 1,
             quantity: 1,
+            subtract_value: 0,
             variants: {
                 photo_types: ['grupo'],
                 orientations: ['vertical', 'horizontal'],

--- a/resources/js/pages/combos/components/combo-form.tsx
+++ b/resources/js/pages/combos/components/combo-form.tsx
@@ -25,6 +25,7 @@ export function ComboForm({ form, products, submitLabel }: ComboFormProps) {
         setAddProduct,
         openEditProductModal,
         updateQuantity,
+        updateSubtractValue,
         addSelectedProduct,
         closeMuralModal,
     } = form;
@@ -109,6 +110,7 @@ export function ComboForm({ form, products, submitLabel }: ComboFormProps) {
                         openAddProductModal={setAddProduct}
                         openEditProductModal={openEditProductModal}
                         updateQuantity={updateQuantity}
+                        updateSubtractValue={updateSubtractValue}
                     >
                         <InputError
                             message={errors.products}

--- a/resources/js/pages/combos/components/combo-form.tsx
+++ b/resources/js/pages/combos/components/combo-form.tsx
@@ -80,25 +80,23 @@ export function ComboForm({ form, products, submitLabel }: ComboFormProps) {
                     />
                 </div>
                 <div className="mt-6">
-                    <Label htmlFor="suggested_max_payments">
-                        Cantidad máxima de cuotas
-                    </Label>
+                    <Label htmlFor="default_payments">Cuotas por defecto</Label>
 
                     <Input
-                        id="suggested_max_payments"
+                        id="default_payments"
                         type="number"
-                        name="suggested_max_payments"
+                        name="default_payments"
                         min={0}
-                        value={data.suggested_max_payments}
+                        value={data.default_payments}
                         onChange={(e) =>
-                            setData('suggested_max_payments', e.target.value)
+                            setData('default_payments', e.target.value)
                         }
                         className="mt-1 block w-full"
                         placeholder="Cantidad en números enteros"
                     />
 
                     <InputError
-                        message={errors.suggested_max_payments}
+                        message={errors.default_payments}
                         className="mt-2"
                     />
                 </div>

--- a/resources/js/pages/combos/components/combo-product-item.tsx
+++ b/resources/js/pages/combos/components/combo-product-item.tsx
@@ -1,5 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
     Edit,
     Minus,
@@ -17,6 +19,7 @@ interface ComboProductItemProps {
     selected: SelectedProduct;
     product: Product;
     updateQuantity: (id: number, value: number) => void;
+    updateSubtractValue: (id: number, value: number) => void;
     openEditProductModal: (id: number) => void;
 }
 
@@ -24,11 +27,12 @@ export function ComboProductItem({
     selected,
     product,
     updateQuantity,
+    updateSubtractValue,
     openEditProductModal,
 }: ComboProductItemProps) {
     return (
-        <li className="flex items-center justify-between rounded-md border border-input bg-background px-4 py-2">
-            <div className="flex gap-1">
+        <li className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-input bg-background px-4 py-2">
+            <div className="flex min-w-0 flex-wrap gap-1">
                 {`${selected.quantity}x ${product.name}`}
                 {product.product_type_id === 1 && product.variants && (
                     <>
@@ -99,6 +103,25 @@ export function ComboProductItem({
                 >
                     <Trash className="h-4 w-4" />
                 </Button>
+            </div>
+
+            <div className="flex w-full flex-wrap items-center gap-2">
+                <Label
+                    htmlFor={`subtract_value_${selected.id}`}
+                    className="text-xs text-muted-foreground"
+                >
+                    Resta del combo si se lo quita
+                </Label>
+                <Input
+                    id={`subtract_value_${selected.id}`}
+                    type="number"
+                    min={0}
+                    className="h-8 w-32"
+                    value={selected.subtract_value}
+                    onChange={(e) =>
+                        updateSubtractValue(selected.id, Number(e.target.value))
+                    }
+                />
             </div>
         </li>
     );

--- a/resources/js/pages/combos/components/combo-products.tsx
+++ b/resources/js/pages/combos/components/combo-products.tsx
@@ -13,8 +13,10 @@ export function ComboProducts({
     openAddProductModal,
     openEditProductModal,
     updateQuantity,
+    updateSubtractValue,
 }: PropsWithChildren<{
     updateQuantity: (id: number, value: number) => void;
+    updateSubtractValue: (id: number, value: number) => void;
     openAddProductModal: (id: number) => void;
     openEditProductModal: (id: number) => void;
     products: Product[];
@@ -46,6 +48,7 @@ export function ComboProducts({
                             selected={selected}
                             product={product}
                             updateQuantity={updateQuantity}
+                            updateSubtractValue={updateSubtractValue}
                             openEditProductModal={openEditProductModal}
                         />
                     );

--- a/resources/js/pages/combos/components/combo-products.tsx
+++ b/resources/js/pages/combos/components/combo-products.tsx
@@ -31,9 +31,7 @@ export function ComboProducts({
 
     return (
         <div className="w-full">
-            <Label htmlFor="suggested_max_payments">
-                Productos del combo ({selectedProducts.length})
-            </Label>
+            <Label>Productos del combo ({selectedProducts.length})</Label>
 
             <ul className="my-2 gap-4">
                 {selectedProducts.map((selected) => {

--- a/resources/js/pages/combos/create.tsx
+++ b/resources/js/pages/combos/create.tsx
@@ -23,7 +23,7 @@ export default function CreateCombo({
         initialData: {
             name: '',
             suggested_price: '0',
-            suggested_max_payments: '0',
+            default_payments: '0',
             products: [],
         },
         onSubmit: (form) => form.post(route('combos.store')),

--- a/resources/js/pages/combos/edit.tsx
+++ b/resources/js/pages/combos/edit.tsx
@@ -28,7 +28,7 @@ export default function EditCombo({
         initialData: {
             name: combo.data.name,
             suggested_price: combo.data.suggested_price,
-            suggested_max_payments: combo.data.suggested_max_payments,
+            default_payments: combo.data.default_payments,
             products: combo.data.products,
         },
         onSubmit: (form) =>

--- a/resources/js/pages/combos/form.test.ts
+++ b/resources/js/pages/combos/form.test.ts
@@ -13,11 +13,15 @@ const variants = (
 
 describe('upsertSelectedProduct', () => {
     it('appends a product that is not selected yet', () => {
-        const result = upsertSelectedProduct([{ id: 1, quantity: 2 }], {
-            id: 5,
-            quantity: 1,
-            variants: variants(['vertical']),
-        });
+        const result = upsertSelectedProduct(
+            [{ id: 1, quantity: 2, subtract_value: 0 }],
+            {
+                id: 5,
+                quantity: 1,
+                subtract_value: 0,
+                variants: variants(['vertical']),
+            },
+        );
 
         expect(result).toHaveLength(2);
         expect(result[1].id).toBe(5);
@@ -25,8 +29,20 @@ describe('upsertSelectedProduct', () => {
 
     it('replaces the variants keeping the chosen quantity when editing', () => {
         const result = upsertSelectedProduct(
-            [{ id: 5, quantity: 3, variants: variants(['vertical']) }],
-            { id: 5, quantity: 1, variants: variants(['horizontal']) },
+            [
+                {
+                    id: 5,
+                    quantity: 3,
+                    subtract_value: 0,
+                    variants: variants(['vertical']),
+                },
+            ],
+            {
+                id: 5,
+                quantity: 1,
+                subtract_value: 0,
+                variants: variants(['horizontal']),
+            },
         );
 
         expect(result).toHaveLength(1);
@@ -34,15 +50,46 @@ describe('upsertSelectedProduct', () => {
         expect(result[0].variants?.orientations).toEqual(['horizontal']);
     });
 
+    it('keeps the subtract value when editing: the modal only edits variants', () => {
+        const result = upsertSelectedProduct(
+            [
+                {
+                    id: 5,
+                    quantity: 1,
+                    subtract_value: 2000,
+                    variants: variants(['vertical']),
+                },
+            ],
+            {
+                id: 5,
+                quantity: 1,
+                subtract_value: 0,
+                variants: variants(['horizontal']),
+            },
+        );
+
+        expect(result[0].subtract_value).toBe(2000);
+    });
+
     it('leaves the other selected products untouched', () => {
         const result = upsertSelectedProduct(
             [
-                { id: 1, quantity: 2 },
-                { id: 5, quantity: 1, variants: variants(['vertical']) },
+                { id: 1, quantity: 2, subtract_value: 500 },
+                {
+                    id: 5,
+                    quantity: 1,
+                    subtract_value: 0,
+                    variants: variants(['vertical']),
+                },
             ],
-            { id: 5, quantity: 1, variants: variants(['horizontal']) },
+            {
+                id: 5,
+                quantity: 1,
+                subtract_value: 0,
+                variants: variants(['horizontal']),
+            },
         );
 
-        expect(result[0]).toEqual({ id: 1, quantity: 2 });
+        expect(result[0]).toEqual({ id: 1, quantity: 2, subtract_value: 500 });
     });
 });

--- a/resources/js/pages/combos/form.ts
+++ b/resources/js/pages/combos/form.ts
@@ -7,12 +7,15 @@ export type FormData = Pick<Combo, 'name'> & {
 export type SelectedProduct = {
     id: number;
     quantity: number;
+    /** How much the combo price drops when this product is taken out */
+    subtract_value: number;
     variants?: Product['variants'];
 };
 
 /**
  * Adds a product to the combo or, when it is already selected, replaces
- * its variants keeping the chosen quantity (used by the edit button).
+ * its variants keeping the quantity and the subtract value (used by the
+ * edit button, whose modal only edits variants).
  */
 export const upsertSelectedProduct = (
     selected: SelectedProduct[],
@@ -26,7 +29,11 @@ export const upsertSelectedProduct = (
 
     return selected.map((product) =>
         product.id === incoming.id
-            ? { ...incoming, quantity: existing.quantity }
+            ? {
+                  ...incoming,
+                  quantity: existing.quantity,
+                  subtract_value: existing.subtract_value,
+              }
             : product,
     );
 };

--- a/resources/js/pages/combos/form.ts
+++ b/resources/js/pages/combos/form.ts
@@ -1,6 +1,6 @@
 export type FormData = Pick<Combo, 'name'> & {
     products: SelectedProduct[];
-    suggested_max_payments: string;
+    default_payments: string;
     suggested_price: string;
 };
 

--- a/resources/js/pages/combos/hooks/use-add-product.ts
+++ b/resources/js/pages/combos/hooks/use-add-product.ts
@@ -97,6 +97,8 @@ export function useAddProduct({
         const selectedProduct = {
             id: product.id,
             quantity: 1,
+            // Kept by upsertSelectedProduct when editing an existing product
+            subtract_value: 0,
             variants: {
                 photo_types: Array.from(photoTypes),
                 orientations: Array.from(orientations),

--- a/resources/js/pages/combos/hooks/use-combo-form.ts
+++ b/resources/js/pages/combos/hooks/use-combo-form.ts
@@ -48,6 +48,7 @@ export function useComboForm({
                 {
                     id: product.id,
                     quantity: 1,
+                    subtract_value: 0,
                 },
             ]);
         } else {
@@ -98,6 +99,17 @@ export function useComboForm({
         }
     };
 
+    const updateSubtractValue = (id: number, value: number) => {
+        setData(
+            'products',
+            data.products.map((product) =>
+                product.id === id
+                    ? { ...product, subtract_value: value }
+                    : product,
+            ),
+        );
+    };
+
     const addSelectedProduct = (product: SelectedProduct) => {
         setData('products', upsertSelectedProduct(data.products, product));
     };
@@ -118,6 +130,7 @@ export function useComboForm({
         submit,
         openEditProductModal,
         updateQuantity,
+        updateSubtractValue,
         addSelectedProduct,
         closeMuralModal,
     };

--- a/resources/js/pages/combos/index.tsx
+++ b/resources/js/pages/combos/index.tsx
@@ -91,7 +91,7 @@ export default function Combos({
                                     Precio
                                 </div>
                             </TableHead>
-                            <TableHead>Cuotas máximas</TableHead>
+                            <TableHead>Cuotas por defecto</TableHead>
                             <TableHead>Productos</TableHead>
                             <TableHead>Acciones</TableHead>
                         </TableRow>
@@ -108,9 +108,7 @@ export default function Combos({
                                 <TableCell>
                                     {formatPrice(combo.suggested_price)}
                                 </TableCell>
-                                <TableCell>
-                                    {combo.suggested_max_payments}
-                                </TableCell>
+                                <TableCell>{combo.default_payments}</TableCell>
                                 <TableCell>
                                     {`${combo.products.length} productos`}
                                 </TableCell>

--- a/resources/js/pages/orders/components/detail-group.tsx
+++ b/resources/js/pages/orders/components/detail-group.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@/components/ui/button';
+import { formatPrice } from '@/lib/utils';
+import { Trash } from 'lucide-react';
+import { DetailEntry } from '../grouping';
+import { ProductListItem } from './product-list-item';
+
+interface DetailGroupProps {
+    title: string;
+    /** Combo price; extras have none, they are priced item by item */
+    price?: number;
+    items: DetailEntry[];
+    products: Product[];
+    onEdit: (index: number) => void;
+    onRemove: (index: number) => void;
+    onRemoveGroup?: () => void;
+}
+
+export function DetailGroup({
+    title,
+    price,
+    items,
+    products,
+    onEdit,
+    onRemove,
+    onRemoveGroup,
+}: DetailGroupProps) {
+    if (items.length === 0) return null;
+
+    return (
+        <section className="my-4 rounded-md border border-input p-3">
+            <header className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="min-w-0 text-sm font-medium">
+                    {title}
+                    {price !== undefined && (
+                        <span className="ml-2 text-muted-foreground">
+                            {formatPrice(price)}
+                        </span>
+                    )}
+                </h3>
+
+                {onRemoveGroup && (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onRemoveGroup();
+                        }}
+                    >
+                        <Trash className="mr-1 h-4 w-4" />
+                        Quitar combo
+                    </Button>
+                )}
+            </header>
+
+            <ul>
+                {items.map(({ detail, index }) => {
+                    const product = products.find(
+                        (p) => p.id === detail.product_id,
+                    );
+
+                    // The product may have been deleted since the detail was
+                    // added or restored
+                    if (!product) return null;
+
+                    return (
+                        <ProductListItem
+                            key={`${detail.product_id}-${index}`}
+                            detail={detail}
+                            product={product}
+                            index={index}
+                            onEdit={onEdit}
+                            onRemove={onRemove}
+                        />
+                    );
+                })}
+            </ul>
+        </section>
+    );
+}

--- a/resources/js/pages/orders/components/order-step.tsx
+++ b/resources/js/pages/orders/components/order-step.tsx
@@ -14,6 +14,7 @@ import { Link } from '@inertiajs/react';
 import { format } from 'date-fns';
 import { AlertCircle } from 'lucide-react';
 import { OrderFormController } from '../hooks/use-create-order-form';
+import { PriceBreakdown } from './price-breakdown';
 
 export function OrderStep({ form }: { form: OrderFormController }) {
     const {
@@ -21,13 +22,16 @@ export function OrderStep({ form }: { form: OrderFormController }) {
         setData,
         errors,
         errorFlags,
-        counts,
+        breakdown,
+        recalculatePrice,
         processing,
         toStep,
         submit,
         handleSaveAsDraft,
         handleSaveAndContinue,
     } = form;
+
+    const adjustedByHand = Number(data.total_price) !== breakdown.total;
 
     return (
         <AccordionItem value="order">
@@ -42,9 +46,6 @@ export function OrderStep({ form }: { form: OrderFormController }) {
             <AccordionContent className="px-1">
                 <div className="mt-3">
                     <Label>Precio final</Label>
-                    <InputHint
-                        message={`Calculado a base de (${Object.keys(counts.combos).length}) combo y (${counts.undefinedCount}) productos`}
-                    />
                     <Input
                         type="number"
                         id="total_price"
@@ -54,6 +55,12 @@ export function OrderStep({ form }: { form: OrderFormController }) {
                         className="mt-1 block w-full"
                     />
                     <InputError message={errors.total_price} />
+
+                    <PriceBreakdown
+                        breakdown={breakdown}
+                        adjustedByHand={adjustedByHand}
+                        onRecalculate={recalculatePrice}
+                    />
                 </div>
 
                 <div className="mt-3">

--- a/resources/js/pages/orders/components/price-breakdown.tsx
+++ b/resources/js/pages/orders/components/price-breakdown.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/components/ui/button';
+import { formatPrice } from '@/lib/utils';
+import { PriceBreakdown as Breakdown } from '../pricing';
+
+interface PriceBreakdownProps {
+    breakdown: Breakdown;
+    /** The seller typed a price other than the calculated one */
+    adjustedByHand: boolean;
+    onRecalculate: () => void;
+}
+
+export function PriceBreakdown({
+    breakdown,
+    adjustedByHand,
+    onRecalculate,
+}: PriceBreakdownProps) {
+    if (breakdown.lines.length === 0) {
+        return (
+            <p className="mt-2 text-xs text-muted-foreground">
+                Agregá un combo o un producto para calcular el precio.
+            </p>
+        );
+    }
+
+    return (
+        <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+            <ul>
+                {breakdown.lines.map((line, index) => (
+                    <li
+                        key={`${line.label}-${index}`}
+                        className="flex flex-wrap justify-between gap-2"
+                    >
+                        <span className="min-w-0">{line.label}</span>
+                        <span>
+                            {line.amount < 0 ? '−' : '+'}{' '}
+                            {formatPrice(Math.abs(line.amount))}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+
+            <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-1">
+                <span>Precio calculado</span>
+                <span className="font-medium">
+                    {formatPrice(breakdown.total)}
+                </span>
+            </div>
+
+            {adjustedByHand && (
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-destructive">
+                        Precio ajustado a mano
+                    </span>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onRecalculate();
+                        }}
+                    >
+                        Recalcular
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/orders/components/product-list-item.tsx
+++ b/resources/js/pages/orders/components/product-list-item.tsx
@@ -14,7 +14,6 @@ import { OrderFormData } from '../form-state';
 interface ProductListItemProps {
     detail: OrderFormData['order_details'][number];
     product: Product;
-    combo?: Combo;
     index: number;
     onEdit: (index: number) => void;
     onRemove: (index: number) => void;
@@ -23,18 +22,14 @@ interface ProductListItemProps {
 export function ProductListItem({
     detail,
     product,
-    combo,
     index,
     onEdit,
     onRemove,
 }: ProductListItemProps) {
     return (
-        <li className="flex items-center justify-between rounded-md border border-input bg-background px-4 py-2">
-            <div className="flex flex-col gap-2">
-                <span>
-                    {product.name}
-                    {combo ? ` (combo ${combo.name})` : ''}
-                </span>
+        <li className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-input bg-background px-4 py-2">
+            <div className="flex min-w-0 flex-col gap-2">
+                <span>{product.name}</span>
                 {product.product_type_id === 1 ? (
                     <div className="flex items-center">
                         <Badge variant="outline" className="gap-1 rounded-lg">

--- a/resources/js/pages/orders/components/products-step.tsx
+++ b/resources/js/pages/orders/components/products-step.tsx
@@ -9,8 +9,9 @@ import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import { AlertCircle, PlusIcon } from 'lucide-react';
 import { ComboWithProducts } from '../form';
+import { groupDetails } from '../grouping';
 import { OrderFormController } from '../hooks/use-create-order-form';
-import { ProductListItem } from './product-list-item';
+import { DetailGroup } from './detail-group';
 
 interface ProductsStepProps {
     form: OrderFormController;
@@ -32,7 +33,10 @@ export function ProductsStep({ form, products, combos }: ProductsStepProps) {
         handleAddProduct,
         handleEditProduct,
         handleRemoveProduct,
+        handleRemoveCombo,
     } = form;
+
+    const { comboGroups, extras } = groupDetails(data.order_details, combos);
 
     return (
         <AccordionItem value="products">
@@ -80,32 +84,26 @@ export function ProductsStep({ form, products, combos }: ProductsStepProps) {
                     </Button>
                 </Combobox>
 
-                <ul className="my-2 gap-4">
-                    {data.order_details.map((selected, index) => {
-                        const product = products.find(
-                            (p) => p.id === selected.product_id,
-                        );
-                        const combo = combos.find(
-                            (c) => c.id === selected.combo_id,
-                        );
+                {comboGroups.map(({ combo, items }) => (
+                    <DetailGroup
+                        key={combo.id}
+                        title={combo.name}
+                        price={combo.suggested_price}
+                        items={items}
+                        products={products}
+                        onEdit={handleEditProduct}
+                        onRemove={handleRemoveProduct}
+                        onRemoveGroup={() => handleRemoveCombo(combo.id)}
+                    />
+                ))}
 
-                        // The product may have been deleted since the detail
-                        // was added or restored
-                        if (!product) return null;
-
-                        return (
-                            <ProductListItem
-                                key={`${product.id}-${combo ? combo.id : ''}-${index}`}
-                                detail={selected}
-                                product={product}
-                                combo={combo}
-                                index={index}
-                                onEdit={handleEditProduct}
-                                onRemove={handleRemoveProduct}
-                            />
-                        );
-                    })}
-                </ul>
+                <DetailGroup
+                    title="Otros productos"
+                    items={extras}
+                    products={products}
+                    onEdit={handleEditProduct}
+                    onRemove={handleRemoveProduct}
+                />
 
                 <InputError message={errors.order_details} />
 

--- a/resources/js/pages/orders/components/products-step.tsx
+++ b/resources/js/pages/orders/components/products-step.tsx
@@ -8,13 +8,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import { AlertCircle, PlusIcon } from 'lucide-react';
+import { ComboWithProducts } from '../form';
 import { OrderFormController } from '../hooks/use-create-order-form';
 import { ProductListItem } from './product-list-item';
 
 interface ProductsStepProps {
     form: OrderFormController;
     products: Product[];
-    combos: Array<Combo & { products: Product[] }>;
+    combos: ComboWithProducts[];
 }
 
 export function ProductsStep({ form, products, combos }: ProductsStepProps) {

--- a/resources/js/pages/orders/create.tsx
+++ b/resources/js/pages/orders/create.tsx
@@ -7,6 +7,7 @@ import { ClientStep } from './components/client-step';
 import { OrderStep } from './components/order-step';
 import { ProductsStep } from './components/products-step';
 import { SchoolStep } from './components/school-step';
+import { ComboWithProducts } from './form';
 import { DraftProp } from './form-state';
 import { SchoolLevel, useCreateOrderForm } from './hooks/use-create-order-form';
 
@@ -29,7 +30,7 @@ export default function CreateOrder({
     draft,
 }: PageProps<{
     schoolLevels: SchoolLevel[];
-    combos: Array<Combo & { products: Product[] }>;
+    combos: ComboWithProducts[];
     schools: Array<School & { classrooms: Classroom[] }>;
     products: Product[];
     draft?: DraftProp | null;

--- a/resources/js/pages/orders/form-state.test.ts
+++ b/resources/js/pages/orders/form-state.test.ts
@@ -1,8 +1,10 @@
 import { format } from 'date-fns';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { ComboProduct, ComboWithProducts } from './form';
 import {
     DraftProp,
     emptyForm,
+    expandComboQuantities,
     removeDetailAt,
     replaceDetailAt,
     resetForNextClient,
@@ -175,5 +177,48 @@ describe('order details editing', () => {
         replaceDetailAt(original, 0, []);
 
         expect(original).toHaveLength(3);
+    });
+});
+
+describe('expandComboQuantities', () => {
+    const inCombo = (id: number, quantity: number) =>
+        ({
+            id,
+            name: `Producto ${id}`,
+            pivot: { quantity, subtract_value: 0 },
+        }) as ComboProduct;
+
+    const combo = {
+        id: 1,
+        name: 'Combo con dos fotos',
+        products: [inCombo(5, 2), inCombo(6, 1)],
+    } as ComboWithProducts;
+
+    it('replicates a combo product carrying several units', () => {
+        const details = [
+            { product_id: 5, combo_id: 1, note: 'Foto de Luca' },
+            { product_id: 6, combo_id: 1, note: 'Mural de Luca' },
+        ];
+
+        expect(expandComboQuantities(details, [combo])).toEqual([
+            details[0],
+            details[0],
+            details[1],
+        ]);
+    });
+
+    it('leaves standalone products alone: they are added one at a time', () => {
+        const details = [{ product_id: 5, note: 'Foto suelta' }];
+
+        expect(expandComboQuantities(details, [combo])).toEqual(details);
+    });
+
+    it('adds a single unit when the combo or the product is unknown', () => {
+        const details = [
+            { product_id: 5, combo_id: 99, note: '' },
+            { product_id: 99, combo_id: 1, note: '' },
+        ];
+
+        expect(expandComboQuantities(details, [combo])).toEqual(details);
     });
 });

--- a/resources/js/pages/orders/form-state.ts
+++ b/resources/js/pages/orders/form-state.ts
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { ProductOrder } from './form';
+import { ComboWithProducts, ProductOrder } from './form';
 
 export type DraftProp = {
     id: number;
@@ -70,6 +70,26 @@ export const removeDetailAt = (
     details: ProductOrder[],
     index: number,
 ): ProductOrder[] => details.filter((_, i) => i !== index);
+
+/**
+ * A combo may carry several units of the same product (`pivot.quantity`): each
+ * unit is its own detail. They are configured once — two identical products of
+ * the same combo share variant and note — and replicated here.
+ */
+export const expandComboQuantities = (
+    details: ProductOrder[],
+    combos: ComboWithProducts[],
+): ProductOrder[] =>
+    details.flatMap((detail) => {
+        const quantity = combos
+            .find((combo) => combo.id === detail.combo_id)
+            ?.products.find((product) => product.id === detail.product_id)
+            ?.pivot.quantity;
+
+        return Array.from({ length: Math.max(quantity ?? 1, 1) }, () => ({
+            ...detail,
+        }));
+    });
 
 export const replaceDetailAt = (
     details: ProductOrder[],

--- a/resources/js/pages/orders/form.ts
+++ b/resources/js/pages/orders/form.ts
@@ -10,6 +10,19 @@ export type ProductOrder = {
     note: string;
 };
 
+export type ComboProductPivot = {
+    quantity: number;
+    /** How much the combo price drops when this product is taken out */
+    subtract_value: number;
+    /** The combo may restrict the variants of the product; JSON as sent */
+    variants?: Product['variants'] | string | null;
+};
+
+export type ComboProduct = Product & { pivot: ComboProductPivot };
+
+/** A combo as the order wizard receives it: products carry their pivot */
+export type ComboWithProducts = Combo & { products: ComboProduct[] };
+
 export type SelectableProduct = Product & {
     combo_id?: number;
     pivot?: { variants: Product['variants'] };

--- a/resources/js/pages/orders/grouping.test.ts
+++ b/resources/js/pages/orders/grouping.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { ComboWithProducts, ProductOrder } from './form';
+import { groupDetails } from './grouping';
+
+const combo = { id: 1, name: 'Combo 1 (M.A)' } as ComboWithProducts;
+const otherCombo = { id: 2, name: 'Combo 2 (CLA)' } as ComboWithProducts;
+const combos = [combo, otherCombo];
+
+const detail = (productId: number, comboId?: number): ProductOrder => ({
+    product_id: productId,
+    combo_id: comboId,
+    note: '',
+});
+
+describe('groupDetails', () => {
+    it('groups the details under their combo and keeps the rest apart', () => {
+        const details = [detail(1, 1), detail(2), detail(3, 1)];
+
+        const { comboGroups, extras } = groupDetails(details, combos);
+
+        expect(comboGroups).toHaveLength(1);
+        expect(comboGroups[0].combo.name).toBe('Combo 1 (M.A)');
+        expect(comboGroups[0].items.map((item) => item.detail)).toEqual([
+            details[0],
+            details[2],
+        ]);
+        expect(extras.map((item) => item.detail)).toEqual([details[1]]);
+    });
+
+    it('keeps the index of each detail so edit and remove still address it', () => {
+        const details = [detail(1, 1), detail(2), detail(3, 1)];
+
+        const { comboGroups, extras } = groupDetails(details, combos);
+
+        expect(comboGroups[0].items.map((item) => item.index)).toEqual([0, 2]);
+        expect(extras.map((item) => item.index)).toEqual([1]);
+    });
+
+    it('lists the combos in the order they were added', () => {
+        const details = [detail(1, 2), detail(2, 1)];
+
+        const { comboGroups } = groupDetails(details, combos);
+
+        expect(comboGroups.map((group) => group.combo.id)).toEqual([2, 1]);
+    });
+
+    it('shows the products of a combo that no longer exists among the extras', () => {
+        const details = [detail(1, 99)];
+
+        const { comboGroups, extras } = groupDetails(details, combos);
+
+        expect(comboGroups).toEqual([]);
+        expect(extras.map((item) => item.detail)).toEqual(details);
+    });
+
+    it('returns empty sections for an empty cart', () => {
+        expect(groupDetails([], combos)).toEqual({
+            comboGroups: [],
+            extras: [],
+        });
+    });
+});

--- a/resources/js/pages/orders/grouping.ts
+++ b/resources/js/pages/orders/grouping.ts
@@ -1,0 +1,49 @@
+import { ComboWithProducts, ProductOrder } from './form';
+
+/** A detail plus its position in `order_details`: edit and remove act by index */
+export type DetailEntry = { detail: ProductOrder; index: number };
+
+export type ComboGroup = { combo: ComboWithProducts; items: DetailEntry[] };
+
+export type GroupedDetails = {
+    comboGroups: ComboGroup[];
+    extras: DetailEntry[];
+};
+
+/**
+ * Splits the cart into one section per combo — in the order the combos were
+ * added — plus the products added outside any combo. A detail naming a combo
+ * that no longer exists is shown among the extras, which is also how it gets
+ * priced.
+ */
+export const groupDetails = (
+    details: ProductOrder[],
+    combos: ComboWithProducts[],
+): GroupedDetails => {
+    const comboGroups: ComboGroup[] = [];
+    const extras: DetailEntry[] = [];
+
+    details.forEach((detail, index) => {
+        const combo = combos.find(
+            (candidate) => candidate.id === detail.combo_id,
+        );
+
+        if (!combo) {
+            extras.push({ detail, index });
+
+            return;
+        }
+
+        const group = comboGroups.find((g) => g.combo.id === combo.id);
+
+        if (group) {
+            group.items.push({ detail, index });
+
+            return;
+        }
+
+        comboGroups.push({ combo, items: [{ detail, index }] });
+    });
+
+    return { comboGroups, extras };
+};

--- a/resources/js/pages/orders/hooks/use-create-order-form.ts
+++ b/resources/js/pages/orders/hooks/use-create-order-form.ts
@@ -2,6 +2,7 @@ import { useForm } from '@inertiajs/react';
 import axios from 'axios';
 import { FormEvent, FormEventHandler, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { ComboWithProducts } from '../form';
 import {
     DraftProp,
     OrderFormData,
@@ -16,7 +17,7 @@ export type AccordionValue =
 
 interface UseCreateOrderFormParams {
     products: Product[];
-    combos: Array<Combo & { products: Product[] }>;
+    combos: ComboWithProducts[];
     schools: Array<School & { classrooms: Classroom[] }>;
     draft?: DraftProp | null;
 }
@@ -70,22 +71,6 @@ export function useCreateOrderForm({
 
     const filteredSchools = schools.filter(
         (school) => levelFilter === 'Todos' || school.level === levelFilter,
-    );
-
-    const counts = data.order_details.reduce<{
-        combos: Record<number, number>;
-        undefinedCount: number;
-    }>(
-        (acc, order) => {
-            if (order.combo_id !== undefined) {
-                acc.combos[order.combo_id] =
-                    (acc.combos[order.combo_id] || 0) + 1;
-            } else {
-                acc.undefinedCount++;
-            }
-            return acc;
-        },
-        { combos: {}, undefinedCount: 0 },
     );
 
     const errorFlags: Record<Exclude<AccordionValue, undefined>, boolean> = {
@@ -180,7 +165,6 @@ export function useCreateOrderForm({
         selectedSchoolData,
         selectedClassroom,
         filteredSchools,
-        counts,
         errorFlags,
         toStep,
         submit,

--- a/resources/js/pages/orders/hooks/use-edit-order.ts
+++ b/resources/js/pages/orders/hooks/use-edit-order.ts
@@ -5,6 +5,8 @@ import { toast } from 'sonner';
 export type EditAccordionValue = 'products' | 'client' | 'order' | undefined;
 
 export type OrderDetailForm = {
+    /** The order_details row: an order may repeat a product */
+    id: number;
     product_id: number;
     note: string | null;
     variant: Record<string, string>;
@@ -14,8 +16,10 @@ export function useEditOrder(order: Order) {
     const [accordionValue, setAccordionValue] =
         useState<EditAccordionValue>('client');
 
-    // Transform order data for form - preserve existing note and variant from pivot
+    // Transform order data for form - preserve existing note and variant from
+    // pivot, addressed by the detail id so repeated products stay apart
     const orderDetails = order.products.map((product) => ({
+        id: product.order_detail_id,
         product_id: product.id,
         note: product.note || null,
         variant: product.variant || {},

--- a/resources/js/pages/orders/hooks/use-order-products.ts
+++ b/resources/js/pages/orders/hooks/use-order-products.ts
@@ -2,7 +2,12 @@ import { InertiaFormProps } from '@inertiajs/react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { ComboWithProducts, ProductOrder } from '../form';
-import { OrderFormData, removeDetailAt, replaceDetailAt } from '../form-state';
+import {
+    expandComboQuantities,
+    OrderFormData,
+    removeDetailAt,
+    replaceDetailAt,
+} from '../form-state';
 import { computeTotal, priceBreakdown } from '../pricing';
 
 interface UseOrderProductsParams {
@@ -86,7 +91,11 @@ export function useOrderProducts({
             return;
         }
 
-        applyDetails([...data.order_details, ...productsOrder]);
+        // Editing replaces one detail: only a fresh add multiplies the units
+        applyDetails([
+            ...data.order_details,
+            ...expandComboQuantities(productsOrder, combos),
+        ]);
     };
 
     const handleEditProduct = (index: number) => {

--- a/resources/js/pages/orders/hooks/use-order-products.ts
+++ b/resources/js/pages/orders/hooks/use-order-products.ts
@@ -112,6 +112,13 @@ export function useOrderProducts({
         toast.info('Producto quitado. Se recalculó el precio.');
     };
 
+    const handleRemoveCombo = (comboId: number) => {
+        applyDetails(
+            data.order_details.filter((detail) => detail.combo_id !== comboId),
+        );
+        toast.info('Combo quitado. Se recalculó el precio.');
+    };
+
     const recalculatePrice = () => {
         setData('total_price', String(breakdown.total));
     };
@@ -127,6 +134,7 @@ export function useOrderProducts({
         setProductsOrder,
         handleEditProduct,
         handleRemoveProduct,
+        handleRemoveCombo,
         recalculatePrice,
     };
 }

--- a/resources/js/pages/orders/hooks/use-order-products.ts
+++ b/resources/js/pages/orders/hooks/use-order-products.ts
@@ -1,14 +1,15 @@
 import { InertiaFormProps } from '@inertiajs/react';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { ProductOrder } from '../form';
+import { ComboWithProducts, ProductOrder } from '../form';
 import { OrderFormData, removeDetailAt, replaceDetailAt } from '../form-state';
+import { computeTotal, priceBreakdown } from '../pricing';
 
 interface UseOrderProductsParams {
     data: OrderFormData;
     setData: InertiaFormProps<OrderFormData>['setData'];
     products: Product[];
-    combos: Array<Combo & { products: Product[] }>;
+    combos: ComboWithProducts[];
 }
 
 /**
@@ -28,35 +29,53 @@ export function useOrderProducts({
 
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
+    const breakdown = priceBreakdown(data.order_details, combos, products);
+
+    const comboOf = (details: ProductOrder[]) =>
+        details.find((detail) => detail.combo_id !== undefined)?.combo_id;
+
+    /**
+     * The single door to the cart: the total is always recomputed from the
+     * details, never accumulated over the previous one. A price typed by hand
+     * therefore survives only until the cart changes again.
+     */
+    const applyDetails = (details: ProductOrder[]) => {
+        const seedsPayments =
+            comboOf(data.order_details) === undefined &&
+            comboOf(details) !== undefined;
+
+        const firstCombo = combos.find(
+            (combo) => combo.id === comboOf(details),
+        );
+
+        setData((current) => ({
+            ...current,
+            order_details: details,
+            total_price: String(computeTotal(details, combos, products)),
+            payment_plan:
+                seedsPayments && firstCombo
+                    ? String(firstCombo.default_payments)
+                    : current.payment_plan,
+        }));
+    };
+
     const handleAddProduct = (id: number) => {
         setOpenAddModal([products.find((p) => p.id === id)!]);
     };
 
+    /**
+     * The combo only enters the cart once its products are configured, so
+     * cancelling the modal leaves the price untouched.
+     */
     const handleAddCombo = (id: number) => {
         const combo = combos.find((p) => p.id === id)!;
-
-        setData(
-            'total_price',
-            String(Number(data.total_price) + Number(combo.suggested_price)),
-        );
-
-        // The first combo of the order seeds the installments; a second one
-        // must not overwrite the number the seller already agreed on
-        const hasCombo = data.order_details.some(
-            (detail) => detail.combo_id !== undefined,
-        );
-
-        if (!hasCombo) {
-            setData('payment_plan', String(combo.default_payments));
-        }
 
         setOpenAddModal(combo.products.map((p) => ({ ...p, combo_id: id })));
     };
 
     const setProductsOrder = (productsOrder: ProductOrder[]) => {
         if (editingIndex !== null) {
-            setData(
-                'order_details',
+            applyDetails(
                 replaceDetailAt(
                     data.order_details,
                     editingIndex,
@@ -67,7 +86,7 @@ export function useOrderProducts({
             return;
         }
 
-        setData('order_details', [...data.order_details, ...productsOrder]);
+        applyDetails([...data.order_details, ...productsOrder]);
     };
 
     const handleEditProduct = (index: number) => {
@@ -89,8 +108,12 @@ export function useOrderProducts({
     };
 
     const handleRemoveProduct = (index: number) => {
-        setData('order_details', removeDetailAt(data.order_details, index));
-        toast.info('Producto quitado. Recordá revisar el precio final.');
+        applyDetails(removeDetailAt(data.order_details, index));
+        toast.info('Producto quitado. Se recalculó el precio.');
+    };
+
+    const recalculatePrice = () => {
+        setData('total_price', String(breakdown.total));
     };
 
     return {
@@ -98,10 +121,12 @@ export function useOrderProducts({
         setOpenAddModal,
         editingIndex,
         setEditingIndex,
+        breakdown,
         handleAddProduct,
         handleAddCombo,
         setProductsOrder,
         handleEditProduct,
         handleRemoveProduct,
+        recalculatePrice,
     };
 }

--- a/resources/js/pages/orders/hooks/use-order-products.ts
+++ b/resources/js/pages/orders/hooks/use-order-products.ts
@@ -39,6 +39,17 @@ export function useOrderProducts({
             'total_price',
             String(Number(data.total_price) + Number(combo.suggested_price)),
         );
+
+        // The first combo of the order seeds the installments; a second one
+        // must not overwrite the number the seller already agreed on
+        const hasCombo = data.order_details.some(
+            (detail) => detail.combo_id !== undefined,
+        );
+
+        if (!hasCombo) {
+            setData('payment_plan', String(combo.default_payments));
+        }
+
         setOpenAddModal(combo.products.map((p) => ({ ...p, combo_id: id })));
     };
 

--- a/resources/js/pages/orders/pricing.test.ts
+++ b/resources/js/pages/orders/pricing.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { ComboProduct, ComboWithProducts, ProductOrder } from './form';
+import { computeTotal, priceBreakdown } from './pricing';
+
+const product = (id: number, name: string, unitPrice: number): Product =>
+    ({ id, name, unit_price: unitPrice }) as Product;
+
+const comboProduct = (
+    id: number,
+    name: string,
+    subtractValue: number,
+): ComboProduct =>
+    ({
+        ...product(id, name, 0),
+        pivot: { quantity: 1, subtract_value: subtractValue },
+    }) as ComboProduct;
+
+const mural = product(1, 'Moldura ancha', 48000);
+const carpeta = product(2, 'Carpeta 2 fotos', 18000);
+const medalla = product(3, 'Medalla', 6000);
+const taza = product(4, 'Taza', 12000);
+
+const products = [mural, carpeta, medalla, taza];
+
+const combo: ComboWithProducts = {
+    id: 1,
+    name: 'Combo 1 (M.A)',
+    suggested_price: 60000,
+    default_payments: 4,
+    products: [
+        comboProduct(1, 'Moldura ancha', 30000),
+        comboProduct(2, 'Carpeta 2 fotos', 8000),
+        comboProduct(3, 'Medalla', 2000),
+    ],
+};
+
+const otherCombo: ComboWithProducts = {
+    id: 2,
+    name: 'Combo 2 (CLA)',
+    suggested_price: 56000,
+    default_payments: 4,
+    products: [comboProduct(1, 'Moldura ancha', 28000)],
+};
+
+const combos = [combo, otherCombo];
+
+const fullCombo = (comboId: number, productIds: number[]): ProductOrder[] =>
+    productIds.map((id) => ({ product_id: id, combo_id: comboId, note: '' }));
+
+const extra = (productId: number): ProductOrder => ({
+    product_id: productId,
+    note: '',
+});
+
+describe('computeTotal', () => {
+    it('is zero for an empty cart', () => {
+        expect(computeTotal([], combos, products)).toBe(0);
+    });
+
+    it('charges the combo price, not the sum of its products', () => {
+        const details = fullCombo(1, [1, 2, 3]);
+
+        expect(computeTotal(details, combos, products)).toBe(60000);
+    });
+
+    it('adds the extras at list price on top of the combo', () => {
+        const details = [...fullCombo(1, [1, 2, 3]), extra(4)];
+
+        expect(computeTotal(details, combos, products)).toBe(72000);
+    });
+
+    it('subtracts the configured value when a combo product is taken out', () => {
+        const details = fullCombo(1, [1, 2]);
+
+        // 60000 − 2000 (medalla), not − 6000 (its list price)
+        expect(computeTotal(details, combos, products)).toBe(58000);
+    });
+
+    it('drops the combo entirely once all of its products are taken out', () => {
+        expect(computeTotal(fullCombo(1, []), combos, products)).toBe(0);
+    });
+
+    it('does not accumulate when the combo is switched: only the cart counts', () => {
+        const first = fullCombo(1, [1, 2, 3]);
+        const switched = fullCombo(2, [1]);
+
+        expect(computeTotal(first, combos, products)).toBe(60000);
+        // Regression (#100): the old total was added to the new combo price
+        expect(computeTotal(switched, combos, products)).toBe(56000);
+    });
+
+    it('sums both combos when both are in the cart', () => {
+        const details = [...fullCombo(1, [1, 2, 3]), ...fullCombo(2, [1])];
+
+        expect(computeTotal(details, combos, products)).toBe(116000);
+    });
+
+    it('prices the products of an unknown combo as standalone extras', () => {
+        const details: ProductOrder[] = [
+            { product_id: 4, combo_id: 99, note: '' },
+        ];
+
+        expect(computeTotal(details, combos, products)).toBe(12000);
+    });
+
+    it('ignores details whose product no longer exists', () => {
+        expect(computeTotal([extra(99)], combos, products)).toBe(0);
+    });
+
+    it('never goes below zero when the subtractions exceed the combo price', () => {
+        const cheapCombo: ComboWithProducts = {
+            ...combo,
+            suggested_price: 1000,
+        };
+
+        const details = fullCombo(1, [1]);
+
+        expect(computeTotal(details, [cheapCombo], products)).toBe(0);
+    });
+});
+
+describe('priceBreakdown', () => {
+    it('explains the price line by line', () => {
+        const details = [...fullCombo(1, [1, 2]), extra(4)];
+
+        expect(priceBreakdown(details, combos, products)).toEqual({
+            lines: [
+                { label: 'Combo 1 (M.A)', amount: 60000 },
+                { label: 'Sin Medalla', amount: -2000 },
+                { label: 'Taza', amount: 12000 },
+            ],
+            total: 70000,
+        });
+    });
+
+    it('omits a product taken out with no subtract value configured', () => {
+        const free: ComboWithProducts = {
+            ...combo,
+            products: [
+                comboProduct(1, 'Moldura ancha', 30000),
+                comboProduct(3, 'Medalla', 0),
+            ],
+        };
+
+        const { lines } = priceBreakdown(fullCombo(1, [1]), [free], products);
+
+        expect(lines).toEqual([{ label: 'Combo 1 (M.A)', amount: 60000 }]);
+    });
+});

--- a/resources/js/pages/orders/pricing.ts
+++ b/resources/js/pages/orders/pricing.ts
@@ -1,0 +1,95 @@
+import { ComboWithProducts, ProductOrder } from './form';
+
+export type PriceLine = {
+    label: string;
+    /** Signed: combos and extras add, subtractions take away */
+    amount: number;
+};
+
+export type PriceBreakdown = {
+    lines: PriceLine[];
+    total: number;
+};
+
+const detailsOfCombo = (details: ProductOrder[], comboId: number) =>
+    details.filter((detail) => detail.combo_id === comboId);
+
+/**
+ * Combos present in the cart, in the order they were added. A combo is in the
+ * cart while at least one of its products is: taking every product out of a
+ * combo removes the combo, and with it its price.
+ */
+const combosInCart = (details: ProductOrder[]) => [
+    ...new Set(
+        details
+            .map((detail) => detail.combo_id)
+            .filter((comboId): comboId is number => comboId !== undefined),
+    ),
+];
+
+/**
+ * The order price is the price of each combo — minus the subtract value of the
+ * products taken out of it — plus the list price of the products added outside
+ * any combo. Never accumulates over a previous total: it is a function of the
+ * cart alone, so adding a second combo cannot double-count the first.
+ */
+export const priceBreakdown = (
+    details: ProductOrder[],
+    combos: ComboWithProducts[],
+    products: Product[],
+): PriceBreakdown => {
+    const lines: PriceLine[] = [];
+    const extras: ProductOrder[] = details.filter(
+        (detail) => detail.combo_id === undefined,
+    );
+
+    combosInCart(details).forEach((comboId) => {
+        const combo = combos.find((candidate) => candidate.id === comboId);
+
+        // A combo deleted from the catalog (a restored draft may still name
+        // it) prices its products as if they had been added on their own
+        if (!combo) {
+            extras.push(...detailsOfCombo(details, comboId));
+
+            return;
+        }
+
+        lines.push({ label: combo.name, amount: combo.suggested_price });
+
+        const kept = detailsOfCombo(details, comboId).map(
+            (detail) => detail.product_id,
+        );
+
+        combo.products
+            .filter((product) => !kept.includes(product.id))
+            .filter((product) => product.pivot.subtract_value > 0)
+            .forEach((product) => {
+                lines.push({
+                    label: `Sin ${product.name}`,
+                    amount: -product.pivot.subtract_value,
+                });
+            });
+    });
+
+    extras.forEach((detail) => {
+        const product = products.find(
+            (candidate) => candidate.id === detail.product_id,
+        );
+
+        if (!product) return;
+
+        lines.push({ label: product.name, amount: product.unit_price });
+    });
+
+    const total = lines.reduce((sum, line) => sum + line.amount, 0);
+
+    // Subtractions bigger than the combo price would leave the seller with a
+    // negative total to correct by hand
+    return { lines, total: Math.max(total, 0) };
+};
+
+export const computeTotal = (
+    details: ProductOrder[],
+    combos: ComboWithProducts[],
+    products: Product[],
+): number => priceBreakdown(details, combos, products).total;

--- a/resources/js/pages/orders/tests/use-create-order-form.test.tsx
+++ b/resources/js/pages/orders/tests/use-create-order-form.test.tsx
@@ -61,7 +61,7 @@ const combos = [
         id: 2,
         name: 'Combo escolar',
         suggested_price: 5000,
-        suggested_max_payments: 3,
+        default_payments: 3,
         products: [taza, mural],
     } as Combo & { products: Product[] },
 ];

--- a/resources/js/pages/orders/tests/use-create-order-form.test.tsx
+++ b/resources/js/pages/orders/tests/use-create-order-form.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { FormEvent } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComboProduct, ComboWithProducts } from '../form';
 import { DraftProp, OrderFormData } from '../form-state';
 import { useCreateOrderForm } from '../hooks/use-create-order-form';
 
@@ -20,11 +21,16 @@ vi.mock('@inertiajs/react', async () => {
         return {
             data,
             setData: (
-                keyOrData: keyof OrderFormData | OrderFormData,
+                keyOrData:
+                    | keyof OrderFormData
+                    | OrderFormData
+                    | ((previous: OrderFormData) => OrderFormData),
                 value?: unknown,
             ) => {
                 if (typeof keyOrData === 'string') {
                     setData((prev) => ({ ...prev, [keyOrData]: value }));
+                } else if (typeof keyOrData === 'function') {
+                    setData(keyOrData);
                 } else {
                     setData(keyOrData);
                 }
@@ -52,18 +58,24 @@ const toast = vi.hoisted(() => ({
 
 vi.mock('sonner', () => ({ toast }));
 
-const taza = { id: 5, name: 'Taza' } as Product;
-const mural = { id: 6, name: 'Mural' } as Product;
+const taza = { id: 5, name: 'Taza', unit_price: 12000 } as Product;
+const mural = { id: 6, name: 'Mural', unit_price: 40000 } as Product;
 const products = [taza, mural];
 
-const combos = [
+const inCombo = (product: Product, subtractValue: number) =>
+    ({
+        ...product,
+        pivot: { quantity: 1, subtract_value: subtractValue },
+    }) as ComboProduct;
+
+const combos: ComboWithProducts[] = [
     {
         id: 2,
         name: 'Combo escolar',
         suggested_price: 5000,
         default_payments: 3,
-        products: [taza, mural],
-    } as Combo & { products: Product[] },
+        products: [inCombo(taza, 1000), inCombo(mural, 3000)],
+    },
 ];
 
 const schools = [
@@ -226,7 +238,7 @@ describe('useCreateOrderForm', () => {
         expect(result.current.filteredSchools.map((s) => s.id)).toEqual([10]);
     });
 
-    it('counts combo repetitions and standalone details separately', () => {
+    it('breaks the price down into the combo, its subtractions and the extras', () => {
         const { result } = renderForm();
 
         act(() =>
@@ -234,15 +246,18 @@ describe('useCreateOrderForm', () => {
                 ...result.current.data,
                 order_details: [
                     { product_id: 5, combo_id: 2, note: '' },
-                    { product_id: 6, combo_id: 2, note: '' },
                     { product_id: 5, note: '' },
                 ],
             }),
         );
 
-        expect(result.current.counts).toEqual({
-            combos: { 2: 2 },
-            undefinedCount: 1,
+        expect(result.current.breakdown).toEqual({
+            lines: [
+                { label: 'Combo escolar', amount: 5000 },
+                { label: 'Sin Mural', amount: -3000 },
+                { label: 'Taza', amount: 12000 },
+            ],
+            total: 14000,
         });
     });
 
@@ -264,12 +279,13 @@ describe('useCreateOrderForm', () => {
         });
     });
 
-    it('adds a combo to the cart summing its price into the total', () => {
+    it('prices the combo only once its products are configured', () => {
         const { result } = renderForm();
 
         act(() => result.current.handleAddCombo(2));
 
-        expect(result.current.data.total_price).toBe('5000');
+        // Cancelling the modal must leave the price untouched
+        expect(result.current.data.total_price).toBe('0');
         expect(
             result.current.openAddModal?.map((p) => ({
                 id: p.id,

--- a/resources/js/pages/orders/tests/use-edit-order.test.tsx
+++ b/resources/js/pages/orders/tests/use-edit-order.test.tsx
@@ -44,8 +44,13 @@ const makeOrder = (overrides: Partial<Order> = {}): Order =>
         due_date: '2026-08-15',
         classroom_id: 4,
         products: [
-            { id: 2, note: 'sin marco', variant: { color: 'negro' } },
-            { id: 5, note: null },
+            {
+                id: 2,
+                order_detail_id: 11,
+                note: 'sin marco',
+                variant: { color: 'negro' },
+            },
+            { id: 5, order_detail_id: 12, note: null },
         ],
         ...overrides,
     }) as unknown as Order;
@@ -69,11 +74,12 @@ describe('useEditOrder', () => {
             classroom_id: 4,
             order_details: [
                 {
+                    id: 11,
                     product_id: 2,
                     note: 'sin marco',
                     variant: { color: 'negro' },
                 },
-                { product_id: 5, note: null, variant: {} },
+                { id: 12, product_id: 5, note: null, variant: {} },
             ],
         });
     });

--- a/resources/js/pages/orders/tests/use-order-products.test.tsx
+++ b/resources/js/pages/orders/tests/use-order-products.test.tsx
@@ -42,7 +42,16 @@ const combo = {
     id: 4,
     name: 'Combo escolar',
     suggested_price: 15000,
+    default_payments: 3,
     products: [comboMural, taza],
+} as unknown as Combo & { products: Product[] };
+
+const otherCombo = {
+    id: 5,
+    name: 'Combo premium',
+    suggested_price: 20000,
+    default_payments: 4,
+    products: [taza],
 } as unknown as Combo & { products: Product[] };
 
 const setup = (details: ProductOrder[] = []) => {
@@ -58,7 +67,7 @@ const setup = (details: ProductOrder[] = []) => {
             setData:
                 setData as unknown as InertiaFormProps<OrderFormData>['setData'],
             products: [mural, taza, portarretrato],
-            combos: [combo],
+            combos: [combo, otherCombo],
         }),
     );
 
@@ -89,6 +98,27 @@ describe('useOrderProducts', () => {
             { ...comboMural, combo_id: 4 },
             { ...taza, combo_id: 4 },
         ]);
+    });
+
+    it('seeds the installments with the default of the first combo added', () => {
+        const { result, setData } = setup();
+
+        act(() => result.current.handleAddCombo(4));
+
+        expect(setData).toHaveBeenCalledWith('payment_plan', '3');
+    });
+
+    it('keeps the installments when a second combo is added', () => {
+        const { result, setData } = setup([
+            { product_id: 2, combo_id: 4, note: '' },
+        ]);
+
+        act(() => result.current.handleAddCombo(5));
+
+        expect(setData).not.toHaveBeenCalledWith(
+            'payment_plan',
+            expect.anything(),
+        );
     });
 
     it('appends the configured products to the order details', () => {

--- a/resources/js/pages/orders/tests/use-order-products.test.tsx
+++ b/resources/js/pages/orders/tests/use-order-products.test.tsx
@@ -1,7 +1,7 @@
 import { InertiaFormProps } from '@inertiajs/react';
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ProductOrder } from '../form';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { ComboProduct, ComboWithProducts, ProductOrder } from '../form';
 import { emptyForm, OrderFormData } from '../form-state';
 import { useOrderProducts } from '../hooks/use-order-products';
 
@@ -21,49 +21,67 @@ const mural = {
     id: 1,
     name: 'Mural clásico',
     product_type_id: 1,
+    unit_price: 40000,
     variants: catalogVariants,
 } as unknown as Product;
 
-const taza = { id: 2, name: 'Taza', product_type_id: 2 } as Product;
+const taza = {
+    id: 2,
+    name: 'Taza',
+    product_type_id: 2,
+    unit_price: 12000,
+} as Product;
 
 const portarretrato = {
     id: 3,
     name: 'Portarretrato',
     product_type_id: 3,
+    unit_price: 15000,
 } as Product;
+
+const pivot = (subtractValue: number) => ({
+    quantity: 1,
+    subtract_value: subtractValue,
+});
 
 // Same mural but restricted by the combo pivot to a single background
 const comboMural = {
     ...mural,
     variants: { ...catalogVariants, backgrounds: ['blue'] },
-} as unknown as Product;
+    pivot: pivot(9000),
+} as unknown as ComboProduct;
+
+const comboTaza = { ...taza, pivot: pivot(3000) } as ComboProduct;
 
 const combo = {
     id: 4,
     name: 'Combo escolar',
     suggested_price: 15000,
     default_payments: 3,
-    products: [comboMural, taza],
-} as unknown as Combo & { products: Product[] };
+    products: [comboMural, comboTaza],
+} as ComboWithProducts;
 
 const otherCombo = {
     id: 5,
     name: 'Combo premium',
     suggested_price: 20000,
     default_payments: 4,
-    products: [taza],
-} as unknown as Combo & { products: Product[] };
+    products: [comboTaza],
+} as ComboWithProducts;
 
 const setup = (details: ProductOrder[] = []) => {
     const setData = vi.fn();
 
+    const data: OrderFormData = {
+        ...emptyForm(),
+        total_price: '12000',
+        payment_plan: '1',
+        order_details: details,
+    };
+
     const { result } = renderHook(() =>
         useOrderProducts({
-            data: {
-                ...emptyForm(),
-                total_price: '12000',
-                order_details: details,
-            },
+            data,
             setData:
                 setData as unknown as InertiaFormProps<OrderFormData>['setData'],
             products: [mural, taza, portarretrato],
@@ -71,7 +89,16 @@ const setup = (details: ProductOrder[] = []) => {
         }),
     );
 
-    return { result, setData };
+    /** The form values left by the last cart mutation */
+    const applied = (): OrderFormData => {
+        const updater = (setData as Mock).mock.calls.at(-1)?.[0] as (
+            current: OrderFormData,
+        ) => OrderFormData;
+
+        return updater(data);
+    };
+
+    return { result, setData, applied };
 };
 
 describe('useOrderProducts', () => {
@@ -88,53 +115,59 @@ describe('useOrderProducts', () => {
         expect(setData).not.toHaveBeenCalled();
     });
 
-    it('sums the combo price into the total and opens its products tagged with the combo', () => {
+    it('opens the combo products tagged with the combo without touching the price', () => {
         const { result, setData } = setup();
 
         act(() => result.current.handleAddCombo(4));
 
-        expect(setData).toHaveBeenCalledWith('total_price', '27000');
         expect(result.current.openAddModal).toEqual([
             { ...comboMural, combo_id: 4 },
-            { ...taza, combo_id: 4 },
+            { ...comboTaza, combo_id: 4 },
         ]);
+        // Regression (#100): the price used to be added here, so picking a
+        // second combo accumulated on top of the first
+        expect(setData).not.toHaveBeenCalled();
     });
 
-    it('seeds the installments with the default of the first combo added', () => {
-        const { result, setData } = setup();
-
-        act(() => result.current.handleAddCombo(4));
-
-        expect(setData).toHaveBeenCalledWith('payment_plan', '3');
-    });
-
-    it('keeps the installments when a second combo is added', () => {
-        const { result, setData } = setup([
-            { product_id: 2, combo_id: 4, note: '' },
-        ]);
-
-        act(() => result.current.handleAddCombo(5));
-
-        expect(setData).not.toHaveBeenCalledWith(
-            'payment_plan',
-            expect.anything(),
-        );
-    });
-
-    it('appends the configured products to the order details', () => {
+    it('appends the configured products and derives the total from the cart', () => {
         const existing: ProductOrder = { product_id: 2, note: 'Taza de Luca' };
         const added: ProductOrder[] = [
-            { product_id: 1, note: 'Mural de Emma' },
+            { product_id: 1, note: 'Mural de Emma', combo_id: 4 },
             { product_id: 2, note: 'Taza de Emma', combo_id: 4 },
         ];
-        const { result, setData } = setup([existing]);
+        const { result, applied } = setup([existing]);
 
         act(() => result.current.setProductsOrder(added));
 
-        expect(setData).toHaveBeenCalledWith('order_details', [
-            existing,
-            ...added,
+        expect(applied().order_details).toEqual([existing, ...added]);
+        // Combo 15000 + the standalone taza 12000, ignoring the old total
+        expect(applied().total_price).toBe('27000');
+    });
+
+    it('seeds the installments with the default of the first combo added', () => {
+        const { result, applied } = setup();
+
+        act(() =>
+            result.current.setProductsOrder([
+                { product_id: 2, combo_id: 4, note: '' },
+            ]),
+        );
+
+        expect(applied().payment_plan).toBe('3');
+    });
+
+    it('keeps the installments when a second combo is added', () => {
+        const { result, applied } = setup([
+            { product_id: 2, combo_id: 4, note: '' },
         ]);
+
+        act(() =>
+            result.current.setProductsOrder([
+                { product_id: 2, combo_id: 5, note: '' },
+            ]),
+        );
+
+        expect(applied().payment_plan).toBe('1');
     });
 
     it('replaces the edited detail in place and leaves edit mode', () => {
@@ -142,7 +175,7 @@ describe('useOrderProducts', () => {
             { product_id: 2, note: 'Taza de Luca' },
             { product_id: 3, note: 'Portarretrato de Luca' },
         ];
-        const { result, setData } = setup(details);
+        const { result, applied } = setup(details);
 
         act(() => result.current.handleEditProduct(0));
 
@@ -155,23 +188,11 @@ describe('useOrderProducts', () => {
             ]),
         );
 
-        expect(setData).toHaveBeenLastCalledWith('order_details', [
+        expect(applied().order_details).toEqual([
             { product_id: 2, note: 'Taza de Lucas' },
             details[1],
         ]);
         expect(result.current.editingIndex).toBeNull();
-
-        // Once edit mode is cleared, saving appends again
-        act(() =>
-            result.current.setProductsOrder([
-                { product_id: 1, note: 'Mural de Emma' },
-            ]),
-        );
-
-        expect(setData).toHaveBeenLastCalledWith('order_details', [
-            ...details,
-            { product_id: 1, note: 'Mural de Emma' },
-        ]);
     });
 
     it('edits a combo item with the pivot-restricted product, not the catalog one', () => {
@@ -207,18 +228,36 @@ describe('useOrderProducts', () => {
         expect(result.current.editingIndex).toBeNull();
     });
 
-    it('removes the detail and reminds about reviewing the price', () => {
+    it('subtracts the configured value when a combo product is removed', () => {
         const details: ProductOrder[] = [
-            { product_id: 1, note: 'Mural de Emma' },
-            { product_id: 2, note: 'Taza de Emma' },
+            { product_id: 1, combo_id: 4, note: '' },
+            { product_id: 2, combo_id: 4, note: '' },
         ];
-        const { result, setData } = setup(details);
+        const { result, applied } = setup(details);
 
-        act(() => result.current.handleRemoveProduct(0));
+        act(() => result.current.handleRemoveProduct(1));
 
-        expect(setData).toHaveBeenCalledWith('order_details', [details[1]]);
+        expect(applied().order_details).toEqual([details[0]]);
+        // 15000 − 3000 (the taza subtract value), not − 12000 (its price)
+        expect(applied().total_price).toBe('12000');
         expect(toast.info).toHaveBeenCalledWith(
             expect.stringContaining('precio'),
         );
+    });
+
+    it('exposes the breakdown and restores the calculated price on demand', () => {
+        const { result, setData } = setup([
+            { product_id: 1, combo_id: 4, note: '' },
+            { product_id: 2, combo_id: 4, note: '' },
+        ]);
+
+        expect(result.current.breakdown).toEqual({
+            lines: [{ label: 'Combo escolar', amount: 15000 }],
+            total: 15000,
+        });
+
+        act(() => result.current.recalculatePrice());
+
+        expect(setData).toHaveBeenCalledWith('total_price', '15000');
     });
 });

--- a/resources/js/pages/orders/tests/use-order-products.test.tsx
+++ b/resources/js/pages/orders/tests/use-order-products.test.tsx
@@ -53,6 +53,12 @@ const comboMural = {
 
 const comboTaza = { ...taza, pivot: pivot(3000) } as ComboProduct;
 
+// The premium combo carries two portarretratos
+const comboPortarretrato = {
+    ...portarretrato,
+    pivot: { quantity: 2, subtract_value: 4000 },
+} as ComboProduct;
+
 const combo = {
     id: 4,
     name: 'Combo escolar',
@@ -66,7 +72,7 @@ const otherCombo = {
     name: 'Combo premium',
     suggested_price: 20000,
     default_payments: 4,
-    products: [comboTaza],
+    products: [comboTaza, comboPortarretrato],
 } as ComboWithProducts;
 
 const setup = (details: ProductOrder[] = []) => {
@@ -142,6 +148,33 @@ describe('useOrderProducts', () => {
         expect(applied().order_details).toEqual([existing, ...added]);
         // Combo 15000 + the standalone taza 12000, ignoring the old total
         expect(applied().total_price).toBe('27000');
+    });
+
+    it('adds one detail per unit when the combo carries several of a product', () => {
+        const { result, applied } = setup();
+        const detail = { product_id: 3, combo_id: 5, note: 'Foto de Emma' };
+
+        act(() => result.current.setProductsOrder([detail]));
+
+        // The combo carries 2 portarretratos: same variants and note, two units
+        expect(applied().order_details).toEqual([detail, detail]);
+    });
+
+    it('does not multiply the units again when the detail is edited', () => {
+        const detail = { product_id: 3, combo_id: 5, note: 'Foto de Emma' };
+        const { result, applied } = setup([detail, detail]);
+
+        act(() => result.current.handleEditProduct(0));
+        act(() =>
+            result.current.setProductsOrder([
+                { ...detail, note: 'Foto de Emma R.' },
+            ]),
+        );
+
+        expect(applied().order_details).toEqual([
+            { ...detail, note: 'Foto de Emma R.' },
+            detail,
+        ]);
     });
 
     it('seeds the installments with the default of the first combo added', () => {

--- a/resources/js/pages/orders/tests/use-order-products.test.tsx
+++ b/resources/js/pages/orders/tests/use-order-products.test.tsx
@@ -245,6 +245,21 @@ describe('useOrderProducts', () => {
         );
     });
 
+    it('removes every detail of a combo and drops its price', () => {
+        const details: ProductOrder[] = [
+            { product_id: 1, combo_id: 4, note: '' },
+            { product_id: 2, combo_id: 4, note: '' },
+            { product_id: 3, note: 'Portarretrato suelto' },
+        ];
+        const { result, applied } = setup(details);
+
+        act(() => result.current.handleRemoveCombo(4));
+
+        expect(applied().order_details).toEqual([details[2]]);
+        // Only the standalone portarretrato is left
+        expect(applied().total_price).toBe('15000');
+    });
+
     it('exposes the breakdown and restores the calculated price on demand', () => {
         const { result, setData } = setup([
             { product_id: 1, combo_id: 4, note: '' },

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -143,7 +143,7 @@ declare global {
         id: number;
         name: string;
         suggested_price: number;
-        suggested_max_payments: number;
+        default_payments: number;
     }
 
     type OrderStatus =

--- a/tests/Feature/ComboTest.php
+++ b/tests/Feature/ComboTest.php
@@ -21,6 +21,7 @@ it('opens the edit page exposing pivot quantity and variants', function () {
 
     $combo->products()->attach($product->id, [
         'quantity' => 2,
+        'subtract_value' => 2000,
         'variants' => ['orientations' => ['vertical']],
     ]);
 
@@ -30,6 +31,7 @@ it('opens the edit page exposing pivot quantity and variants', function () {
         fn (Assert $page) => $page
             ->component('combos/edit')
             ->where('combo.data.products.0.quantity', 2)
+            ->where('combo.data.products.0.subtract_value', 2000)
             ->where('combo.data.products.0.variants.orientations.0', 'vertical'),
     );
 });
@@ -49,6 +51,7 @@ it('stores variants encoded once and returns them as an array', function () {
             [
                 'id' => $product->id,
                 'quantity' => 1,
+                'subtract_value' => 0,
                 'variants' => ['orientations' => ['horizontal']],
             ],
         ],
@@ -75,17 +78,48 @@ it('updates a combo keeping quantities', function () {
         'suggested_max_payments' => 4,
     ]);
 
-    $combo->products()->attach($product->id, ['quantity' => 1]);
+    $combo->products()->attach($product->id, ['quantity' => 1, 'subtract_value' => 0]);
 
     \Pest\Laravel\put(route('combos.update', $combo), [
         'name' => 'Combo renombrado',
         'suggested_price' => 70000,
         'suggested_max_payments' => 4,
         'products' => [
-            ['id' => $product->id, 'quantity' => 3],
+            ['id' => $product->id, 'quantity' => 3, 'subtract_value' => 5000],
         ],
     ])->assertSessionHasNoErrors();
 
     expect($combo->refresh()->name)->toBe('Combo renombrado')
-        ->and($combo->products()->first()?->pivot?->quantity)->toBe(3);
+        ->and($combo->products()->first()?->pivot?->quantity)->toBe(3)
+        ->and($combo->products()->first()?->pivot?->subtract_value)->toBe(5000);
+});
+
+it('requires a subtract value for every product of the combo', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create();
+
+    \Pest\Laravel\post(route('combos.store'), [
+        'name' => 'Combo sin resta',
+        'suggested_price' => 64000,
+        'suggested_max_payments' => 4,
+        'products' => [
+            ['id' => $product->id, 'quantity' => 1],
+        ],
+    ])->assertSessionHasErrors('products.0.subtract_value');
+});
+
+it('rejects a negative subtract value', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create();
+
+    \Pest\Laravel\post(route('combos.store'), [
+        'name' => 'Combo resta negativa',
+        'suggested_price' => 64000,
+        'suggested_max_payments' => 4,
+        'products' => [
+            ['id' => $product->id, 'quantity' => 1, 'subtract_value' => -1],
+        ],
+    ])->assertSessionHasErrors('products.0.subtract_value');
 });

--- a/tests/Feature/ComboTest.php
+++ b/tests/Feature/ComboTest.php
@@ -16,7 +16,7 @@ it('opens the edit page exposing pivot quantity and variants', function () {
     $combo = Combo::create([
         'name' => 'Combo test',
         'suggested_price' => 64000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
     ]);
 
     $combo->products()->attach($product->id, [
@@ -46,7 +46,7 @@ it('stores variants encoded once and returns them as an array', function () {
     \Pest\Laravel\post(route('combos.store'), [
         'name' => 'Combo roundtrip',
         'suggested_price' => 64000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
         'products' => [
             [
                 'id' => $product->id,
@@ -75,7 +75,7 @@ it('updates a combo keeping quantities', function () {
     $combo = Combo::create([
         'name' => 'Combo test',
         'suggested_price' => 64000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
     ]);
 
     $combo->products()->attach($product->id, ['quantity' => 1, 'subtract_value' => 0]);
@@ -83,7 +83,7 @@ it('updates a combo keeping quantities', function () {
     \Pest\Laravel\put(route('combos.update', $combo), [
         'name' => 'Combo renombrado',
         'suggested_price' => 70000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
         'products' => [
             ['id' => $product->id, 'quantity' => 3, 'subtract_value' => 5000],
         ],
@@ -102,7 +102,7 @@ it('requires a subtract value for every product of the combo', function () {
     \Pest\Laravel\post(route('combos.store'), [
         'name' => 'Combo sin resta',
         'suggested_price' => 64000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
         'products' => [
             ['id' => $product->id, 'quantity' => 1],
         ],
@@ -117,7 +117,7 @@ it('rejects a negative subtract value', function () {
     \Pest\Laravel\post(route('combos.store'), [
         'name' => 'Combo resta negativa',
         'suggested_price' => 64000,
-        'suggested_max_payments' => 4,
+        'default_payments' => 4,
         'products' => [
             ['id' => $product->id, 'quantity' => 1, 'subtract_value' => -1],
         ],

--- a/tests/Feature/OrderTest.php
+++ b/tests/Feature/OrderTest.php
@@ -135,3 +135,63 @@ it('soft deletes an order without payments', function () {
 
     assertSoftDeleted('orders', ['id' => $order->id]);
 });
+
+it('keeps each detail of a repeated product apart when the order is edited', function () {
+    actingAsRole();
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    $order = Order::factory()->create([
+        'classroom_id' => $classroom->id,
+        'total_price' => 24000,
+        'payment_plan' => 2,
+    ]);
+
+    // The same product twice: two mugs with a different name printed on each
+    $order->products()->attach($product->id, ['note' => 'Taza de Luca', 'variant' => []]);
+    $order->products()->attach($product->id, ['note' => 'Taza de Emma', 'variant' => []]);
+
+    $details = $order->details()->orderBy('id')->get();
+
+    // Regression: syncing by product_id collapsed both rows into one, so
+    // editing the price alone overwrote the first note with the second
+    put(route('orders.update', $order), [
+        ...validOrderPayload($classroom, $product),
+        'total_price' => 30000,
+        'order_details' => $details->map(fn ($detail) => [
+            'id' => $detail->id,
+            'product_id' => $detail->product_id,
+            'note' => $detail->note,
+        ])->all(),
+    ])->assertSessionHasNoErrors();
+
+    expect($order->refresh()->total_price)->toBe(30000)
+        ->and($order->details()->orderBy('id')->pluck('note')->all())
+        ->toBe(['Taza de Luca', 'Taza de Emma']);
+});
+
+it('updates the note of a single detail without touching its twin', function () {
+    actingAsRole();
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $order->products()->attach($product->id, ['note' => 'Taza de Luca', 'variant' => []]);
+    $order->products()->attach($product->id, ['note' => 'Taza de Emma', 'variant' => []]);
+
+    $details = $order->details()->orderBy('id')->get();
+
+    put(route('orders.update', $order), [
+        ...validOrderPayload($classroom, $product),
+        'order_details' => [
+            ['id' => $details[0]->id, 'product_id' => $product->id, 'note' => 'Taza de Lucas'],
+            ['id' => $details[1]->id, 'product_id' => $product->id, 'note' => 'Taza de Emma'],
+        ],
+    ])->assertSessionHasNoErrors();
+
+    expect($order->details()->orderBy('id')->pluck('note')->all())
+        ->toBe(['Taza de Lucas', 'Taza de Emma']);
+});

--- a/tests/Feature/PageSmokeTest.php
+++ b/tests/Feature/PageSmokeTest.php
@@ -52,7 +52,7 @@ it('renders every GET page without errors', function () {
                 'combo' => Combo::first() ?? Combo::create([
                     'name' => 'Combo smoke',
                     'suggested_price' => 64000,
-                    'suggested_max_payments' => 4,
+                    'default_payments' => 4,
                 ]),
                 'order' => Order::first(),
                 'product' => Product::first(),


### PR DESCRIPTION
Rediseño del precio de los combos, según lo hablado en la reunión del 9/7. Los cuatro issues son el mismo problema de raíz: el precio del pedido era un **acumulador** (`total_price = total_price + precio del combo`), los productos sueltos no sumaban nada y quitar un producto solo mostraba un aviso de "revisá el precio". Ahora el total es una **función pura del carrito**:

```
total = Σ combos (precio del combo − restas de los productos que se le sacaron)
      + Σ extras (a precio de lista)
```

Como el total se recalcula entero en cada cambio del carrito y nunca se suma sobre el anterior, **el bug de acumulación (#100) desaparece por construcción**: elegir otro combo ya no arrastra el precio del anterior.

## Commits

| Commit | Qué hace |
| --- | --- |
| `feat(combos): add per-product subtract value` | Campo **valor de resta** por producto del combo (`combo_product.subtract_value`): cuánto baja el precio del combo si se saca ese producto. No es el precio de lista (la medalla resta 2.000 aunque valga 6.000, como en el video). |
| `feat(combos): add default installments` | `suggested_max_payments` → `default_payments` ("cuotas por defecto"): era un máximo que no limitaba nada. El primer combo que se agrega al pedido siembra las cuotas; un segundo combo ya no las pisa. |
| `feat(orders): derive the total from combos and extras` | `pricing.ts` con el cálculo puro + desglose línea por línea y botón **Recalcular**. El precio sigue siendo editable a mano ("es a criterio mío"), y ese valor se respeta hasta el próximo cambio del carrito. |
| `feat(orders): group cart details by combo` | Paso 4 agrupado: una sección por combo (con su precio y **Quitar combo**) y otra de **Otros productos**. |
| `fix(orders): add one detail per combo unit` | Bug encontrado durante el trabajo: el wizard ignoraba `combo_product.quantity`, así que un combo con `2x Foto` cargaba una sola. Ahora cada unidad es su propio detalle (se configuran una vez: dos productos iguales del mismo combo comparten variante y nota). |
| `test(e2e): expect the derived total after restoring a draft` | Consecuencia de lo anterior: un borrador con precio tipeado a mano y sin productos recalcula el total al agregar el primer producto. |
| `fix(orders): update order details by row instead of by product` | Segundo bug encontrado, **con corrupción de datos**: ver abajo. |

## Decisiones tomadas

- **Varios combos por pedido**: el total suma todos. "Cambiar de combo" es quitar uno y agregar otro, con el botón **Quitar combo** de cada sección.
- **Un combo sale del pedido cuando se le sacan todos sus productos** (y con él, su precio).
- **La pertenencia al combo no se persiste**: vive en el paso 4 (y en el borrador). `order_details` no cambió.
- El precio nunca queda negativo: si las restas superan al precio del combo, el calculado es 0 y se corrige a mano.

## El bug del `sync()` (corrupción silenciosa de datos)

`UpdateOrder` sincronizaba los detalles por `product_id`. Como un pedido **puede repetir un producto** (dos tazas con nombres distintos, un mural del combo más otro suelto), eso rompía dos veces:

1. `mapWithKeys` usa `product_id` como clave y un array PHP no admite claves repetidas: de las dos tazas sobrevivía **la última**.
2. Con un pivot custom (`using(OrderDetail::class)`), `updateExistingPivot` actualiza **una sola** de las filas duplicadas.

Reproducido: editando **solo el precio** de un pedido con dos tazas, `Taza de Luca | Taza de Emma` quedaba en `Taza de Emma | Taza de Emma`. No borraba filas, pero duplicaba un dato y perdía otro, en silencio. Era alcanzable desde la UI aunque el paso de productos de la edición tenga los botones deshabilitados, porque el formulario igual manda los detalles existentes en cada guardado.

El commit `fix(orders): add one detail per combo unit` de este mismo PR vuelve **normales** a los productos repetidos, así que se arregla acá: la edición manda el `id` de cada `order_detail` (`order_detail_id`, ya expuesto por `OrderResource`) y `UpdateOrder` actualiza fila por fila, con el update acotado al pedido (un id de otro pedido no matchea nada). Dos tests de Pest lo fijan; verificado que fallan contra el código viejo.

## Verificación

- `validate-code` limpio; **Pest 125**, **Vitest 201** (21 tests nuevos: cálculo, agrupado, unidades del combo, detalles repetidos), **Playwright 14/14**.
- Verificado a mano en el browser a 390px: agrupado, resta al quitar la medalla (70.000, no 66.000), quitar el combo, desglose y Recalcular. Sin scroll horizontal.

Closes #96, #97, #98, #100
