### PR TITLE
feat(orders): búsqueda por teléfono + botón de WhatsApp

### DIFF
--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -14,20 +14,27 @@ use App\Http\Resources\OrderResource;
 use App\Models\Classroom;
 use App\Models\Order;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class ClassroomController extends Controller
 {
-    public function show(Classroom $classroom): Response
+    public function show(Request $request, Classroom $classroom): Response
     {
+        /** @var string|null $search */
+        $search = $request->query('search');
+
         $orders = Order::where('classroom_id', $classroom->id)
             ->with('client', 'products.type', 'classroom.school')
-            ->paginate(20);
+            ->search($search)
+            ->paginate(20)
+            ->withQueryString();
 
         return Inertia::render('classrooms/show', [
             'classroom' => $classroom->load('teacher', 'school'),
             'orders' => OrderResource::collection($orders),
+            'filters' => ['search' => $search],
         ]);
     }
 

--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -26,7 +26,7 @@ class OrderController extends Controller
 {
     public function index(Request $request): Response
     {
-        /** @var 'id' search */
+        /** @var string|null $search */
         $search = $request->query('search');
 
         /** @var string sort_by */
@@ -44,7 +44,7 @@ class OrderController extends Controller
             ->get();
 
         $orders = Order::with('client', 'products.type', 'classroom.school')
-            ->where('id', 'like', "%$search%")
+            ->search($search)
             ->whereHas('classroom', function ($query) use ($school_id) {
                 if (empty($school_id)) {
                     return $query;
@@ -53,11 +53,13 @@ class OrderController extends Controller
                 return $query->where('classrooms.school_id', $school_id);
             })
             ->orderBy($sort_by, $sort_order)
-            ->paginate(20);
+            ->paginate(20)
+            ->withQueryString();
 
         return Inertia::render('orders/index', [
             'orders' => OrderResource::collection($orders),
             'schools' => $schools,
+            'filters' => ['search' => $search],
         ]);
     }
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\Phone;
 use Carbon\CarbonInterface;
 use Database\Factories\OrderFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -22,6 +24,15 @@ class Order extends Model
     use HasFactory;
 
     use SoftDeletes;
+
+    /** Below this many digits a search term is an order number, not a phone. */
+    private const MIN_PHONE_DIGITS = 4;
+
+    /**
+     * Phones are stored as free text, so the column is stripped of its
+     * separators on the fly to be comparable with a normalized search term.
+     */
+    private const CLIENT_PHONE_DIGITS = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(clients.phone, ' ', ''), '-', ''), '(', ''), ')', ''), '+', ''), '.', '')";
 
     /**
      * @return BelongsTo<Client, $this>
@@ -72,6 +83,43 @@ class Order extends Model
     public function notes()
     {
         return $this->hasMany(Note::class)->latest();
+    }
+
+    /**
+     * Free-text search over the columns the order tables show: order number,
+     * child, client and — the WhatsApp use case — the client's phone, matched
+     * digit by digit so separators and the +549 prefix don't get in the way.
+     *
+     * The phone is only searched with at least MIN_PHONE_DIGITS digits, or a
+     * short numeric search (an order number) would match every phone
+     * containing those digits.
+     *
+     * @param  Builder<Order>  $query
+     * @return Builder<Order>
+     */
+    public function scopeSearch(Builder $query, ?string $term): Builder
+    {
+        $term = trim((string) $term);
+
+        if ($term === '') {
+            return $query;
+        }
+
+        $like = '%'.addcslashes($term, '%_\\').'%';
+        $digits = Phone::localDigits($term);
+        $phone = strlen($digits) >= self::MIN_PHONE_DIGITS ? '%'.$digits.'%' : null;
+
+        return $query->where(function (Builder $query) use ($like, $phone) {
+            $query->where('orders.id', 'like', $like)
+                ->orWhere('orders.child_name', 'like', $like)
+                ->orWhereHas('client', function (Builder $client) use ($like, $phone) {
+                    $client->where('clients.name', 'like', $like);
+
+                    if ($phone !== null) {
+                        $client->orWhereRaw(self::CLIENT_PHONE_DIGITS.' like ?', [$phone]);
+                    }
+                });
+        });
     }
 
     public function paidTotal(): int

--- a/app/Support/Phone.php
+++ b/app/Support/Phone.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Argentine phone numbers, as typed by humans. Mirrors the frontend
+ * `lib/whatsapp.ts` normalization so a number copied from WhatsApp
+ * (+54 9 380 400-0003) and the same number stored locally (3804000003)
+ * are comparable.
+ */
+class Phone
+{
+    /**
+     * The dialable part of a number: digits only, without the country code
+     * (54), the mobile 9, or the domestic trunk 0.
+     */
+    public static function localDigits(string $phone): string
+    {
+        $digits = preg_replace('/\D/', '', $phone) ?? '';
+
+        if (str_starts_with($digits, '549')) {
+            $digits = substr($digits, 3);
+        } elseif (str_starts_with($digits, '54')) {
+            $digits = substr($digits, 2);
+        }
+
+        if (str_starts_with($digits, '0')) {
+            $digits = substr($digits, 1);
+        }
+
+        return $digits;
+    }
+}

