### PR TITLE
feat(orders): filtros por escuela y curso + botones "ver pedidos"

### DIFF
--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -35,8 +35,8 @@ class OrderController extends Controller
         /** @var 'asc'|'desc' sort_order */
         $sort_order = $request->query('sort_order') ?? 'asc';
 
-        /** @var int|null $school_id */
-        $school_id = $request->query('school_id');
+        $school_id = $request->filled('school_id') ? $request->integer('school_id') : null;
+        $classroom_id = $request->filled('classroom_id') ? $request->integer('classroom_id') : null;
 
         $schools = School::query()
             ->with(['classrooms'])
@@ -45,13 +45,8 @@ class OrderController extends Controller
 
         $orders = Order::with('client', 'products.type', 'classroom.school')
             ->search($search)
-            ->whereHas('classroom', function ($query) use ($school_id) {
-                if (empty($school_id)) {
-                    return $query;
-                }
-
-                return $query->where('classrooms.school_id', $school_id);
-            })
+            ->forSchool($school_id)
+            ->forClassroom($classroom_id)
             ->orderBy($sort_by, $sort_order)
             ->paginate(20)
             ->withQueryString();
@@ -59,7 +54,11 @@ class OrderController extends Controller
         return Inertia::render('orders/index', [
             'orders' => OrderResource::collection($orders),
             'schools' => $schools,
-            'filters' => ['search' => $search],
+            'filters' => [
+                'search' => $search,
+                'school_id' => $school_id,
+                'classroom_id' => $classroom_id,
+            ],
         ]);
     }
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -122,6 +122,34 @@ class Order extends Model
         });
     }
 
