### PR TITLE
fix(orders): mora mes a mes en el dashboard + date picker que guardaba un día menos

### DIFF
--- a/app/Http/Controllers/BO/DashboardController.php
+++ b/app/Http/Controllers/BO/DashboardController.php
@@ -68,13 +68,17 @@ class DashboardController extends Controller
             })
             ->map(fn ($group) => $group->count());
 
-        // Overdue orders: due date past, balance pending
+        // Overdue orders: paid less than the installments already due. The
+        // schedule runs month to month from the first due date, so a client
+        // who paid the first installment is up to date until the next one.
+        $today = now()->startOfDay();
+
         $overdueOrders = (clone $activeOrders)
             ->with('client', 'classroom.school')
             ->withSum('payments', 'amount')
-            ->where('due_date', '<', now()->startOfDay())
+            ->where('due_date', '<', $today)
             ->get()
-            ->filter(fn (Order $order) => ((int) $order->payments_sum_amount) < $order->total_price)
+            ->filter(fn (Order $order) => ((int) $order->payments_sum_amount) < $order->amountOverdue($today))
             ->sortBy('due_date')
             ->take(8)
             ->values()

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
 use Database\Factories\OrderFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -81,6 +82,47 @@ class Order extends Model
     public function balance(): int
     {
         return (int) $this->total_price - $this->paidTotal();
+    }
+
+    /**
+     * Installments whose due day already passed on the given date. The first
+     * one falls on `due_date` and each following one a month later, on the
+     * same day: 25/7, 25/8, 25/9…
+     *
+     * A due day that a shorter month lacks rolls over (31/1 → 3/3), so an
+     * order is never counted late before the day the seller picked.
+     */
+    public function overdueInstallments(CarbonInterface $on): int
+    {
+        $plan = (int) $this->payment_plan;
+        $day = $on->copy()->startOfDay();
+
+        $overdue = 0;
+
+        for ($month = 0; $month < $plan; $month++) {
+            if ($this->due_date->copy()->addMonths($month)->startOfDay()->greaterThanOrEqualTo($day)) {
+                break;
+            }
+
+            $overdue++;
+        }
+
+        return $overdue;
+    }
+
+    /**
+     * Amount the client should have paid by the given date: one installment
+     * per due day already passed.
+     */
+    public function amountOverdue(CarbonInterface $on): int
+    {
+        $plan = (int) $this->payment_plan;
+
+        if ($plan <= 0) {
+            return 0;
+        }
+
+        return (int) round((int) $this->total_price * $this->overdueInstallments($on) / $plan);
     }
 
     /**

--- a/resources/js/components/date-picker.test.tsx
+++ b/resources/js/components/date-picker.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DatePicker } from './date-picker';
+
+describe('DatePicker', () => {
+    it('shows the day it was given, not the one before', () => {
+        render(<DatePicker date="2026-07-25" setDate={vi.fn()} />);
+
+        expect(screen.getByText('25 de julio de 2026')).toBeTruthy();
+    });
+
+    it('falls back to the placeholder when there is no date', () => {
+        render(
+            <DatePicker date="" placeholder="Sin fecha" setDate={vi.fn()} />,
+        );
+
+        expect(screen.getByText('Sin fecha')).toBeTruthy();
+    });
+});

--- a/resources/js/components/date-picker.tsx
+++ b/resources/js/components/date-picker.tsx
@@ -6,7 +6,7 @@ import {
     PopoverTrigger,
 } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import { format } from 'date-fns';
+import { format, isValid, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { Calendar as CalendarIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -15,9 +15,21 @@ import { type DayPickerProps } from 'react-day-picker';
 
 type DatePickerProps = {
     placeholder?: string;
-    date: Date;
+    /** A `Date`, or the `yyyy-MM-dd` string the forms keep in their state. */
+    date: Date | string;
     setDate: (date: Date | undefined) => void;
     disabled?: DayPickerProps['disabled'];