--- a/resources/js/features/highlight.test.tsx
+++ b/resources/js/features/highlight.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Highlight } from './highlight';
+
+describe('Highlight', () => {
+    it('marks the part of the text matching the search term', () => {
+        render(<Highlight text="Carla López" term="lopez" />);
+
+        expect(screen.getByText('López').tagName).toBe('MARK');
+        expect(screen.getByText('Carla', { exact: false })).toBeDefined();
+    });
+
+    it('marks nothing without a term', () => {
+        const { container } = render(<Highlight text="Carla López" />);
+
+        expect(container.querySelector('mark')).toBe(null);
+        expect(container.textContent).toBe('Carla López');
+    });
+
+    it('matches a phone digit by digit when asked to', () => {
+        const { container } = render(
+            <Highlight text="380 400-0003" term="+54 9 3804000003" phone />,
+        );
+
+        expect(container.querySelector('mark')?.textContent).toBe(
+            '380 400-0003',
+        );
+    });
+
+    it('does not treat a phone term as plain text', () => {
+        const { container } = render(
+            <Highlight text="380 400-0003" term="3804000003" />,
+        );
+
+        expect(container.querySelector('mark')).toBe(null);
+    });
+});

--- a/resources/js/features/highlight.tsx
+++ b/resources/js/features/highlight.tsx
@@ -1,0 +1,36 @@
+import { highlightPhoneSegments, highlightSegments } from '@/lib/highlight';
+
+interface HighlightProps {
+    text: string;
+    /** The active search term, as echoed back by the page's `filters`. */
+    term?: string | null;
+    /** Match the term digit by digit, ignoring separators and the +549 prefix. */
+    phone?: boolean;
+}
+
+/**
+ * Renders a table cell's text with the part matching the current search
+ * term marked, so the reason a row came up is visible at a glance.
+ */
+export function Highlight({ text, term, phone = false }: HighlightProps) {
+    const segments = phone
+        ? highlightPhoneSegments(text, term)
+        : highlightSegments(text, term);
+
+    return (
+        <>
+            {segments.map((segment, index) =>
+                segment.match ? (
+                    <mark
+                        key={index}
+                        className="rounded-sm bg-yellow-200 px-0.5 text-inherit dark:bg-yellow-500/40"
+                    >
+                        {segment.text}
+                    </mark>
+                ) : (
+                    <span key={index}>{segment.text}</span>
+                ),
+            )}
+        </>
+    );
+}

--- a/resources/js/features/phone-link.test.tsx
+++ b/resources/js/features/phone-link.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PhoneLink } from './phone-link';
+
+describe('PhoneLink', () => {
+    it('shows the phone with a link to its whatsapp chat', () => {
+        render(<PhoneLink phone="380 400-0003" />);
+
+        const link = screen.getByRole('link', {
+            name: 'Abrir chat de WhatsApp con 380 400-0003',
+        });
+
+        expect(link.getAttribute('href')).toBe('https://wa.me/5493804000003');
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(screen.getByText('380 400-0003')).toBeDefined();
+    });
+
+    it('shows a phone that cannot be dialed as plain text', () => {
+        render(<PhoneLink phone="1234" />);
+
+        expect(screen.queryByRole('link')).toBe(null);
+        expect(screen.getByText('1234')).toBeDefined();
+    });
+
+    it('shows nothing to call when there is no phone', () => {
+        render(<PhoneLink phone={null} />);
+
+        expect(screen.queryByRole('link')).toBe(null);
+        expect(screen.getByText('N/A')).toBeDefined();
+    });
+
+    it('marks the digits matching the search term', () => {
+        const { container } = render(
+            <PhoneLink phone="380 400-0003" term="4000003" />,
+        );
+
+        expect(container.querySelector('mark')?.textContent).toBe('400-0003');
+    });
+});

--- a/resources/js/features/phone-link.tsx
+++ b/resources/js/features/phone-link.tsx
@@ -1,0 +1,45 @@
+import { buttonVariants } from '@/components/ui/button';
+import { Highlight } from '@/features/highlight';
+import { cn } from '@/lib/utils';
+import { waChatUrl } from '@/lib/whatsapp';
+import { MessageCircle } from 'lucide-react';
+
+interface PhoneLinkProps {
+    phone?: string | null;
+    /** The active search term, so the matched digits show up marked. */
+    term?: string | null;
+}
+
+/**
+ * A client's phone with a button that opens their WhatsApp chat — the way
+ * the studio actually contacts people. Numbers that cannot be dialed
+ * (missing or too short) render as plain text, with no button.
+ */
+export function PhoneLink({ phone, term }: PhoneLinkProps) {
+    if (!phone) {
+        return <span className="text-muted-foreground">N/A</span>;
+    }
+
+    const chat = waChatUrl(phone);
+
+    return (
+        <span className="flex items-center gap-1 whitespace-nowrap">
+            <Highlight text={phone} term={term} phone />
+            {chat && (
+                <a
+                    href={chat}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`Abrir chat de WhatsApp con ${phone}`}
+                    aria-label={`Abrir chat de WhatsApp con ${phone}`}
+                    className={cn(
+                        buttonVariants({ size: 'icon', variant: 'ghost' }),
+                        'size-7 text-green-600 hover:text-green-700',
+                    )}
+                >
+                    <MessageCircle className="size-4" />
+                </a>
+            )}
+        </span>
+    );
+}