+    /**
+     * @param  Builder<Order>  $query
+     * @return Builder<Order>
+     */
+    public function scopeForSchool(Builder $query, ?int $schoolId): Builder
+    {
+        if ($schoolId === null) {
+            return $query;
+        }
+
+        return $query->whereHas('classroom', function (Builder $classroom) use ($schoolId) {
+            $classroom->where('classrooms.school_id', $schoolId);
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     * @return Builder<Order>
+     */
+    public function scopeForClassroom(Builder $query, ?int $classroomId): Builder
+    {
+        if ($classroomId === null) {
+            return $query;
+        }
+
+        return $query->where('orders.classroom_id', $classroomId);
+    }
+
     public function paidTotal(): int
     {
         return (int) $this->payments()->sum('amount');

--- a/resources/js/lib/services/filter.test.ts
+++ b/resources/js/lib/services/filter.test.ts
@@ -1,0 +1,61 @@
+import { router } from '@inertiajs/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { onFilter } from './filter';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+}));
+
+const get = vi.mocked(router.get);
+
+/** Stub route() so it echoes the current query params of the page. */
+function stubQueryParams(params: Record<string, string>) {
+    vi.stubGlobal('route', (name?: string) =>
+        name === undefined
+            ? { queryParams: { ...params } }
+            : `http://localhost/${name}`,
+    );
+}
+
+beforeEach(() => {
+    get.mockClear();
+});
+
+describe('onFilter', () => {
+    it('applies the given filters as query params', () => {
+        stubQueryParams({});
+
+        onFilter({ school_id: 7 }, 'orders.index');
+
+        expect(get).toHaveBeenCalledWith('http://localhost/orders.index', {
+            school_id: '7',
+        });
+    });
+
+    it('preserves the other params but leaves the page behind', () => {
+        stubQueryParams({
+            search: 'carla',
+            sort_by: 'id',
+            page: '3',
+            school_id: '1',
+        });
+
+        onFilter({ school_id: 2 }, 'orders.index');
+
+        expect(get).toHaveBeenCalledWith('http://localhost/orders.index', {
+            search: 'carla',
+            sort_by: 'id',
+            school_id: '2',
+        });
+    });
+
+    it('clears a filter passed as null', () => {
+        stubQueryParams({ school_id: '1', classroom_id: '10' });
+
+        onFilter({ school_id: 2, classroom_id: null }, 'orders.index');
+
+        expect(get).toHaveBeenCalledWith('http://localhost/orders.index', {
+            school_id: '2',
+        });
+    });
+});

--- a/resources/js/lib/services/filter.ts
+++ b/resources/js/lib/services/filter.ts
@@ -22,6 +22,24 @@ export function onSearch(
     });
 }
 
+export function onFilter(
+    filters: Record<string, string | number | null>,
+    indexRoute: string,
+) {
+    const query = route().queryParams;
+    delete query.page;
+
+    for (const [key, value] of Object.entries(filters)) {
+        delete query[key];
+
+        if (value !== null && value !== '') {
+            query[key] = String(value);
+        }
+    }
+
+    router.get(route(indexRoute), query);
+}
+
 export function onSort(sort_by: string, indexRoute: string) {
     const sort_order =
         route().queryParams.sort_order === 'desc' ? 'asc' : 'desc';

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -10,7 +10,7 @@ import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/react';
-import { ArrowLeft, ImagePlus } from 'lucide-react';
+import { ArrowLeft, ImagePlus, ShoppingCart } from 'lucide-react';
 import { StudentsTable } from './components/students-table';
 
 export default function ClassroomShow({
@@ -43,20 +43,35 @@ export default function ClassroomShow({
 
             <section className="px-6 pt-6">
                 <Card className="relative max-w-106.25">
-                    <Link
-                        href={route('schools.show', {
-                            school: classroom.school.id,
-                        })}
-                        className={cn(
-                            'absolute top-4 right-4',
-                            buttonVariants({
-                                size: 'sm',
-                                variant: 'outline',
-                            }),
-                        )}
-                    >
-                        <ArrowLeft />
-                    </Link>
+                    <div className="absolute top-4 right-4 flex gap-2">
+                        <Link
+                            href={route('orders.index', {
+                                classroom_id: classroom.id,
+                            })}
+                            className={cn(
+                                buttonVariants({
+                                    size: 'sm',
+                                    variant: 'outline',
+                                }),
+                            )}
+                        >
+                            <ShoppingCart />
+                            Ver pedidos
+                        </Link>
+                        <Link
+                            href={route('schools.show', {
+                                school: classroom.school.id,
+                            })}
+                            className={cn(
+                                buttonVariants({
+                                    size: 'sm',
+                                    variant: 'outline',
+                                }),
+                            )}
+                        >
+                            <ArrowLeft />
+                        </Link>
+                    </div>
                     <CardHeader>
                         <CardDescription>
                             {classroom.school.name}

--- a/resources/js/pages/orders/components/order-filters.test.tsx
+++ b/resources/js/pages/orders/components/order-filters.test.tsx
@@ -1,0 +1,125 @@
+import { onFilter } from '@/lib/services/filter';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    OrderFilters,
+    OrderIndexFilters,
+    SchoolWithClassrooms,
+} from './order-filters';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+    onFilter: vi.fn(),
+}));
+
+vi.stubGlobal('route', (name?: string) => `http://localhost/${name ?? ''}`);
+
+const filter = vi.mocked(onFilter);
+
+const schools: SchoolWithClassrooms[] = [
+    {
+        id: 1,
+        name: 'Escuela Normal',
+        classrooms: [
+            { id: 10, name: '5 A', school_id: 1 },
+            { id: 11, name: '5 B', school_id: 1 },
+        ],
+    },
+    {
+        id: 2,
+        name: 'San José',
+        classrooms: [{ id: 20, name: '1 A', school_id: 2 }],
+    },
+] as SchoolWithClassrooms[];
+
+const noFilters: OrderIndexFilters = {
+    search: null,
+    school_id: null,
+    classroom_id: null,
+};
+
+function renderFilters(filters: Partial<OrderIndexFilters> = {}) {
+    return render(
+        <OrderFilters
+            schools={schools}
+            filters={{ ...noFilters, ...filters }}
+        />,
+    );
+}
+
+beforeEach(() => {
+    filter.mockClear();
+});
+
+describe('OrderFilters', () => {
+    it('shows the placeholders when no filter is applied', () => {
+        renderFilters();
+
+        expect(screen.getByText('Filtrar por escuela')).toBeTruthy();
+        expect(screen.getByText('Filtrar por curso')).toBeTruthy();
+    });
+
+    it('shows the filtered school name', () => {
+        renderFilters({ school_id: 2 });
+
+        expect(screen.getByText('San José')).toBeTruthy();
+        expect(screen.getByText('Filtrar por curso')).toBeTruthy();
+    });
+
+    it('derives the school from a classroom-only filter', () => {
+        renderFilters({ classroom_id: 10 });
+
+        expect(screen.getByText('Escuela Normal')).toBeTruthy();
+        expect(screen.getByText('5 A')).toBeTruthy();
+    });
+
+    it('drops the classroom filter when a school is picked', () => {
+        renderFilters({ classroom_id: 10 });
+
+        fireEvent.click(screen.getByText('Escuela Normal'));
+        fireEvent.click(screen.getByText('San José'));
+
+        expect(filter).toHaveBeenCalledWith(
+            { school_id: '2', classroom_id: null },
+            'orders.index',
+        );
+    });
+
+    it('scopes the classroom list to the filtered school', () => {
+        renderFilters({ school_id: 1 });
+
+        fireEvent.click(screen.getByText('Filtrar por curso'));
+
+        expect(screen.getByText('5 A')).toBeTruthy();
+        expect(screen.getByText('5 B')).toBeTruthy();
+        expect(screen.queryByText(/1 A/)).toBeNull();
+    });
+
+    it('prefixes classrooms with their school when no school is filtered', () => {
+        renderFilters();
+
+        fireEvent.click(screen.getByText('Filtrar por curso'));
+
+        expect(screen.getByText('Escuela Normal — 5 A')).toBeTruthy();
+        expect(screen.getByText('San José — 1 A')).toBeTruthy();
+    });
+
+    it('keeps the school filter when a classroom is picked', () => {
+        renderFilters({ school_id: 1 });
+
+        fireEvent.click(screen.getByText('Filtrar por curso'));
+        fireEvent.click(screen.getByText('5 B'));
+
+        expect(filter).toHaveBeenCalledWith(
+            { classroom_id: '11' },
+            'orders.index',
+        );
+    });
+});

--- a/resources/js/pages/orders/components/order-filters.tsx
+++ b/resources/js/pages/orders/components/order-filters.tsx
@@ -1,0 +1,108 @@
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
+import { Searchbar } from '@/features/searchbar';
+import { onFilter } from '@/lib/services/filter';
+import { cn } from '@/lib/utils';
+import { Link } from '@inertiajs/react';
+import { FileText, GraduationCap, School as SchoolIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export interface OrderIndexFilters {
+    search: string | null;
+    school_id: number | null;
+    classroom_id: number | null;
+}
+
+export type SchoolWithClassrooms = School & { classrooms: Classroom[] };
+
+export function OrderFilters({
+    schools,
+    filters,
+}: {
+    schools: SchoolWithClassrooms[];
+    filters: OrderIndexFilters;
+}) {
+    const [schoolOpen, setSchoolOpen] = useState(false);
+    const [classroomOpen, setClassroomOpen] = useState(false);
+
+    // A classroom implies its school, so the school combobox also reflects
+    // visits that only carried classroom_id (the "Ver pedidos" buttons).
+    const selectedSchool =
+        schools.find((school) => school.id === filters.school_id) ??
+        schools.find((school) =>
+            school.classrooms.some(
+                (classroom) => classroom.id === filters.classroom_id,
+            ),
+        );
+
+    const selectedClassroom = selectedSchool?.classrooms.find(
+        (classroom) => classroom.id === filters.classroom_id,
+    );
+
+    const classroomItems = selectedSchool
+        ? selectedSchool.classrooms.map((classroom) => ({
+              label: classroom.name,
+              value: classroom.id,
+          }))
+        : schools.flatMap((school) =>
+              school.classrooms.map((classroom) => ({
+                  label: `${school.name} — ${classroom.name}`,
+                  value: classroom.id,
+              })),
+          );
+
+    return (
+        <div className="mb-4 flex flex-wrap gap-4">
+            <Searchbar
+                indexRoute="orders.index"
+                term={filters.search}
+                placeholder="N°, nombre o teléfono"
+            />
+            <Combobox
+                items={schools.map((school) => ({
+                    label: school.name,
+                    value: school.id,
+                }))}
+                action={(value) =>
+                    // Changing school invalidates any classroom filter
+                    onFilter(
+                        { school_id: value, classroom_id: null },
+                        'orders.index',
+                    )
+                }
+                open={schoolOpen}
+                setOpen={setSchoolOpen}
+                placeholder="Buscar escuela"
+            >
+                <Button variant="secondary" role="combobox">
+                    {selectedSchool?.name ?? 'Filtrar por escuela'}
+                    <SchoolIcon />
+                </Button>
+            </Combobox>
+            <Combobox
+                items={classroomItems}
+                action={(value) =>
+                    onFilter({ classroom_id: value }, 'orders.index')
+                }
+                open={classroomOpen}
+                setOpen={setClassroomOpen}
+                placeholder="Buscar curso"
+            >
+                <Button variant="secondary" role="combobox">
+                    {selectedClassroom?.name ?? 'Filtrar por curso'}
+                    <GraduationCap />
+                </Button>
+            </Combobox>
+            <Link
+                href={route('drafts.index')}
+                className={cn(
+                    buttonVariants({ variant: 'outline' }),
+                    'ml-auto',
+                )}
+            >
+                <FileText />
+                Borradores
+            </Link>
+        </div>
+    );
+}

--- a/resources/js/pages/orders/components/orders-table.tsx
+++ b/resources/js/pages/orders/components/orders-table.tsx
@@ -13,6 +13,7 @@ import { onSort } from '@/lib/services/filter';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
 import { ArrowUpDown, Eye, Trash } from 'lucide-react';
+import { ProductsTooltip } from './products-tooltip';
 
 interface OrdersTableProps {
     orders: Order[];
@@ -72,7 +73,12 @@ export function OrdersTable({ orders, search, onDelete }: OrdersTableProps) {
                                 term={search}
                             />
                         </TableCell>
-                        <TableCell>{order.products.length}</TableCell>
+                        <TableCell>
+                            <div className="flex items-center gap-1">
+                                {order.products.length}
+                                <ProductsTooltip products={order.products} />
+                            </div>
+                        </TableCell>
                         <TableCell>{formatPrice(order.total_price)}</TableCell>
                         <TableCell>
                             {order.payment_plan} (

--- a/resources/js/pages/orders/components/product-list-item.tsx
+++ b/resources/js/pages/orders/components/product-list-item.tsx
@@ -1,15 +1,7 @@
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-    Edit,
-    RectangleHorizontal,
-    RectangleVertical,
-    Square,
-    Trash,
-    User,
-    Users,
-} from 'lucide-react';
+import { Edit, Trash } from 'lucide-react';
 import { OrderFormData } from '../form-state';
+import { VariantBadges } from './variant-badges';
 
 interface ProductListItemProps {
     detail: OrderFormData['order_details'][number];
@@ -31,31 +23,7 @@ export function ProductListItem({
             <div className="flex min-w-0 flex-col gap-2">
                 <span>{product.name}</span>
                 {product.product_type_id === 1 ? (
-                    <div className="flex items-center">
-                        <Badge variant="outline" className="gap-1 rounded-lg">
-                            <Square
-                                className="h-4 w-4"
-                                style={{ fill: detail.variant?.color }}
-                            />
-                        </Badge>
-                        <Badge variant="outline" className="rounded-lg">
-                            {detail.variant?.background}
-                        </Badge>
-                        <Badge variant="outline" className="rounded-lg">
-                            {detail.variant?.photo_type === 'individual' ? (
-                                <User className="h-4 w-4" />
-                            ) : (
-                                <Users className="h-4 w-4" />
-                            )}
-                        </Badge>
-                        <Badge variant="outline" className="rounded-lg">
-                            {detail.variant?.orientation === 'vertical' ? (
-                                <RectangleVertical className="h-4 w-4" />
-                            ) : (
-                                <RectangleHorizontal className="h-4 w-4" />
-                            )}
-                        </Badge>
-                    </div>
+                    <VariantBadges variant={detail.variant} />
                 ) : undefined}
             </div>
             <div className="flex gap-1">

--- a/resources/js/pages/orders/components/products-tooltip.test.tsx
+++ b/resources/js/pages/orders/components/products-tooltip.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProductsTooltip } from './products-tooltip';
+
+const products = [
+    {
+        order_detail_id: 1,
+        name: 'Mural clásico',
+        product_type_id: 1,
+        variant: {
+            color: '#fff',
+            background: 'Bosque',
+            photo_type: 'individual',
+            orientation: 'vertical',
+        },
+    },
+    {
+        order_detail_id: 2,
+        name: 'Taza',
+        product_type_id: 2,
+    },
+] as unknown as OrderProduct[];
+
+describe('ProductsTooltip', () => {
+    it('lists the order products when the eye button is clicked', () => {
+        render(<ProductsTooltip products={products} />);
+
+        expect(screen.queryByText('Mural clásico')).toBeNull();
+
+        fireEvent.click(screen.getByLabelText('Ver productos'));
+
+        expect(screen.getByText('Mural clásico')).toBeTruthy();
+        expect(screen.getByText('Taza')).toBeTruthy();
+        expect(screen.getByText('Bosque')).toBeTruthy();
+    });
+});

--- a/resources/js/pages/orders/components/products-tooltip.tsx
+++ b/resources/js/pages/orders/components/products-tooltip.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import { ProductIcon } from '@/features/product-icon';
+import { VariantBadges } from './variant-badges';
+
+/**
+ * "Ver" button listing the order's products. A popover rather than a hover
+ * tooltip: the app is used mostly on phones, where hover does not exist.
+ */
+export function ProductsTooltip({ products }: { products: OrderProduct[] }) {
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-2 text-xs text-muted-foreground"
+                    aria-label="Ver productos"
+                >
+                    Ver
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 p-4" align="start">
+                <h4 className="text-sm font-medium">Productos</h4>
+                <ul className="divide-y divide-border">
+                    {products.map((product) => (
+                        <li
+                            key={product.order_detail_id}
+                            className="flex items-start gap-3 py-2.5 last:pb-0"
+                        >
+                            <div className="rounded bg-muted p-1.5">
+                                <ProductIcon
+                                    type={product.product_type_id}
+                                    className="h-4 w-4 text-muted-foreground"
+                                />
+                            </div>
+                            <div className="min-w-0 space-y-1.5">
+                                <p className="pt-0.5 text-sm font-medium">
+                                    {product.name}
+                                </p>
+                                {product.product_type_id === 1 && (
+                                    <VariantBadges variant={product.variant} />
+                                )}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/resources/js/pages/orders/components/variant-badges.tsx
+++ b/resources/js/pages/orders/components/variant-badges.tsx
@@ -1,0 +1,48 @@
+import { Badge } from '@/components/ui/badge';
+import {
+    RectangleHorizontal,
+    RectangleVertical,
+    Square,
+    User,
+    Users,
+} from 'lucide-react';
+
+/**
+ * The mural variant chosen on an order detail, as badges. Accepts both the
+ * create-form shape and the loosely-typed variant the API serializes.
+ */
+export function VariantBadges({
+    variant,
+}: {
+    variant?: {
+        color?: string;
+        background?: string;
+        photo_type?: string;
+        orientation?: string;
+    };
+}) {
+    return (
+        <div className="flex flex-wrap items-center gap-1">
+            <Badge variant="outline" className="gap-1 rounded-lg">
+                <Square className="h-4 w-4" style={{ fill: variant?.color }} />
+            </Badge>
+            <Badge variant="outline" className="rounded-lg">
+                {variant?.background}
+            </Badge>
+            <Badge variant="outline" className="rounded-lg">
+                {variant?.photo_type === 'individual' ? (
+                    <User className="h-4 w-4" />
+                ) : (
+                    <Users className="h-4 w-4" />
+                )}
+            </Badge>
+            <Badge variant="outline" className="rounded-lg">
+                {variant?.orientation === 'vertical' ? (
+                    <RectangleVertical className="h-4 w-4" />
+                ) : (
+                    <RectangleHorizontal className="h-4 w-4" />
+                )}
+            </Badge>
+        </div>
+    );
+}

--- a/resources/js/pages/orders/index.tsx
+++ b/resources/js/pages/orders/index.tsx
@@ -1,14 +1,14 @@
 import { PaginationNav } from '@/components/paginationNav';
-import { Button, buttonVariants } from '@/components/ui/button';
-import { Combobox } from '@/components/ui/combobox';
-import { Searchbar } from '@/features/searchbar';
 import AppLayout from '@/layouts/app-layout';
-import { cn } from '@/lib/utils';
 import { BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
-import { FileText, School } from 'lucide-react';
+import { Head } from '@inertiajs/react';
 import { useState } from 'react';
 import { DeleteOrderConfirmation } from './components/delete-confirmation';
+import {
+    OrderFilters,
+    OrderIndexFilters,
+    SchoolWithClassrooms,
+} from './components/order-filters';
 import { OrdersTable } from './components/orders-table';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -24,15 +24,9 @@ export default function Orders({
     filters,
 }: PageProps<{
     orders: Paginated<Order>;
-    schools: School[];
-    filters: { search: string | null };
+    schools: SchoolWithClassrooms[];
+    filters: OrderIndexFilters;
 }>) {
-    const params = new URLSearchParams(window.location.search);
-
-    const [comboDropdownOpen, setComboDropdownOpen] = useState(false);
-    const [selectedSchool] = useState<number | null>(
-        params.get('school_id') ? Number(params.get('school_id')!) : null,
-    );
     const [deleteableOrder, setDeleteableOrder] = useState<Order | null>(null);
 
     return (
@@ -48,47 +42,7 @@ export default function Orders({
             )}
 
             <section className="p-6">
-                <div className="mb-4 flex flex-wrap gap-4">
-                    <Searchbar
-                        indexRoute="orders.index"
-                        term={filters.search}
-                        placeholder="N°, nombre o teléfono"
-                    />
-                    <Combobox
-                        items={schools.map((school) => ({
-                            label: school.name,
-                            value: school.id,
-                        }))}
-                        action={(value) => {
-                            params.set('school_id', value);
-                            router.get(
-                                `${route('orders.index')}?${params.toString()}`,
-                            );
-                        }}
-                        open={comboDropdownOpen}
-                        setOpen={setComboDropdownOpen}
-                        placeholder="Buscar escuela"
-                    >
-                        <Button variant="secondary" role="combobox">
-                            {selectedSchool
-                                ? schools.find(
-                                      (school) => school.id === selectedSchool,
-                                  )?.name || 'Filtrar por escuela'
-                                : 'Filtrar por escuela'}
-                            <School />
-                        </Button>
-                    </Combobox>
-                    <Link
-                        href={route('drafts.index')}
-                        className={cn(
-                            buttonVariants({ variant: 'outline' }),
-                            'ml-auto',
-                        )}
-                    >
-                        <FileText />
-                        Borradores
-                    </Link>
-                </div>
+                <OrderFilters schools={schools} filters={filters} />
 
                 <OrdersTable
                     orders={orders.data}

--- a/resources/js/pages/schools/components/classrooms-table.test.tsx
+++ b/resources/js/pages/schools/components/classrooms-table.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    type SchoolShowController,
+    type SchoolShowData,
+} from '../hooks/use-school-show';
+import { ClassroomsTable } from './classrooms-table';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+    onSort: vi.fn(),
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, string | number>) =>
+        `http://localhost/${name}?${new URLSearchParams(
+            Object.entries(params ?? {}).map(([key, value]) => [
+                key,
+                String(value),
+            ]),
+        )}`,
+);
+
+const school = {
+    id: 7,
+    name: 'Escuela Normal',
+    classrooms: [
+        { id: 10, name: '5 A', teacher: { name: 'Marta' } },
+        { id: 11, name: '5 B', teacher: { name: 'Jorge' } },
+    ],
+} as unknown as SchoolShowData;
+
+const controller = {
+    setShowAddClassroom: vi.fn(),
+    setEditableClassroom: vi.fn(),
+    setDeleteableClassroom: vi.fn(),
+} as unknown as SchoolShowController;
+
+describe('ClassroomsTable', () => {
+    it('links each classroom to its filtered orders', () => {
+        render(<ClassroomsTable school={school} controller={controller} />);
+
+        const links = screen
+            .getAllByText('Ver pedidos')
+            .map((el) => (el.closest('a') as HTMLAnchorElement).href);
+
+        expect(links).toEqual([
+            'http://localhost/orders.index?classroom_id=10',
+            'http://localhost/orders.index?classroom_id=11',
+        ]);
+    });
+});

--- a/resources/js/pages/schools/components/classrooms-table.test.tsx
+++ b/resources/js/pages/schools/components/classrooms-table.test.tsx
@@ -8,8 +8,17 @@ import { ClassroomsTable } from './classrooms-table';
 
 vi.mock('@inertiajs/react', () => ({
     router: { get: vi.fn() },
-    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
-        <a href={href}>{children}</a>
+    Link: ({
+        href,
+        children,
+        ...props
+    }: {
+        href: string;
+        children: React.ReactNode;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
     ),
 }));
 
@@ -49,8 +58,8 @@ describe('ClassroomsTable', () => {
         render(<ClassroomsTable school={school} controller={controller} />);
 
         const links = screen
-            .getAllByText('Ver pedidos')
-            .map((el) => (el.closest('a') as HTMLAnchorElement).href);
+            .getAllByLabelText<HTMLAnchorElement>('Ver pedidos')
+            .map((el) => el.href);
 
         expect(links).toEqual([
             'http://localhost/orders.index?classroom_id=10',

--- a/resources/js/pages/schools/components/classrooms-table.tsx
+++ b/resources/js/pages/schools/components/classrooms-table.tsx
@@ -11,7 +11,7 @@ import { Searchbar } from '@/features/searchbar';
 import { onSort } from '@/lib/services/filter';
 import { cn } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
-import { ArrowUpDown, Edit2, Plus, Trash } from 'lucide-react';
+import { ArrowUpDown, Edit2, Plus, ShoppingCart, Trash } from 'lucide-react';
 import {
     type SchoolShowController,
     type SchoolShowData,
@@ -71,7 +71,6 @@ export function ClassroomsTable({
                         <TableHead>
                             <div className="flex items-center gap-2">Niños</div>
                         </TableHead>
-                        <TableHead>Pedidos</TableHead>
 
                         <TableHead>Acciones</TableHead>
                     </TableRow>
@@ -99,8 +98,10 @@ export function ClassroomsTable({
                                     Ver alumnos
                                 </Link>
                             </TableCell>
-                            <TableCell>
+
+                            <TableCell className="flex gap-2">
                                 <Link
+                                    aria-label="Ver pedidos"
                                     href={route('orders.index', {
                                         classroom_id: classroom.id,
                                     })}
@@ -111,11 +112,8 @@ export function ClassroomsTable({
                                         }),
                                     )}
                                 >
-                                    Ver pedidos
+                                    <ShoppingCart />
                                 </Link>
-                            </TableCell>
-
-                            <TableCell className="flex gap-2">
                                 <Button
                                     variant="warning"
                                     size="sm"

--- a/resources/js/pages/schools/components/classrooms-table.tsx
+++ b/resources/js/pages/schools/components/classrooms-table.tsx
@@ -71,6 +71,7 @@ export function ClassroomsTable({
                         <TableHead>
                             <div className="flex items-center gap-2">Niños</div>
                         </TableHead>
+                        <TableHead>Pedidos</TableHead>
 
                         <TableHead>Acciones</TableHead>
                     </TableRow>
@@ -96,6 +97,21 @@ export function ClassroomsTable({
                                     )}
                                 >
                                     Ver alumnos
+                                </Link>
+                            </TableCell>
+                            <TableCell>
+                                <Link
+                                    href={route('orders.index', {
+                                        classroom_id: classroom.id,
+                                    })}
+                                    className={cn(
+                                        buttonVariants({
+                                            size: 'sm',
+                                            variant: 'outline',
+                                        }),
+                                    )}
+                                >
+                                    Ver pedidos
                                 </Link>
                             </TableCell>
 

--- a/resources/js/pages/schools/components/school-info-card.test.tsx
+++ b/resources/js/pages/schools/components/school-info-card.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { type SchoolShowData } from '../hooks/use-school-show';
+import { SchoolInfoCard } from './school-info-card';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, string | number>) =>
+        `http://localhost/${name}?${new URLSearchParams(
+            Object.entries(params ?? {}).map(([key, value]) => [
+                key,
+                String(value),
+            ]),
+        )}`,
+);
+
+const school = {
+    id: 7,
+    name: 'Escuela Normal',
+    level: 'Primaria',
+    user: { id: 1, name: 'Vendedor', email: 'v@example.com' },
+    classrooms: [],
+    full_address: 'Av. Siempreviva 742',
+} as unknown as SchoolShowData;
+
+describe('SchoolInfoCard', () => {
+    it('links to the orders filtered by the school', () => {
+        render(<SchoolInfoCard school={school} />);
+
+        const link = screen
+            .getByText('Ver pedidos')
+            .closest('a') as HTMLAnchorElement;
+
+        expect(link.href).toBe('http://localhost/orders.index?school_id=7');
+    });
+});

--- a/resources/js/pages/schools/components/school-info-card.tsx
+++ b/resources/js/pages/schools/components/school-info-card.tsx
@@ -7,27 +7,42 @@ import {
 } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
-import { Edit } from 'lucide-react';
+import { Edit, ShoppingCart } from 'lucide-react';
 import { type SchoolShowData } from '../hooks/use-school-show';
 
 export function SchoolInfoCard({ school }: { school: SchoolShowData }) {
     return (
         <section className="px-6 pt-6">
             <Card className="relative max-w-106.25">
-                <Link
-                    href={route('schools.edit', {
-                        school: school.id,
-                    })}
-                    className={cn(
-                        'absolute top-4 right-4',
-                        buttonVariants({
-                            size: 'sm',
-                            variant: 'warning',
-                        }),
-                    )}
-                >
-                    <Edit />
-                </Link>
+                <div className="absolute top-4 right-4 flex gap-2">
+                    <Link
+                        href={route('orders.index', {
+                            school_id: school.id,
+                        })}
+                        className={cn(
+                            buttonVariants({
+                                size: 'sm',
+                                variant: 'outline',
+                            }),
+                        )}
+                    >
+                        <ShoppingCart />
+                        Ver pedidos
+                    </Link>
+                    <Link
+                        href={route('schools.edit', {
+                            school: school.id,
+                        })}
+                        className={cn(
+                            buttonVariants({
+                                size: 'sm',
+                                variant: 'warning',
+                            }),
+                        )}
+                    >
+                        <Edit />
+                    </Link>
+                </div>
                 <CardHeader>
                     <CardDescription>{school.user.name}</CardDescription>
                     <CardTitle>

--- a/resources/js/tests/setup.ts
+++ b/resources/js/tests/setup.ts
@@ -14,6 +14,9 @@ vi.stubGlobal(
     },
 );
 
+// jsdom does not implement scrollIntoView, required by cmdk's command list
+Element.prototype.scrollIntoView = vi.fn();
+
 // jsdom does not implement matchMedia, required by the sidebar's
 // useIsMobile hook and other responsive components
 Object.defineProperty(window, 'matchMedia', {

--- a/tests/Feature/OrderFilterTest.php
+++ b/tests/Feature/OrderFilterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Classroom;
+use App\Models\Client;
+use App\Models\Order;
+use App\Models\School;
+
+use function Pest\Laravel\get;
+
+/**
+ * @param  array<string, int|string>  $query
+ * @return array<int, int>
+ */
+function filteredOrderIds(array $query): array
+{
+    $response = get(route('orders.index', $query));
+    $response->assertOk();
+
+    /** @var array<int, array<string, mixed>> $orders */
+    $orders = $response->viewData('page')['props']['orders']['data'];
+
+    return array_map(fn (array $order) => (int) $order['id'], $orders);
+}
+
+beforeEach(function () {
+    actingAsRole();
+});
+
+it('filters orders by school', function () {
+    $classroom = Classroom::factory()->create();
+    $other = Classroom::factory()->create();
+
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Order::factory()->create(['classroom_id' => $other->id]);
+
+    expect(filteredOrderIds(['school_id' => $classroom->school_id]))->toBe([$order->id]);
+});
+
+it('filters orders by classroom, narrower than its school', function () {
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
+    $sibling = Classroom::factory()->create(['school_id' => $school->id]);
+
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Order::factory()->create(['classroom_id' => $sibling->id]);
+
+    expect(filteredOrderIds(['classroom_id' => $classroom->id]))->toBe([$order->id])
+        ->and(filteredOrderIds(['school_id' => $school->id]))->toHaveCount(2);
+});
+
+it('combines the classroom filter with the search term', function () {
+    $classroom = Classroom::factory()->create();
+    $other = Classroom::factory()->create();
+
+    $client = Client::factory()->create(['name' => 'Carla López']);
+    $order = Order::factory()->create([
+        'classroom_id' => $classroom->id,
+        'client_id' => $client->id,
+    ]);
+
+    // Same client name in another classroom: search alone would match it
+    $twin = Client::factory()->create(['name' => 'Carla López']);
+    Order::factory()->create([
+        'classroom_id' => $other->id,
+        'client_id' => $twin->id,
+    ]);
+
+    expect(filteredOrderIds(['classroom_id' => $classroom->id, 'search' => 'Carla']))
+        ->toBe([$order->id]);
+});
+
+it('returns nothing when no order belongs to the filtered classroom', function () {
+    Order::factory()->create();
+    $empty = Classroom::factory()->create();
+
+    expect(filteredOrderIds(['classroom_id' => $empty->id]))->toBe([]);
+});
+
+it('echoes the applied filters back to the page', function () {
+    $classroom = Classroom::factory()->create();
+    Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    get(route('orders.index', [
+        'school_id' => $classroom->school_id,
+        'classroom_id' => $classroom->id,
+        'search' => 'carla',
+    ]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('filters.school_id', $classroom->school_id)
+            ->where('filters.classroom_id', $classroom->id)
+            ->where('filters.search', 'carla'));
+});
+
+it('echoes null filters when nothing is applied', function () {
+    Order::factory()->create();
+
+    get(route('orders.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('filters.school_id', null)
+            ->where('filters.classroom_id', null)
+            ->where('filters.search', null));
+});


### PR DESCRIPTION
## Resumen

El flujo real del cliente es escuela → curso → niño (reunión 9/7, §2.3). Este PR conecta ese flujo con `/orders`:

- **`/orders` ahora filtra por escuela y por curso vía query params** (`school_id`, `classroom_id`), combinables entre sí y con la búsqueda.
- **Combobox "Filtrar por curso"** junto al de escuela: muestra los cursos de la escuela filtrada (o todos, prefijados con su escuela). Cambiar de escuela limpia el filtro de curso.
- **Botones "Ver pedidos"**: en la card del show de escuela, en la card del show de curso y por fila en la tabla de cursos — cada uno navega a `/orders` con el filtro ya aplicado.

- **Botón "Ver" en la columna Productos** (pedido durante la review): abre un popover con los productos del pedido — ícono de tipo, nombre y badges de variante para murales. Popover y no tooltip de hover porque la app se usa sobre todo en el teléfono. Los badges de variante se extrajeron de `product-list-item` a `variant-badges` y los comparten el form de crear pedido y el popover.

## Detalles

- Scopes `forSchool` / `forClassroom` en `Order` reemplazan el `whereHas` inline del controller; el controller normaliza los params a `?int` y los devuelve en `filters`, así la página deja de parsear `window.location`.
- La fila de filtros se extrajo a `orders/components/order-filters.tsx`; la navegación pasa por un helper `onFilter` en `lib/services/filter.ts` que preserva los demás params y descarta `page` (antes, cambiar de escuela arrastraba la página de la paginación).
- Stub de `scrollIntoView` en el setup de vitest (jsdom no lo implementa y cmdk lo usa al abrir la lista).

## Tests

- Pest: `OrderFilterTest` (6) — filtro por escuela, por curso, combinado con búsqueda y echo de filtros.
- Vitest: `order-filters` (7), `filter` service (3), hrefs de los botones en `school-info-card` y `classrooms-table`.
- Verificado en browser (spec descartable de Playwright): los tres botones aterrizan filtrado, cambiar de escuela limpia el curso, sin scroll horizontal a 320/351/390px.

Closes #104

