### PR TITLE
fix(orders): reparte las cards del detalle en columnas masonry balanceadas

### DIFF
--- a/resources/js/components/masonry/index.test.tsx
+++ b/resources/js/components/masonry/index.test.tsx
@@ -1,0 +1,221 @@
+import { Masonry, MasonryItem } from '@/components/masonry';
+import { assignToShortestColumn, columnsFor } from '@/hooks/use-masonry';
+import { act, render } from '@testing-library/react';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// jsdom lays nothing out, so every element reports offsetHeight 0. The masonry
+// measures the wrapper it puts around each item, so the fake height is read from
+// the item it wraps.
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get(this: HTMLElement) {
+            const child = this.firstElementChild as HTMLElement | null;
+
+            return Number(child?.dataset.height ?? 0);
+        },
+    });
+});
+
+function setWidth(width: number) {
+    Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: width,
+    });
+}
+
+function card(key: string, height: number): MasonryItem {
+    return {
+        key,
+        content: (
+            <div data-testid={key} data-height={height}>
+                {key}
+            </div>
+        ),
+    };
+}
+
+/** The keys of each column, in the order they are painted. */
+function columnsOf(container: HTMLElement): string[][] {
+    const root = container.firstElementChild as HTMLElement;
+
+    return Array.from(root.children).map((column) =>
+        Array.from(column.querySelectorAll<HTMLElement>('[data-testid]')).map(
+            (item) => item.dataset.testid ?? '',
+        ),
+    );
+}
+
+// The heights the real order page produces: a short client card, a very tall
+// detail card, and three middling ones.
+const ORDER_CARDS = [
+    card('info', 300),
+    card('details', 671),
+    card('delivery', 352),
+    card('payments', 186),
+    card('notes', 372),
+];
+
+describe('assignToShortestColumn', () => {
+    it('keeps the source order in a single column', () => {
+        expect(assignToShortestColumn([300, 671, 352], 1)).toEqual([0, 0, 0]);
+    });
+
+    it('sends each item to the column that is shortest so far', () => {
+        // 300 -> c0 (0); 671 -> c1 (0); 352 -> c0 (300 < 671); 186 -> c0 (652 <
+        // 671); 372 -> c1 (671 < 838)
+        expect(assignToShortestColumn([300, 671, 352, 186, 372], 2)).toEqual([
+            0, 1, 0, 0, 1,
+        ]);
+    });
+
+    it('breaks ties towards the leftmost column, so equal cards round-robin', () => {
+        expect(assignToShortestColumn([100, 100, 100, 100], 2)).toEqual([
+            0, 1, 0, 1,
+        ]);
+    });
+
+    it('leaves the surplus columns empty when there are fewer items', () => {
+        expect(assignToShortestColumn([100, 100], 3)).toEqual([0, 1]);
+    });
+
+    it('never leaves a column more than one card taller than the others', () => {
+        const heights = [300, 671, 352, 186, 372];
+        const totals = [0, 0, 0];
+
+        assignToShortestColumn(heights, 3).forEach((column, index) => {
+            totals[column] += heights[index];
+        });
+
+        // The greedy bound: any imbalance is smaller than the tallest card, so
+        // no column can strand a hole bigger than one card.
+        expect(Math.max(...totals) - Math.min(...totals)).toBeLessThan(
+            Math.max(...heights),
+        );
+    });
+});
+
+describe('columnsFor', () => {
+    it.each([
+        [390, 1],
+        [1023, 1],
+        [1024, 2],
+        [1535, 2],
+        [1536, 3],
+        [2560, 3],
+    ])('renders %i px wide in %i column(s)', (width, columns) => {
+        expect(columnsFor(width)).toBe(columns);
+    });
+});
+
+describe('<Masonry />', () => {
+    it('stacks everything in source order on mobile', () => {
+        setWidth(390);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+
+        expect(columnsOf(container)).toEqual([
+            ['info', 'details', 'delivery', 'payments', 'notes'],
+        ]);
+    });
+
+    it('balances the cards over two columns on a laptop', () => {
+        setWidth(1280);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+
+        expect(columnsOf(container)).toEqual([
+            ['info', 'delivery', 'payments'],
+            ['details', 'notes'],
+        ]);
+    });
+
+    it('balances the cards over three columns on a wide screen', () => {
+        setWidth(1600);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+
+        // The tall detail card gets a column of its own; the short client card
+        // is topped up with the payments one instead of stranding a hole.
+        expect(columnsOf(container)).toEqual([
+            ['info', 'payments'],
+            ['details'],
+            ['delivery', 'notes'],
+        ]);
+    });
+
+    it('re-balances when the window is resized', () => {
+        setWidth(390);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+        expect(columnsOf(container)).toHaveLength(1);
+
+        act(() => {
+            setWidth(1600);
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        expect(columnsOf(container)).toHaveLength(3);
+    });
+
+    it('keeps every card when the window shrinks back to a single column', () => {
+        setWidth(1600);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+        expect(columnsOf(container)).toHaveLength(3);
+
+        // The assignment left over from three columns points at columns that no
+        // longer exist: the cards used to vanish here.
+        act(() => {
+            setWidth(390);
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        expect(columnsOf(container)).toEqual([
+            ['info', 'details', 'delivery', 'payments', 'notes'],
+        ]);
+    });
+
+    it('renders every item exactly once, whatever the column count', () => {
+        setWidth(1600);
+
+        const { container } = render(<Masonry items={ORDER_CARDS} />);
+
+        expect(columnsOf(container).flat().sort()).toEqual(
+            ORDER_CARDS.map((item) => item.key).sort(),
+        );
+    });
+
+    it('keeps unmeasured cards in source order in the first column', () => {
+        setWidth(1600);
+
+        const items = [
+            { key: 'a', content: <div data-testid="a">a</div> },
+            { key: 'b', content: <div data-testid="b">b</div> },
+            { key: 'c', content: <div data-testid="c">c</div> },
+        ];
+
+        const { container } = render(<Masonry items={items} />);
+
+        // Cards that report no height are all equally short, so they end up in
+        // the first column. It never shows: the measuring pass runs in a layout
+        // effect, before the browser paints.
+        expect(columnsOf(container)).toEqual([['a', 'b', 'c'], [], []]);
+    });
+
+    it('drops a card from the layout when it stops being rendered', () => {
+        setWidth(1600);
+
+        const { container, rerender } = render(<Masonry items={ORDER_CARDS} />);
+
+        // A cancelled order renders no delivery card.
+        rerender(
+            <Masonry
+                items={ORDER_CARDS.filter((item) => item.key !== 'delivery')}
+            />,
+        );
+
+        expect(columnsOf(container).flat()).not.toContain('delivery');
+        expect(columnsOf(container).flat()).toHaveLength(4);
+    });
+});

--- a/resources/js/components/masonry/index.tsx
+++ b/resources/js/components/masonry/index.tsx
@@ -1,0 +1,47 @@
+import { useMasonry } from '@/hooks/use-masonry';
+import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
+
+export interface MasonryItem {
+    key: string;
+    content: ReactNode;
+}
+
+/**
+ * Lays the items out in balanced columns: each one goes to the shortest column,
+ * so a short card never leaves a hole next to a tall neighbour. Below the first
+ * breakpoint everything collapses into a single column, in source order.
+ */
+export function Masonry({
+    items,
+    className,
+}: {
+    items: MasonryItem[];
+    className?: string;
+}) {
+    const { columns, register } = useMasonry(items.map((item) => item.key));
+
+    const contentOf = new Map(items.map((item) => [item.key, item.content]));
+
+    return (
+        <div
+            className={cn(
+                'flex flex-col gap-6 lg:flex-row lg:items-start',
+                className,
+            )}
+        >
+            {columns.map((keys, column) => (
+                <div
+                    key={column}
+                    className="flex min-w-0 flex-1 flex-col gap-6"
+                >
+                    {keys.map((key) => (
+                        <div key={key} ref={register(key)}>
+                            {contentOf.get(key)}
+                        </div>
+                    ))}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/hooks/use-masonry.ts
+++ b/resources/js/hooks/use-masonry.ts
@@ -1,0 +1,104 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Column count per viewport width. Mirrors the lg/2xl Tailwind breakpoints.
+ */
+export function columnsFor(width: number): number {
+    if (width >= 1536) return 3;
+    if (width >= 1024) return 2;
+    return 1;
+}
+
+/**
+ * Assigns each item to the shortest column so far. CSS can only split a list of
+ * cards in source order (that is what `columns-*` and column wrappers do), which
+ * strands short cards next to a tall neighbour; picking the shortest column is
+ * what keeps the columns even.
+ */
+export function assignToShortestColumn(
+    heights: number[],
+    columns: number,
+): number[] {
+    const totals: number[] = new Array(columns).fill(0);
+
+    return heights.map((height) => {
+        let target = 0;
+        for (let column = 1; column < columns; column++) {
+            if (totals[column] < totals[target]) target = column;
+        }
+
+        totals[target] += height;
+
+        return target;
+    });
+}
+
+function sameAssignment(a: number[], b: number[]): boolean {
+    return a.length === b.length && a.every((column, i) => column === b[i]);
+}
+
+/**
+ * Distributes `keys` over a responsive number of columns, keeping the columns as
+ * even as possible. Returns the column each key belongs to, plus the ref
+ * callback that has to be attached to every item so it can be measured.
+ */
+export function useMasonry(keys: string[]) {
+    const [columns, setColumns] = useState(1);
+    const [assignment, setAssignment] = useState<number[]>([]);
+    const nodes = useRef(new Map<string, HTMLElement>());
+
+    useLayoutEffect(() => {
+        const readWidth = () => setColumns(columnsFor(window.innerWidth));
+
+        readWidth();
+        window.addEventListener('resize', readWidth);
+
+        return () => window.removeEventListener('resize', readWidth);
+    }, []);
+
+    // No dependency array: items change parent when they are reassigned, which
+    // remounts their nodes, so the observer has to be re-attached every render.
+    useLayoutEffect(() => {
+        const measure = () => {
+            const heights = keys.map(
+                (key) => nodes.current.get(key)?.offsetHeight ?? 0,
+            );
+
+            const next = assignToShortestColumn(heights, columns);
+
+            setAssignment((current) =>
+                sameAssignment(current, next) ? current : next,
+            );
+        };
+
+        const observer = new ResizeObserver(measure);
+        nodes.current.forEach((node) => observer.observe(node));
+        measure();
+
+        return () => observer.disconnect();
+    });
+
+    const register = (key: string) => (node: HTMLElement | null) => {
+        if (node) {
+            nodes.current.set(key, node);
+        } else {
+            nodes.current.delete(key);
+        }
+    };
+
+    const columnsOfKeys: string[][] = Array.from(
+        { length: columns },
+        () => [] as string[],
+    );
+
+    // On the render right after the viewport shrinks the assignment still points
+    // at columns that no longer exist; clamping keeps the cards on screen until
+    // the layout effect below re-measures them.
+    keys.forEach((key, index) => {
+        const column = Math.min(assignment[index] ?? 0, columns - 1);
+
+        columnsOfKeys[column].push(key);
+    });
+
+    return { columns: columnsOfKeys, register };
+}

--- a/resources/js/pages/orders/components/delivery.tsx
+++ b/resources/js/pages/orders/components/delivery.tsx
@@ -34,7 +34,7 @@ export function DeliveryCard({
     } = useDelivery(order);
 
     return (
-        <Card className="lg:min-w-100">
+        <Card>
             {pendingDelivery && (
                 <DeliveryWarningModal
                     show={Boolean(pendingDelivery)}

--- a/resources/js/pages/orders/components/details.tsx
+++ b/resources/js/pages/orders/components/details.tsx
@@ -18,7 +18,7 @@ export function Details({ order }: { order: Order }) {
     const isCancelled = Boolean(order.cancelled_at);
 
     return (
-        <Card className="lg:min-w-100">
+        <Card>
             <CardHeader>
                 <CardTitle className="text-xl">Detalle</CardTitle>
             </CardHeader>

--- a/resources/js/pages/orders/components/order-info-card.tsx
+++ b/resources/js/pages/orders/components/order-info-card.tsx
@@ -29,7 +29,7 @@ export function OrderInfoCard({ order, onCancel }: OrderInfoCardProps) {
     const isCancelled = Boolean(order.cancelled_at);
 
     return (
-        <Card className="relative lg:min-w-100">
+        <Card className="relative">
             {order.can_edit ? (
                 <Link
                     href={route('orders.edit', {

--- a/resources/js/pages/orders/components/order-notes.tsx
+++ b/resources/js/pages/orders/components/order-notes.tsx
@@ -38,7 +38,7 @@ export function OrderNotes({ order, notes }: { order: Order; notes: Note[] }) {
                 />
             )}
 
-            <Card className="lg:min-w-100">
+            <Card>
                 <CardHeader>
                     <CardTitle className="text-xl">Notas del pedido</CardTitle>
                 </CardHeader>

--- a/resources/js/pages/orders/components/payment-history.tsx
+++ b/resources/js/pages/orders/components/payment-history.tsx
@@ -58,7 +58,7 @@ export function PaymentHistory({
                 />
             )}
 
-            <Card className="lg:min-w-100">
+            <Card>
                 <CardHeader>
                     <CardTitle className="flex items-center justify-between text-xl">
                         <span>Historial de pagos</span>

--- a/resources/js/pages/orders/show.tsx
+++ b/resources/js/pages/orders/show.tsx
@@ -1,3 +1,4 @@
+import { Masonry } from '@/components/masonry';
 import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
@@ -53,31 +54,63 @@ export default function Order({
                 />
             )}
 
-            <section className="flex flex-col gap-6 px-6 py-6 lg:flex-row lg:flex-wrap">
-                <OrderInfoCard
-                    order={data}
-                    onCancel={() => setShowCancelModal(true)}
+            <section className="px-6 py-6">
+                <Masonry
+                    items={[
+                        {
+                            key: 'info',
+                            content: (
+                                <OrderInfoCard
+                                    order={data}
+                                    onCancel={() => setShowCancelModal(true)}
+                                />
+                            ),
+                        },
+                        {
+                            key: 'details',
+                            content: <Details order={data} />,
+                        },
+                        ...(isCancelled
+                            ? []
+                            : [
+                                  {
+                                      key: 'delivery',
+                                      content: (
+                                          <DeliveryCard
+                                              order={data}
+                                              onPayBalance={openPayBalance}
+                                          />
+                                      ),
+                                  },
+                              ]),
+                        {
+                            key: 'payments',
+                            content: (
+                                <PaymentHistory
+                                    order={data}
+                                    payments={data.payments || []}
+                                    showCreatePayment={showCreatePayment}
+                                    setShowCreatePayment={(show) => {
+                                        setShowCreatePayment(show);
+                                        if (!show)
+                                            setPaymentInitialAmount(null);
+                                    }}
+                                    initialAmount={paymentInitialAmount}
+                                    canRegister={!isCancelled}
+                                />
+                            ),
+                        },
+                        {
+                            key: 'notes',
+                            content: (
+                                <OrderNotes
+                                    order={data}
+                                    notes={data.notes || []}
+                                />
+                            ),
+                        },
+                    ]}
                 />
-
-                <Details order={data} />
-
-                {!isCancelled && (
-                    <DeliveryCard order={data} onPayBalance={openPayBalance} />
-                )}
-
-                <PaymentHistory
-                    order={data}
-                    payments={data.payments || []}
-                    showCreatePayment={showCreatePayment}
-                    setShowCreatePayment={(show) => {
-                        setShowCreatePayment(show);
-                        if (!show) setPaymentInitialAmount(null);
-                    }}
-                    initialAmount={paymentInitialAmount}
-                    canRegister={!isCancelled}
-                />
-
-                <OrderNotes order={data} notes={data.notes || []} />
             </section>
         </AppLayout>
     );

--- a/resources/js/tests/setup.ts
+++ b/resources/js/tests/setup.ts
@@ -4,6 +4,16 @@ import { afterEach, vi } from 'vitest';
 // Without vitest globals, testing-library cannot register its own cleanup
 afterEach(() => cleanup());
 
+// jsdom does not implement ResizeObserver, required by the masonry layout
+vi.stubGlobal(
+    'ResizeObserver',
+    class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    },
+);
+
 // jsdom does not implement matchMedia, required by the sidebar's
 // useIsMobile hook and other responsive components
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
Cierra #151.

## Problema

Las cinco cards del detalle de pedido se renderizaban como hijos de un `flex flex-row flex-wrap`. Con `align-items: stretch`, la card corta (Cliente) se estiraba hasta la altura de la más alta de su fila (Detalle), y Notas caía a una segunda fila que empezaba recién debajo de esa altura: de ahí el hueco enorme del issue.

## Por qué no se hizo lo que proponía el issue

La propuesta (4 columnas fijas agrupando Cliente + Notas) no cierra el problema:

- Cualquier layout CSS —`columns-*` o columnas explícitas— sólo puede partir las cards **en el orden del DOM**. No puede poner Cliente junto a Pagos salteándose Detalle, que es justo lo que hace falta para emparejar las columnas. Con 2 columnas la agrupación fija deja colgada la columna izquierda; con 3, el navegador deja a Cliente solo. En ambos casos el hueco vuelve, sólo que en otro lado.
- 4 columnas fijas × `min-w-100` pedían ~1700px: por debajo de eso, scroll horizontal (prohibido en el proyecto).
- La card de Entrega no existe en pedidos cancelados, así que una asignación estática deja un agujero.

## Solución

Masonry real: cada card va a la columna **más corta** hasta ese momento, que es lo único que empareja las columnas y no depende de los datos del pedido.

- `components/masonry/` (`index.tsx`) + `hooks/use-masonry.ts`: mide las cards, las reparte, y re-mide con `ResizeObserver` y en cada resize de ventana. Responsive: 1 columna en mobile (mismo orden que antes), 2 desde `lg`, 3 desde `2xl`.
- `orders/show.tsx` pasa las cards como items del masonry; se sacó `lg:min-w-100` de las cinco cards (ahora el ancho lo fija la columna).

## Verificación

- 19 tests nuevos del masonry (algoritmo + componente), incluida la regresión de achicar la ventana hasta 1 columna.
- Chequeado en el navegador a 390 / 1024 / 1280 / 1536 / 1920 / 2560 px, en un pedido activo y en uno cancelado: columnas parejas, sin scroll horizontal y sin errores de consola al redimensionar.
- `validate-code --full` (220 vitest) y las 14 specs e2e en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)