--- a/resources/js/features/searchbar.test.tsx
+++ b/resources/js/features/searchbar.test.tsx
@@ -1,0 +1,94 @@
+import { onSearch } from '@/lib/services/filter';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Searchbar } from './searchbar';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+}));
+
+const search = vi.mocked(onSearch);
+
+/** Let the 1s debounce elapse. */
+function settle() {
+    act(() => {
+        vi.advanceTimersByTime(1000);
+    });
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    search.mockClear();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('Searchbar', () => {
+    it('keeps showing the term already applied', () => {
+        render(<Searchbar indexRoute="orders.index" term="3804000003" />);
+
+        expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+            '3804000003',
+        );
+
+        settle();
+        expect(search).not.toHaveBeenCalled();
+    });
+
+    it('searches once the typed term settles', () => {
+        render(<Searchbar indexRoute="orders.index" />);
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: 'lopez' },
+        });
+        settle();
+
+        expect(search).toHaveBeenCalledWith('lopez', 'orders.index', undefined);
+    });
+
+    it('searches a single digit, which is an order number', () => {
+        render(<Searchbar indexRoute="orders.index" />);
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: '7' },
+        });
+        settle();
+
+        expect(search).toHaveBeenCalledWith('7', 'orders.index', undefined);
+    });
+
+    it('clears the filter when the input is emptied', () => {
+        render(<Searchbar indexRoute="orders.index" term="lopez" />);
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: '' },
+        });
+        settle();
+
+        expect(search).toHaveBeenCalledWith('', 'orders.index', undefined);
+    });
+
+    it('carries the route params of pages that are not plain indexes', () => {
+        render(
+            <Searchbar
+                indexRoute="classrooms.show"
+                routeParams={{ classroom: 4 }}
+            />,
+        );
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: 'lopez' },
+        });
+        settle();
+
+        expect(search).toHaveBeenCalledWith('lopez', 'classrooms.show', {
+            classroom: 4,
+        });
+    });
+});