+};
+
+/**
+ * `new Date('2026-07-25')` reads a date-only string as midnight UTC, which in
+ * Argentina (UTC−3) is the 24th at 21:00 — the picker showed the day before
+ * the one that was chosen. `parseISO` reads it in local time.
+ */
+const toLocalDate = (date: Date | string): Date | undefined => {
+    const parsed = typeof date === 'string' ? parseISO(date) : date;
+
+    return isValid(parsed) ? parsed : undefined;
 };
 
 export function DatePicker({
@@ -27,6 +39,7 @@ export function DatePicker({
     disabled,
 }: DatePickerProps) {
     const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+    const selected = toLocalDate(date);
 
     return (
         <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
@@ -35,19 +48,19 @@ export function DatePicker({
                     variant={'outline'}
                     className={cn(
                         'mt-1 w-full justify-start text-left font-normal',
-                        !date && 'text-muted-foreground',
+                        !selected && 'text-muted-foreground',
                     )}
                 >
                     <CalendarIcon className="mr-2 h-4 w-4" />
-                    {date
-                        ? format(date, 'PPP', { locale: es })
+                    {selected
+                        ? format(selected, 'PPP', { locale: es })
                         : placeholder && <span>{placeholder}</span>}
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0">
                 <Calendar
                     mode="single"
-                    selected={date}
+                    selected={selected}
                     onSelect={(day) => {
                         setDate(day);
                         setIsCalendarOpen(false);

--- a/resources/js/pages/orders/components/create-payment-modal.tsx
+++ b/resources/js/pages/orders/components/create-payment-modal.tsx
@@ -112,7 +112,7 @@ export function CreatePaymentModal({
                 <div className="mt-2">
                     <Label htmlFor="paid_on">Fecha de pago</Label>
                     <DatePicker
-                        date={new Date(data.paid_on)}
+                        date={data.paid_on}
                         setDate={(date) =>
                             setData(
                                 'paid_on',

--- a/resources/js/pages/orders/components/edit-order-step.tsx
+++ b/resources/js/pages/orders/components/edit-order-step.tsx
@@ -76,11 +76,7 @@ export function EditOrderStep({ form, orderId }: EditOrderStepProps) {
                     <div className="block">
                         <DatePicker
                             placeholder="Primer vencimiento"
-                            date={
-                                data.due_date
-                                    ? new Date(data.due_date)
-                                    : new Date()
-                            }
+                            date={data.due_date}
                             setDate={(date) =>
                                 setData(
                                     'due_date',

--- a/resources/js/pages/orders/components/edit-payment-modal.tsx
+++ b/resources/js/pages/orders/components/edit-payment-modal.tsx
@@ -110,7 +110,7 @@ export function EditPaymentModal({
                 <div className="mt-2">
                     <Label htmlFor="paid_on">Fecha de pago</Label>
                     <DatePicker
-                        date={new Date(data.paid_on)}
+                        date={data.paid_on}
                         setDate={(date) =>
                             setData(
                                 'paid_on',

--- a/resources/js/pages/orders/components/order-step.tsx
+++ b/resources/js/pages/orders/components/order-step.tsx
@@ -90,11 +90,7 @@ export function OrderStep({ form }: { form: OrderFormController }) {
                     <div className="block">
                         <DatePicker
                             placeholder="Primer vencimiento"
-                            date={
-                                data.due_date
-                                    ? new Date(data.due_date)
-                                    : new Date()
-                            }
+                            date={data.due_date}
                             setDate={(date) =>
                                 setData(
                                     'due_date',

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -67,3 +67,54 @@ it('does not list fully paid orders as overdue', function () {
         fn (Assert $page) => $page->has('overdueOrders', 0),
     );
 });
+
+it('does not list an order that paid every installment already due', function () {
+    actingAsRole();
+
+    // Venció la primera cuota; la segunda vence recién el mes que viene
+    $upToDate = Order::factory()->create([
+        'total_price' => 20000,
+        'payment_plan' => 4,
+        'due_date' => now()->subDays(10)->format('Y-m-d'),
+    ]);
+    Payment::factory()->create(['order_id' => $upToDate->id, 'amount' => 5000]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page->has('overdueOrders', 0),
+    );
+});
+
+it('lists an order that fell behind on a later installment', function () {
+    actingAsRole();
+
+    // Vencieron tres cuotas (mes a mes desde el primer vencimiento), pagó una
+    $behind = Order::factory()->create([
+        'total_price' => 20000,
+        'payment_plan' => 4,
+        'due_date' => now()->subMonths(2)->subDays(10)->format('Y-m-d'),
+    ]);
+    Payment::factory()->create(['order_id' => $behind->id, 'amount' => 5000]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('overdueOrders', 1)
+            ->where('overdueOrders.0.id', $behind->id)
+            ->where('overdueOrders.0.balance', 15000),
+    );
+});
+
+it('stops counting installments once the plan is complete', function () {
+    actingAsRole();
+
+    // Plan de 2 cuotas vencido hace un año: se debe el total, no más
+    $order = Order::factory()->create([
+        'total_price' => 10000,
+        'payment_plan' => 2,
+        'due_date' => now()->subYear()->format('Y-m-d'),
+    ]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 10000]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page->has('overdueOrders', 0),
+    );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     },
     test: {
         environment: 'jsdom',
+        // The app runs in Argentina (UTC−3): dates behave there, not in UTC
+        env: { TZ: 'America/Argentina/Buenos_Aires' },
         include: ['resources/js/**/*.test.{ts,tsx}'],
         setupFiles: ['resources/js/tests/setup.ts'],
     },


### PR DESCRIPTION
Closes #99.

## 1. Mora cuota a cuota en el dashboard

Antes, el dashboard marcaba vencido cualquier pedido con saldo apenas pasaba el **primer** vencimiento. Con el cronograma mes a mes eso es un falso positivo: quien pagó la cuota 1 en fecha está al día hasta la cuota 2.

- `Order::overdueInstallments()` cuenta los vencimientos ya pasados: el primero cae en `due_date` y los siguientes el mismo día de cada mes (25/7, 25/8, 25/9…). Un día que el mes más corto no tiene se corre (31/1 → 3/3), así que nunca se marca a nadie en mora antes del día que eligió el vendedor.
- `Order::amountOverdue()` traduce esas cuotas a plata y el dashboard lista el pedido solo si pagó menos que eso.
- No se persiste ningún cronograma: todo se deriva de `due_date` + `payment_plan`.

Tests: el que está al día no aparece, el que se atrasó en una cuota posterior sí, y el conteo se corta al completar el plan.

## 2. El date picker guardaba un día menos

En la reunión quedó anotado que no se podían elegir fines de semana. **No era eso** (no existe ni existió tal restricción): elegir el 25/7 dejaba el campo en 24/7, y lo mismo con cualquier día.

Causa: los pickers recibían su valor con `new Date('2026-07-25')`, que lee una fecha sin hora como medianoche **UTC** → en Argentina (UTC−3) cae el 24 a las 21:00. El valor enviado al backend era correcto, pero el botón y el día resaltado mostraban el día anterior.

- `DatePicker` ahora acepta el string `yyyy-MM-dd` que los formularios ya tienen en su estado y lo lee en hora local (`parseISO`).
- Los cuatro usos (alta y edición de pedido, alta y edición de pago) pasan el string directo, así que el bug no puede reaparecer por un quinto uso.
- Vitest corre con `TZ=America/Argentina/Buenos_Aires` para que las fechas se comporten como en producción; sin eso, el test del picker pasaría igual con el bug.