--- a/resources/js/features/searchbar.tsx
+++ b/resources/js/features/searchbar.tsx
@@ -48,6 +48,8 @@ export function Searchbar({
                 placeholder={placeholder}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
+                // Room for the search icon sitting on top of the input
+                className="pr-10"
             />
             <div
                 className={cn(

--- a/resources/js/features/searchbar.tsx
+++ b/resources/js/features/searchbar.tsx
@@ -4,24 +4,48 @@ import { onSearch } from '@/lib/services/filter';
 import { cn } from '@/lib/utils';
 import { router } from '@inertiajs/react';
 import { FilterX, Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 
-export function Searchbar({ indexRoute }: { indexRoute: string }) {
-    const [search, setSearch] = useState('');
+interface SearchbarProps {
+    indexRoute: string;
+    /** Route params for pages that are not plain indexes (e.g. a classroom). */
+    routeParams?: Record<string, string | number>;
+    /** The term already applied, echoed back by the page, so it survives reloads. */
+    term?: string | null;
+    placeholder?: string;
+}
+
+export function Searchbar({
+    indexRoute,
+    routeParams,
+    term,
+    placeholder,
+}: SearchbarProps) {
+    const applied = term ?? '';
+    const [search, setSearch] = useState(applied);
     const [debouncedSearch] = useDebounce(search, 1000);
+    const requested = useRef(applied);
 
     useEffect(() => {
-        if (debouncedSearch.length < 3) return;
+        // Already the applied filter: nothing to do (this is also the mount case).
+        // Any other term is searched, however short: order numbers are 1-2 digits.
+        if (debouncedSearch === applied) return;
 
-        onSearch(debouncedSearch, indexRoute);
-    }, [debouncedSearch, indexRoute]);
+        // The visit preserves this component's state, so a re-render must not
+        // fire the same search again.
+        if (debouncedSearch === requested.current) return;
+
+        requested.current = debouncedSearch;
+        onSearch(debouncedSearch, indexRoute, routeParams);
+    }, [debouncedSearch, applied, indexRoute, routeParams]);
 
     return (
         <div className="relative flex gap-1">
             <Input
                 id="search"
                 name="search"
+                placeholder={placeholder}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
             />
@@ -39,7 +63,7 @@ export function Searchbar({ indexRoute }: { indexRoute: string }) {
             <Button
                 variant="outline"
                 size="icon"
-                onClick={() => router.get(route(indexRoute))}
+                onClick={() => router.get(route(indexRoute, routeParams))}
             >
                 <FilterX />
             </Button>

--- a/resources/js/lib/highlight.test.ts
+++ b/resources/js/lib/highlight.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { highlightPhoneSegments, highlightSegments } from './highlight';
+
+/** The matched parts, in order — what ends up inside a <mark>. */
+function matched(segments: { text: string; match: boolean }[]): string[] {
+    return segments.filter((segment) => segment.match).map(({ text }) => text);
+}
+
+describe('highlightSegments', () => {
+    it('marks the matching part of the text', () => {
+        expect(highlightSegments('Carla López', 'car')).toEqual([
+            { text: 'Car', match: true },
+            { text: 'la López', match: false },
+        ]);
+    });
+
+    it('matches without accents, as the database collation does', () => {
+        expect(matched(highlightSegments('Carla López', 'lopez'))).toEqual([
+            'López',
+        ]);
+    });
+
+    it('marks every occurrence', () => {
+        expect(matched(highlightSegments('Ana Anabel', 'ana'))).toEqual([
+            'Ana',
+            'Ana',
+        ]);
+    });
+
+    it('leaves the text untouched without a term', () => {
+        expect(highlightSegments('Carla López', null)).toEqual([
+            { text: 'Carla López', match: false },
+        ]);
+        expect(highlightSegments('Carla López', '  ')).toEqual([
+            { text: 'Carla López', match: false },
+        ]);
+    });
+
+    it('marks nothing when the term does not appear', () => {
+        expect(matched(highlightSegments('Carla López', 'mateo'))).toEqual([]);
+    });
+});
+
+describe('highlightPhoneSegments', () => {
+    it('marks the matched digits inside a phone stored with separators', () => {
+        expect(
+            highlightPhoneSegments('380 400-0003', '+54 9 380 400-0003'),
+        ).toEqual([{ text: '380 400-0003', match: true }]);
+    });
+
+    it('marks a partial match, spanning the separators it crosses', () => {
+        expect(
+            matched(highlightPhoneSegments('380 400-0003', '4000003')),
+        ).toEqual(['400-0003']);
+    });
+
+    it('ignores the country code and the trunk zero, as the search does', () => {
+        expect(
+            matched(highlightPhoneSegments('3804000003', '03804000003')),
+        ).toEqual(['3804000003']);
+    });
+
+    it('marks nothing when the digits do not match', () => {
+        expect(
+            matched(highlightPhoneSegments('3804000003', '3804111111')),
+        ).toEqual([]);
+    });
+
+    it('leaves the phone untouched without a term', () => {
+        expect(highlightPhoneSegments('3804000003', '')).toEqual([
+            { text: '3804000003', match: false },
+        ]);
+    });
+
+    it('leaves the phone untouched when the term has no digits', () => {
+        expect(highlightPhoneSegments('3804000003', 'carla')).toEqual([
+            { text: '3804000003', match: false },
+        ]);
+    });
+});

--- a/resources/js/lib/highlight.ts
+++ b/resources/js/lib/highlight.ts
@@ -1,0 +1,105 @@
+import { localPhoneDigits } from '@/lib/whatsapp';
+
+export interface HighlightSegment {
+    text: string;
+    match: boolean;
+}
+
+/** Lowercase and strip accents, so "lopez" matches "López" as the DB does. */
+function fold(text: string): string {
+    return text
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '');
+}
+
+function segments(
+    text: string,
+    ranges: [number, number][],
+): HighlightSegment[] {
+    const result: HighlightSegment[] = [];
+    let cursor = 0;
+
+    for (const [start, end] of ranges) {
+        if (start > cursor) {
+            result.push({ text: text.slice(cursor, start), match: false });
+        }
+
+        result.push({ text: text.slice(start, end), match: true });
+        cursor = end;
+    }
+
+    if (cursor < text.length) {
+        result.push({ text: text.slice(cursor), match: false });
+    }
+
+    return result;
+}
+
+/**
+ * Splits `text` into segments, marking the ones that match the search term.
+ * Matching mirrors the backend search: case and accent insensitive.
+ */
+export function highlightSegments(
+    text: string,
+    term: string | null | undefined,
+): HighlightSegment[] {
+    const needle = fold(term?.trim() ?? '');
+
+    if (!needle) {
+        return [{ text, match: false }];
+    }
+
+    const haystack = fold(text);
+    const ranges: [number, number][] = [];
+
+    let from = 0;
+    let found = haystack.indexOf(needle, from);
+
+    while (found !== -1) {
+        ranges.push([found, found + needle.length]);
+        from = found + needle.length;
+        found = haystack.indexOf(needle, from);
+    }
+
+    return segments(text, ranges);
+}
+
+/**
+ * Same, for a phone: the term is matched digit by digit (the backend ignores
+ * separators and the +549 prefix), so the highlight has to map the matched
+ * digits back onto the original string — searching "+54 9 380 400-0003"
+ * highlights "380 400-0003" inside a phone stored with its separators.
+ */
+export function highlightPhoneSegments(
+    phone: string,
+    term: string | null | undefined,
+): HighlightSegment[] {
+    const needle = localPhoneDigits(term?.trim() ?? '');
+
+    if (!needle) {
+        return [{ text: phone, match: false }];
+    }
+
+    // Position of every digit of `phone` within `phone` itself.
+    const positions: number[] = [];
+    let digits = '';
+
+    for (let index = 0; index < phone.length; index++) {
+        if (/\d/.test(phone[index])) {
+            digits += phone[index];
+            positions.push(index);
+        }
+    }
+
+    const at = digits.indexOf(needle);
+
+    if (at === -1) {
+        return [{ text: phone, match: false }];
+    }
+
+    const start = positions[at];
+    const end = positions[at + needle.length - 1] + 1;
+
+    return segments(phone, [[start, end]]);
+}

--- a/resources/js/lib/services/filter.ts
+++ b/resources/js/lib/services/filter.ts
@@ -1,14 +1,25 @@
 import { router } from '@inertiajs/react';
 
-export function onSearch(searchTerm: string, indexRoute: string) {
+export function onSearch(
+    searchTerm: string,
+    indexRoute: string,
+    routeParams?: Record<string, string | number>,
+) {
     const query = route().queryParams;
     delete query.search;
+    delete query.page;
 
     if (searchTerm) {
         query.search = searchTerm;
     }
 
-    router.get(route(indexRoute), query);
+    // The search fires while typing: remounting the page would take the focus
+    // away from the input mid-word, so the visit reuses the mounted components.
+    router.get(route(indexRoute, routeParams), query, {
+        preserveState: true,
+        preserveScroll: true,
+        replace: true,
+    });
 }
 
 export function onSort(sort_by: string, indexRoute: string) {

--- a/resources/js/lib/whatsapp.test.ts
+++ b/resources/js/lib/whatsapp.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeArPhone, waShareUrl } from './whatsapp';
+import {
+    localPhoneDigits,
+    normalizeArPhone,
+    waChatUrl,
+    waShareUrl,
+} from './whatsapp';
+
+describe('localPhoneDigits', () => {
+    it('keeps only the dialable digits', () => {
+        expect(localPhoneDigits('380 412-3456')).toBe('3804123456');
+        expect(localPhoneDigits('+54 9 380 412-3456')).toBe('3804123456');
+        expect(localPhoneDigits('543804123456')).toBe('3804123456');
+        expect(localPhoneDigits('03804123456')).toBe('3804123456');
+    });
+
+    it('is empty when the text has no digits', () => {
+        expect(localPhoneDigits('sin teléfono')).toBe('');
+    });
+});
+
+describe('waChatUrl', () => {
+    it('links to the chat with that number', () => {
+        expect(waChatUrl('380 412-3456')).toBe('https://wa.me/5493804123456');
+    });
+
+    it('is null when the number cannot be dialed', () => {
+        expect(waChatUrl(null)).toBe(null);
+        expect(waChatUrl('')).toBe(null);
+        expect(waChatUrl('1234')).toBe(null);
+    });
+});
 
 describe('normalizeArPhone', () => {
     it('prefixes local numbers with the mobile country code', () => {

--- a/resources/js/lib/whatsapp.ts
+++ b/resources/js/lib/whatsapp.ts
@@ -1,16 +1,14 @@
 /**
- * Normalizes a locally-stored Argentine phone number to the
- * international digits-only format WhatsApp links expect (549...).
- * Returns null when the number is too short to be dialable.
+ * The dialable part of a phone number: digits only, without the country code
+ * (54), the mobile 9, or the domestic trunk 0. Mirrors the backend
+ * `App\Support\Phone::localDigits()`, which the order search normalizes with.
  */
-export function normalizeArPhone(phone: string): string | null {
+export function localPhoneDigits(phone: string): string {
     let digits = phone.replace(/\D/g, '');
 
     if (digits.startsWith('549')) {
-        return digits.length >= 11 ? digits : null;
-    }
-
-    if (digits.startsWith('54')) {
+        digits = digits.slice(3);
+    } else if (digits.startsWith('54')) {
         digits = digits.slice(2);
     }
 
@@ -18,11 +16,32 @@ export function normalizeArPhone(phone: string): string | null {
         digits = digits.slice(1);
     }
 
+    return digits;
+}
+
+/**
+ * Normalizes a locally-stored Argentine phone number to the
+ * international digits-only format WhatsApp links expect (549...).
+ * Returns null when the number is too short to be dialable.
+ */
+export function normalizeArPhone(phone: string): string | null {
+    const digits = localPhoneDigits(phone);
+
     if (digits.length < 8) {
         return null;
     }
 
     return `549${digits}`;
+}
+
+/**
+ * wa.me link to the chat with that number, or null when the number is
+ * missing or too short to be dialable.
+ */
+export function waChatUrl(phone: string | null | undefined): string | null {
+    const normalized = phone ? normalizeArPhone(phone) : null;
+
+    return normalized ? `https://wa.me/${normalized}` : null;
 }
 
 /**

--- a/resources/js/pages/classrooms/components/students-table.tsx
+++ b/resources/js/pages/classrooms/components/students-table.tsx
@@ -1,0 +1,99 @@
+import { buttonVariants } from '@/components/ui/button';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { Highlight } from '@/features/highlight';
+import { PhoneLink } from '@/features/phone-link';
+import { cn, formatPrice } from '@/lib/utils';
+import { Link } from '@inertiajs/react';
+
+interface StudentsTableProps {
+    orders: Order[];
+    /** The applied search term, marked in the columns it matched. */
+    search?: string | null;
+}
+
+export function StudentsTable({ orders, search }: StudentsTableProps) {
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead className="w-25">#</TableHead>
+                    <TableHead>Nombre del Niño</TableHead>
+                    <TableHead>Cliente</TableHead>
+                    <TableHead>Teléfono</TableHead>
+                    <TableHead>Productos</TableHead>
+                    <TableHead>Precio</TableHead>
+                    <TableHead>Cuotas</TableHead>
+                    <TableHead>Vencimiento</TableHead>
+                    <TableHead>Acción</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {orders.map((order) => (
+                    <TableRow key={order.id}>
+                        <TableCell className="font-medium">
+                            <Highlight text={String(order.id)} term={search} />
+                        </TableCell>
+                        <TableCell>
+                            {order.child_name ? (
+                                <Highlight
+                                    text={order.child_name}
+                                    term={search}
+                                />
+                            ) : (
+                                'N/A'
+                            )}
+                        </TableCell>
+                        <TableCell>
+                            {order.client.name ? (
+                                <Highlight
+                                    text={order.client.name}
+                                    term={search}
+                                />
+                            ) : (
+                                'Sin especificar'
+                            )}
+                        </TableCell>
+                        <TableCell>
+                            <PhoneLink
+                                phone={order.client.phone}
+                                term={search}
+                            />
+                        </TableCell>
+                        <TableCell>{order.products.length}</TableCell>
+                        <TableCell>{formatPrice(order.total_price)}</TableCell>
+                        <TableCell>
+                            {order.payment_plan} (
+                            {formatPrice(
+                                order.total_price / order.payment_plan,
+                            )}
+                            )
+                        </TableCell>
+                        <TableCell>{order.due_date}</TableCell>
+                        <TableCell>
+                            <Link
+                                className={cn(
+                                    buttonVariants({
+                                        size: 'sm',
+                                        variant: 'outline',
+                                    }),
+                                )}
+                                href={route('orders.show', {
+                                    order: order.id,
+                                })}
+                            >
+                                Ver
+                            </Link>
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+}

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -97,7 +97,7 @@ export default function ClassroomShow({
                         indexRoute="classrooms.show"
                         routeParams={{ classroom: classroom.id }}
                         term={filters.search}
-                        placeholder="Buscar por #, nombre o teléfono"
+                        placeholder="N°, nombre o teléfono"
                     />
                 </div>
 

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -5,26 +5,22 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table';
+import { Searchbar } from '@/features/searchbar';
 import AppLayout from '@/layouts/app-layout';
-import { cn, formatPrice } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/react';
 import { ArrowLeft, ImagePlus } from 'lucide-react';
+import { StudentsTable } from './components/students-table';
 
 export default function ClassroomShow({
     classroom,
     orders,
+    filters,
 }: PageProps<{
     classroom: Classroom & { teacher?: Teacher; school: School };
     orders: Paginated<Order>;
+    filters: { search: string | null };
 }>) {
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -96,75 +92,27 @@ export default function ClassroomShow({
                     </Link>
                 </div>
 
+                <div className="mb-4">
+                    <Searchbar
+                        indexRoute="classrooms.show"
+                        routeParams={{ classroom: classroom.id }}
+                        term={filters.search}
+                        placeholder="Buscar por #, nombre o teléfono"
+                    />
+                </div>
+
                 {orders.data.length > 0 ? (
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead className="w-25">#</TableHead>
-                                <TableHead>Nombre del Niño</TableHead>
-                                <TableHead>Cliente</TableHead>
-                                <TableHead>Teléfono</TableHead>
-                                <TableHead>Productos</TableHead>
-                                <TableHead>Precio</TableHead>
-                                <TableHead>Cuotas</TableHead>
-                                <TableHead>Vencimiento</TableHead>
-                                <TableHead>Acción</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {orders.data.map((order) => (
-                                <TableRow key={order.id}>
-                                    <TableCell className="font-medium">
-                                        {order.id}
-                                    </TableCell>
-                                    <TableCell>
-                                        {order.child_name || 'N/A'}
-                                    </TableCell>
-                                    <TableCell>
-                                        {order.client.name || 'Sin especificar'}
-                                    </TableCell>
-                                    <TableCell>
-                                        {order.client.phone || 'N/A'}
-                                    </TableCell>
-                                    <TableCell>
-                                        {order.products.length}
-                                    </TableCell>
-                                    <TableCell>
-                                        {formatPrice(order.total_price)}
-                                    </TableCell>
-                                    <TableCell>
-                                        {order.payment_plan} (
-                                        {formatPrice(
-                                            order.total_price /
-                                                order.payment_plan,
-                                        )}
-                                        )
-                                    </TableCell>
-                                    <TableCell>{order.due_date}</TableCell>
-                                    <TableCell>
-                                        <Link
-                                            className={cn(
-                                                buttonVariants({
-                                                    size: 'sm',
-                                                    variant: 'outline',
-                                                }),
-                                            )}
-                                            href={route('orders.show', {
-                                                order: order.id,
-                                            })}
-                                        >
-                                            Ver
-                                        </Link>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
+                    <StudentsTable
+                        orders={orders.data}
+                        search={filters.search}
+                    />
                 ) : (
                     <Card>
                         <CardHeader>
                             <CardDescription className="text-center">
-                                No hay alumnos registrados en este curso
+                                {filters.search
+                                    ? 'Ningún alumno coincide con la búsqueda'
+                                    : 'No hay alumnos registrados en este curso'}
                             </CardDescription>
                         </CardHeader>
                     </Card>

--- a/resources/js/pages/orders/components/order-info-card.tsx
+++ b/resources/js/pages/orders/components/order-info-card.tsx
@@ -7,6 +7,7 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import { PhoneLink } from '@/features/phone-link';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
 import { Ban, Edit2 } from 'lucide-react';
@@ -73,6 +74,9 @@ export function OrderInfoCard({ order, onCancel }: OrderInfoCardProps) {
                         </Badge>
                     )}
                 </CardTitle>
+                <CardDescription className="flex items-center gap-1">
+                    <PhoneLink phone={order.client.phone} />
+                </CardDescription>
                 <CardDescription>
                     {`Pedido #${order.id}`}
                     {order.child_name ? ` · Niño/a: ${order.child_name}` : ''}

--- a/resources/js/pages/orders/components/orders-table.test.tsx
+++ b/resources/js/pages/orders/components/orders-table.test.tsx
@@ -113,11 +113,51 @@ describe('OrdersTable', () => {
         render(<OrdersTable orders={[]} onDelete={vi.fn()} />);
 
         const headers = screen.getAllByRole('columnheader');
+        const header = (name: string) =>
+            headers.find((columnheader) =>
+                columnheader.textContent?.includes(name),
+            )!;
 
-        fireEvent.click(within(headers[0]).getByRole('button'));
+        fireEvent.click(within(header('#')).getByRole('button'));
         expect(sort).toHaveBeenCalledWith('id', 'orders.index');
 
-        fireEvent.click(within(headers[3]).getByRole('button'));
+        fireEvent.click(within(header('Precio')).getByRole('button'));
         expect(sort).toHaveBeenCalledWith('total_price', 'orders.index');
+    });
+
+    it('shows the client phone with a link to their whatsapp chat', () => {
+        render(
+            <OrdersTable
+                orders={[
+                    makeOrder({
+                        client: { name: 'Marta López', phone: '3804000003' },
+                    }),
+                ]}
+                onDelete={vi.fn()}
+            />,
+        );
+
+        const row = screen.getAllByRole('row')[1];
+        const chat = within(row).getByRole('link', {
+            name: 'Abrir chat de WhatsApp con 3804000003',
+        });
+
+        expect(chat.getAttribute('href')).toBe('https://wa.me/5493804000003');
+    });
+
+    it('marks the searched phone in the row it matched', () => {
+        const { container } = render(
+            <OrdersTable
+                orders={[
+                    makeOrder({
+                        client: { name: 'Marta López', phone: '3804000003' },
+                    }),
+                ]}
+                search="+54 9 3804000003"
+                onDelete={vi.fn()}
+            />,
+        );
+
+        expect(container.querySelector('mark')?.textContent).toBe('3804000003');
     });
 });

--- a/resources/js/pages/orders/components/orders-table.tsx
+++ b/resources/js/pages/orders/components/orders-table.tsx
@@ -7,6 +7,8 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
+import { Highlight } from '@/features/highlight';
+import { PhoneLink } from '@/features/phone-link';
 import { onSort } from '@/lib/services/filter';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
@@ -14,10 +16,12 @@ import { ArrowUpDown, Eye, Trash } from 'lucide-react';
 
 interface OrdersTableProps {
     orders: Order[];
+    /** The applied search term, marked in the columns it matched. */
+    search?: string | null;
     onDelete: (order: Order) => void;
 }
 
-export function OrdersTable({ orders, onDelete }: OrdersTableProps) {
+export function OrdersTable({ orders, search, onDelete }: OrdersTableProps) {
     return (
         <Table>
             <TableHeader>
@@ -33,6 +37,7 @@ export function OrdersTable({ orders, onDelete }: OrdersTableProps) {
                         </div>
                     </TableHead>
                     <TableHead>Cliente</TableHead>
+                    <TableHead>Teléfono</TableHead>
                     <TableHead>Productos</TableHead>
                     <TableHead>
                         <div className="flex items-center gap-2">
@@ -56,10 +61,16 @@ export function OrdersTable({ orders, onDelete }: OrdersTableProps) {
                 {orders.map((order) => (
                     <TableRow key={order.id}>
                         <TableCell className="font-medium">
-                            {order.id}
+                            <Highlight text={String(order.id)} term={search} />
                         </TableCell>
-                        <TableCell className="flex gap-2">
-                            {order.client.name}
+                        <TableCell>
+                            <Highlight text={order.client.name} term={search} />
+                        </TableCell>
+                        <TableCell>
+                            <PhoneLink
+                                phone={order.client.phone}
+                                term={search}
+                            />
                         </TableCell>
                         <TableCell>{order.products.length}</TableCell>
                         <TableCell>{formatPrice(order.total_price)}</TableCell>

--- a/resources/js/pages/orders/index.tsx
+++ b/resources/js/pages/orders/index.tsx
@@ -21,7 +21,12 @@ const breadcrumbs: BreadcrumbItem[] = [
 export default function Orders({
     orders,
     schools,
-}: PageProps<{ orders: Paginated<Order>; schools: School[] }>) {
+    filters,
+}: PageProps<{
+    orders: Paginated<Order>;
+    schools: School[];
+    filters: { search: string | null };
+}>) {
     const params = new URLSearchParams(window.location.search);
 
     const [comboDropdownOpen, setComboDropdownOpen] = useState(false);
@@ -44,7 +49,11 @@ export default function Orders({
 
             <section className="p-6">
                 <div className="mb-4 flex flex-wrap gap-4">
-                    <Searchbar indexRoute="orders.index" />
+                    <Searchbar
+                        indexRoute="orders.index"
+                        term={filters.search}
+                        placeholder="Buscar por #, nombre o teléfono"
+                    />
                     <Combobox
                         items={schools.map((school) => ({
                             label: school.name,
@@ -83,6 +92,7 @@ export default function Orders({
 
                 <OrdersTable
                     orders={orders.data}
+                    search={filters.search}
                     onDelete={setDeleteableOrder}
                 />
 

--- a/resources/js/pages/orders/index.tsx
+++ b/resources/js/pages/orders/index.tsx
@@ -52,7 +52,7 @@ export default function Orders({
                     <Searchbar
                         indexRoute="orders.index"
                         term={filters.search}
-                        placeholder="Buscar por #, nombre o teléfono"
+                        placeholder="N°, nombre o teléfono"
                     />
                     <Combobox
                         items={schools.map((school) => ({

--- a/tests/Feature/OrderSearchTest.php
+++ b/tests/Feature/OrderSearchTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Classroom;
+use App\Models\Client;
+use App\Models\Order;
+
+use function Pest\Laravel\get;
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function orderFor(string $clientName, string $phone, array $attributes = []): Order
+{
+    $client = Client::factory()->create(['name' => $clientName, 'phone' => $phone]);
+
+    return Order::factory()->create([...$attributes, 'client_id' => $client->id]);
+}
+
+/**
+ * @return array<int, int>
+ */
+function searchedOrderIds(string $term, ?Classroom $classroom = null): array
+{
+    $route = $classroom === null
+        ? route('orders.index', ['search' => $term])
+        : route('classrooms.show', ['classroom' => $classroom->id, 'search' => $term]);
+
+    $response = get($route);
+    $response->assertOk();
+
+    /** @var array<int, array<string, mixed>> $orders */
+    $orders = $response->viewData('page')['props']['orders']['data'];
+
+    return array_map(fn (array $order) => (int) $order['id'], $orders);
+}
+
+beforeEach(function () {
+    actingAsRole();
+});
+
+it('finds an order by the client phone', function () {
+    $order = orderFor('Carla López', '3804000003');
+    orderFor('Otro Cliente', '3804999999');
+
+    expect(searchedOrderIds('3804000003'))->toBe([$order->id]);
+});
+
+it('finds an order by a phone typed as it arrives from whatsapp', function (string $term) {
+    $order = orderFor('Carla López', '3804000003');
+    orderFor('Otro Cliente', '3804999999');
+
+    expect(searchedOrderIds($term))->toBe([$order->id]);
+})->with([
+    'international' => '+54 9 380 400-0003',
+    'country code' => '543804000003',
+    'trunk zero' => '03804000003',
+    'last digits' => '000003',
+]);
+
+it('finds an order whose phone is stored with separators', function () {
+    $order = orderFor('Carla López', '380 400-0003');
+
+    expect(searchedOrderIds('3804000003'))->toBe([$order->id]);
+});
+
+it('finds an order by the client name, case and accent insensitive', function (string $term) {
+    $order = orderFor('Carla López', '3804000003');
+    orderFor('Otro Cliente', '3804999999');
+
+    expect(searchedOrderIds($term))->toBe([$order->id]);
+})->with([
+    'lowercase' => 'carla',
+    'without accent' => 'lopez',
+]);
+
+it('finds an order by the child name', function () {
+    $order = orderFor('Carla López', '3804000003', ['child_name' => 'Joaquín Pérez']);
+    orderFor('Otro Cliente', '3804999999', ['child_name' => 'Mateo Díaz']);
+
+    expect(searchedOrderIds('Joaquín'))->toBe([$order->id]);
+});
+
+it('still finds an order by its number', function () {
+    $order = orderFor('Carla López', '3804000003');
+
+    expect(searchedOrderIds((string) $order->id))->toContain($order->id);
+});
+
+it('does not match phones on a short numeric term, which is an order number', function () {
+    orderFor('Carla López', '3804380999');
+
+    expect(searchedOrderIds('380'))->toBe([]);
+});
+
+it('returns nothing when no order matches', function () {
+    orderFor('Carla López', '3804000003');
+
+    expect(searchedOrderIds('3804111111'))->toBe([]);
+});
+
+it('keeps the classroom search scoped to its classroom', function () {
+    $classroom = Classroom::factory()->create();
+    $other = Classroom::factory()->create();
+
+    $order = orderFor('Carla López', '3804000003', ['classroom_id' => $classroom->id]);
+    orderFor('Carla López', '3804000003', ['classroom_id' => $other->id]);
+
+    expect(searchedOrderIds('3804000003', $classroom))->toBe([$order->id]);
+});
+
+it('echoes the search term back to the page', function () {
+    orderFor('Carla López', '3804000003');
+
+    get(route('orders.index', ['search' => '3804000003']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('filters.search', '3804000003'));
+});


### PR DESCRIPTION
Closes #103

Cuando llega un mensaje por WhatsApp, el pedido ahora se encuentra desde el número de teléfono, y desde cualquier teléfono que se muestre se abre el chat con esa persona.

## Búsqueda

- La búsqueda de /orders sale del controlador y pasa a `Order::scopeSearch`, que matchea **número de pedido, nombre del cliente, nombre del niño y teléfono**. El curso (`/classrooms/{id}`) reutiliza el mismo scope y estrena buscador (antes no tenía).
- El teléfono se compara **dígito a dígito** (`App\Support\Phone`, espejo de `lib/whatsapp.ts`): un número pegado desde WhatsApp (`+54 9 380 400-0003`) encuentra al cliente guardado como `3804000003`, y al revés. Los separadores con los que esté guardado el teléfono tampoco molestan. Con menos de 4 dígitos no se busca por teléfono: eso es un número de pedido, no un celular.
- El término aplicado vuelve a la página (`filters.search`), así sobrevive a la recarga.
- El buscador ya no ignora términos de 1-2 caracteres (los números de pedido lo son) y **no pierde el foco mientras se tipea** (la visita preserva el estado).

## WhatsApp y resaltado

- `PhoneLink`: cada teléfono que se muestra viene con un botón que abre el chat de WhatsApp (wa.me, reusa la normalización de #51). Si el número no se puede discar, se muestra como texto plano, sin botón. Está en /orders (columna nueva **Teléfono**), en el detalle del pedido y en la tabla de alumnos del curso.
- `Highlight`: se marca la parte de cada celda que coincide con la búsqueda — sin acentos ni mayúsculas para los nombres, y dígito a dígito para los teléfonos (buscar `+54 9 380 400-0003` resalta `380 400-0003` aunque esté guardado con separadores).
- La tabla de alumnos del curso se extrajo de la página a su propio componente.

## Verificación

- Backend: 14 tests nuevos (teléfono exacto, con separadores, con `+549`, por nombre sin acento, por niño, por número de pedido, búsqueda del curso acotada al curso).
- Frontend: tests de `highlight`, `waChatUrl`, `PhoneLink`, `Highlight`, `Searchbar` y la tabla de pedidos.
- En el navegador (mobile 320/351/390): sin scroll horizontal de página con la columna nueva, el foco se mantiene al tipear, la búsqueda de un dígito trae el pedido y el botón de WhatsApp abre `wa.me/5493804000003`.
- `validate-code --full` + e2e 14/14 en verde.