### PR TITLE
feat(production): fabricación habilitada por la primera cuota

### DIFF
--- a/app/Actions/Orders/SetDetailProductionStatus.php
+++ b/app/Actions/Orders/SetDetailProductionStatus.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Orders;
+
+use App\Actions\Tracking\MoveDetailsToStage;
+use App\Contracts\ActionContract;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\ProductionStatus;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+
+class SetDetailProductionStatus implements ActionContract
+{
+    public function __construct(private MoveDetailsToStage $moveDetailsToStage) {}
+
+    /**
+     * Change a detail's production status from the order page. Production is
+     * gated by the first installment: until it is paid nothing gets enabled.
+     * A null status enables the detail as "sin empezar" (it enters /tracking);
+     * a stage delegates to the tracking flow, which deducts stock.
+     *
+     * @param  array<string, mixed>  $params  {order: Order, detail_id: int, status_id: ?int, user: ?User}
+     *
+     * @throws ValidationException
+     */
+    public function handle(array $params): void
+    {
+        /** @var Order $order */
+        $order = $params['order'];
+
+        /** @var int $detailId */
+        $detailId = $params['detail_id'];
+
+        /** @var int|null $statusId */
+        $statusId = $params['status_id'];
+
+        /** @var User|null $user */
+        $user = $params['user'];
+
+        if ($order->cancelled_at !== null) {
+            throw ValidationException::withMessages([
+                'order' => 'No se puede fabricar un producto de un pedido cancelado.',
+            ]);
+        }
+
+        $detail = $order->details()
+            ->whereNull('recycled_to')
+            ->whereNull('delivered_at')
+            ->find($detailId);
+
+        if ($detail === null) {
+            throw ValidationException::withMessages([
+                'detail_id' => 'No se encontró el producto en este pedido.',
+            ]);
+        }
+
+        if (! $order->firstInstallmentPaid()) {
+            throw ValidationException::withMessages([
+                'order' => 'La fabricación se habilita cuando la primera cuota está paga.',
+            ]);
+        }
+
+        if ($statusId === null) {
+            $this->markPending($detail);
+
+            return;
+        }
+
+        /** @var ProductionStatus $status */
+        $status = ProductionStatus::findOrFail($statusId);
+
+        $this->moveDetailsToStage->handle([
+            'detail_ids' => [$detail->id],
+            'status' => $status,
+            'user' => $user,
+        ]);
+    }
+
+    /**
+     * Enable the detail with no stage yet: it shows up in /tracking as
+     * "sin empezar". Already-deducted stock stays deducted, mirroring
+     * backward moves on the tracking board.
+     */
+    private function markPending(OrderDetail $detail): void
+    {
+        $detail->production_enabled_at ??= now();
+        $detail->production_status_id = null;
+        $detail->status_updated_at = now();
+        $detail->save();
+    }
+}

--- a/app/Actions/Tracking/MoveDetailsToStage.php
+++ b/app/Actions/Tracking/MoveDetailsToStage.php
@@ -54,6 +54,8 @@ class MoveDetailsToStage implements ActionContract
         DB::transaction(function () use ($details, $status, $user) {
             foreach ($details as $detail) {
                 $detail->productionStatus()->associate($status);
+                // A detail on a stage is by definition enabled for production
+                $detail->production_enabled_at ??= now();
                 $detail->status_updated_at = now();
                 $detail->save();
                 $detail->setRelation('productionStatus', $status);

--- a/app/Http/Controllers/BO/DashboardController.php
+++ b/app/Http/Controllers/BO/DashboardController.php
@@ -38,10 +38,13 @@ class DashboardController extends Controller
             ->whereHas('order', fn ($q) => $q->whereNull('cancelled_at'))
             ->sum('amount');
 
-        // Production: pending details of active, undelivered orders
+        // Production: pending details of active, undelivered orders. Details
+        // whose production is not enabled yet (first installment unpaid) are
+        // not workshop work, so they stay out of these metrics.
         $activeDetails = OrderDetail::query()
             ->whereNull('delivered_at')
             ->whereNull('recycled_to')
+            ->whereNotNull('production_enabled_at')
             ->whereHas('order', fn ($q) => $q->whereNull('cancelled_at'));
 
         /** @var array<int, int> $lastPositions */

--- a/app/Http/Controllers/BO/DetailProductionStatusController.php
+++ b/app/Http/Controllers/BO/DetailProductionStatusController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Actions\Orders\SetDetailProductionStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\BO\UpdateDetailProductionStatusRequest;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+
+class DetailProductionStatusController extends Controller
+{
+    /**
+     * Change the production status of a detail from the order page: enable
+     * production once the first installment is paid, or move the detail to a
+     * stage of its product's chain.
+     */
+    public function update(UpdateDetailProductionStatusRequest $request, Order $order, SetDetailProductionStatus $action): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        /** @var int $detailId */
+        $detailId = $validated['detail_id'];
+
+        /** @var int|null $statusId */
+        $statusId = $validated['production_status_id'] ?? null;
+
+        /** @var User|null $user */
+        $user = $request->user();
+
+        $action->handle([
+            'order' => $order,
+            'detail_id' => $detailId,
+            'status_id' => $statusId,
+            'user' => $user,
+        ]);
+
+        return back()->with('success', 'Estado de fabricación actualizado');
+    }
+}

--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -107,7 +107,7 @@ class OrderController extends Controller
 
     public function show(Order $order): Response
     {
-        $order->load('client', 'products.type', 'payments', 'notes', 'classroom.school', 'details.productionStatus');
+        $order->load('client', 'products.type', 'products.productionStatuses', 'payments', 'notes', 'classroom.school', 'details.productionStatus');
 
         return Inertia::render('orders/show', [
             'order' => new OrderResource($order),

--- a/app/Http/Controllers/BO/TrackingController.php
+++ b/app/Http/Controllers/BO/TrackingController.php
@@ -39,6 +39,9 @@ class TrackingController extends Controller
             ->with('product.type', 'productionStatus', 'order.client', 'order.classroom.school')
             ->whereNull('delivered_at')
             ->whereNull('recycled_to')
+            // Production starts with the first paid installment: details not
+            // yet enabled from the order page stay out of the workshop board
+            ->whereNotNull('production_enabled_at')
             ->whereHas('order', function ($query) use ($school_id, $search) {
                 $query->whereNull('cancelled_at');
 

--- a/app/Http/Requests/BO/UpdateDetailProductionStatusRequest.php
+++ b/app/Http/Requests/BO/UpdateDetailProductionStatusRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDetailProductionStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * A null production_status_id means "sin empezar": the detail enters (or
+     * returns to) the pending state that precedes the product's stage chain.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'detail_id' => ['required', 'integer'],
+            'production_status_id' => ['nullable', 'integer', 'exists:production_statuses,id'],
+        ];
+    }
+}

--- a/app/Http/Resources/OrderResource.php
+++ b/app/Http/Resources/OrderResource.php
@@ -57,6 +57,7 @@ class OrderResource extends JsonResource
             'paid_total' => $this->whenLoaded('payments', fn () => $this->sumPayments()),
             'balance' => $this->whenLoaded('payments', fn () => $this->total_price - $this->sumPayments()),
             'can_edit' => $this->canEdit(),
+            'first_installment_paid' => $this->firstInstallmentPaid(),
             'can_delete' => $this->cancelled_at === null && $this->payments()->doesntExist(),
             'payments' => $this->whenLoaded('payments', function () {
                 return $this->payments->map(function ($payment) {
@@ -98,8 +99,16 @@ class OrderResource extends JsonResource
                     'delivered_at' => $product->pivot->delivered_at,  // @phpstan-ignore-line
                     'production_status' => $detail?->productionStatus?->name,
                     'production_status_id' => $detail?->production_status_id,
+                    'production_enabled' => $detail?->production_enabled_at !== null,
                     'priority' => $detail?->priority,
                     'recycled_to' => $detail?->recycled_to,
+                    'statuses' => $product->relationLoaded('productionStatuses')
+                        ? $product->productionStatuses->map(fn (ProductionStatus $status) => [
+                            'id' => $status->id,
+                            'name' => $status->name,
+                            'position' => $status->position,
+                        ])
+                        : [],
                 ];
             }),
             'classroom' => $classroom,
@@ -128,10 +137,7 @@ class OrderResource extends JsonResource
             return false;
         }
 
-        $totalPaid = $this->payments()->sum('amount');
-        $firstQuote = $this->total_price / $this->payment_plan;
-
-        return $totalPaid < $firstQuote;
+        return ! $this->firstInstallmentPaid();
     }
 
     /**
@@ -161,6 +167,10 @@ class OrderResource extends JsonResource
 
         if ($delivered->isNotEmpty()) {
             return 'entregado parcial';
+        }
+
+        if ($active->every(fn (OrderDetail $detail) => $detail->production_enabled_at === null)) {
+            return 'sin habilitar';
         }
 
         if ($active->every(fn (OrderDetail $detail) => $detail->production_status_id === null)) {

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -49,7 +49,7 @@ class Order extends Model
     {
         return $this->belongsToMany(Product::class, 'order_details')
             ->using(OrderDetail::class)
-            ->withPivot('id', 'note', 'variant', 'delivered_at', 'production_status_id', 'status_updated_at', 'priority', 'recycled_to')
+            ->withPivot('id', 'note', 'variant', 'delivered_at', 'production_status_id', 'production_enabled_at', 'status_updated_at', 'priority', 'recycled_to')
             ->withTimestamps();
     }
 
@@ -125,6 +125,24 @@ class Order extends Model
     public function paidTotal(): int
     {
         return (int) $this->payments()->sum('amount');
+    }
+
+    /**
+     * Whether the client already covered the first installment
+     * (total / plan). It gates production: nothing is manufactured —
+     * or enters /tracking — before this is true.
+     */
+    public function firstInstallmentPaid(): bool
+    {
+        if ((int) $this->payment_plan <= 0) {
+            return false;
+        }
+
+        $paid = $this->relationLoaded('payments')
+            ? $this->payments->sum(fn (Payment $payment): int => (int) $payment->amount)
+            : $this->paidTotal();
+
+        return $paid >= (int) $this->total_price / (int) $this->payment_plan;
     }
 
     public function balance(): int

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -54,6 +54,7 @@ class OrderDetail extends Pivot
     protected $casts = [
         'variant' => 'array',
         'priority' => 'boolean',
+        'production_enabled_at' => 'datetime',
         'status_updated_at' => 'datetime',
         'delivered_at' => 'datetime',
     ];

--- a/database/factories/OrderDetailFactory.php
+++ b/database/factories/OrderDetailFactory.php
@@ -32,6 +32,15 @@ class OrderDetailFactory extends Factory
         return $this->state(fn () => ['delivered_at' => now()]);
     }
 
+    /**
+     * Production enabled: the first installment was paid and the office
+     * let the detail into the workshop board.
+     */
+    public function enabled(): static
+    {
+        return $this->state(fn () => ['production_enabled_at' => now()]);
+    }
+
     public function recycled(string $destination = 'reciclaje'): static
     {
         return $this->state(fn () => ['recycled_to' => $destination]);

--- a/database/migrations/2025_02_22_162356_create_order_details_table.php
+++ b/database/migrations/2025_02_22_162356_create_order_details_table.php
@@ -24,6 +24,7 @@ return new class extends Migration
             $table->json('variant')->nullable();
             $table->text('note')->nullable();
             $table->foreignId('production_status_id')->nullable()->constrained();
+            $table->timestamp('production_enabled_at')->nullable();
             $table->timestamp('status_updated_at')->nullable();
             $table->boolean('priority')->default(false);
             $table->string('recycled_to')->nullable();

--- a/database/seeders/DemoOrderSeeder.php
+++ b/database/seeders/DemoOrderSeeder.php
@@ -15,10 +15,12 @@ use App\Services\StockService;
 use Illuminate\Database\Seeder;
 
 /**
- * Eleven orders covering every state of the manual checklist: pending,
- * in production, priority, finished, partially/fully delivered,
- * cancelled with recycling/stock return, overdue with balance and one
- * without a photo session.
+ * Eleven orders covering every state of the manual checklist: production
+ * not yet enabled (first installment unpaid), pending, in production,
+ * priority, finished, partially/fully delivered, cancelled with
+ * recycling/stock return, overdue with balance and one without a photo
+ * session. Every order with details in /tracking has its first
+ * installment paid — production is gated by it (#106).
  */
 class DemoOrderSeeder extends Seeder
 {
@@ -42,13 +44,13 @@ class DemoOrderSeeder extends Seeder
         $medalla = Product::where('name', 'Medalla')->firstOrFail();
         $taza = Product::where('name', 'Taza')->firstOrFail();
 
-        // 1. Pending order: nothing produced, partial cash payment,
-        // still editable (paid less than the first installment)
+        // 1. Pending order: first installment paid and production enabled,
+        // nothing produced yet (all details "sin empezar" in /tracking)
         $order = $this->makeOrder($sextoA, 'Ana Suárez', '3804000001', 'Valentina', 1, 60000, 4, 30);
-        $this->addDetail($order, $molduraAncha, $this->muralVariant('vertical', 'pink'), 'Valentina - egresados 2026');
-        $this->addDetail($order, $carpeta, null, 'Valentina');
-        $this->addDetail($order, $medalla, null, 'Valentina');
-        $order->payments()->create(['amount' => 10000, 'type' => 'efectivo', 'paid_on' => now()->toDateString()]);
+        $this->addDetail($order, $molduraAncha, $this->muralVariant('vertical', 'pink'), 'Valentina - egresados 2026', enabled: true);
+        $this->addDetail($order, $carpeta, null, 'Valentina', enabled: true);
+        $this->addDetail($order, $medalla, null, 'Valentina', enabled: true);
+        $order->payments()->create(['amount' => 15000, 'type' => 'efectivo', 'paid_on' => now()->toDateString()]);
         $order->notes()->create(['body' => 'La mamá pidió que la avisemos por WhatsApp cuando esté lista la moldura.']);
         $order->notes()->create(['body' => 'Confirmar dirección de entrega antes de despachar.']);
 
@@ -57,7 +59,7 @@ class DemoOrderSeeder extends Seeder
         $order = $this->makeOrder($sextoA, 'Bruno Díaz', '3804000002', 'Thiago', 2, 56000, 4, 20);
         $detail = $this->addDetail($order, $clasico, $this->muralVariant('horizontal', 'black'), 'Thiago - egresados 2026');
         $this->setStatus($detail, $clasico, 3, hoursAgo: 30);
-        $this->addDetail($order, $carpeta, null, 'Thiago');
+        $this->addDetail($order, $carpeta, null, 'Thiago', enabled: true);
         $order->payments()->create(['amount' => 20000, 'type' => 'transferencia', 'transaction_number' => 'MP73920184652', 'paid_on' => now()->subDays(2)->toDateString()]);
 
         // 3. Priority: the mural broke after "Corte de moldura" (one strip
@@ -67,6 +69,7 @@ class DemoOrderSeeder extends Seeder
         $detail = $this->addDetail($order, $molduraFina, $this->muralVariant('vertical', 'black'), 'Lola - egresados 2026');
         $this->setStatus($detail, $molduraFina, 3, hoursAgo: 48);
         $this->setStatus($detail, $molduraFina, 2, priority: true, hoursAgo: 2);
+        $order->payments()->create(['amount' => 10000, 'type' => 'efectivo', 'paid_on' => now()->subDays(3)->toDateString()]);
 
         // 4. Finished and fully paid: ready to deliver with no warning
         $order = $this->makeOrder($sextoA, 'Diego Farías', '3804000004', 'Benjamín', 4, 12000, 1, 10);
@@ -83,7 +86,7 @@ class DemoOrderSeeder extends Seeder
         $detail->save();
         $detail = $this->addDetail($order, $carpeta, null, 'Mora');
         $this->setStatus($detail, $carpeta, 3, hoursAgo: 24);
-        $this->addDetail($order, $medalla, null, 'Mora');
+        $this->addDetail($order, $medalla, null, 'Mora', enabled: true);
         $order->payments()->create(['amount' => 26000, 'type' => 'transferencia', 'transaction_number' => 'BNA48210937566', 'paid_on' => now()->subDays(2)->toDateString()]);
 
         // 6. Fully delivered and paid: gone from /tracking
@@ -105,7 +108,7 @@ class DemoOrderSeeder extends Seeder
         $detail = $this->addDetail($order, $medalla, null, 'Emma');
         $detail->recycled_to = 'reciclaje';
         $detail->save();
-        $order->payments()->create(['amount' => 10000, 'type' => 'efectivo', 'paid_on' => now()->subDays(1)->toDateString()]);
+        $order->payments()->create(['amount' => 14000, 'type' => 'efectivo', 'paid_on' => now()->subDays(1)->toDateString()]);
         $order->cancelled_at = now()->subDay();
         $order->save();
 
@@ -113,18 +116,23 @@ class DemoOrderSeeder extends Seeder
         $order = $this->makeOrder($sextoA, 'Hernán Luna', '3804000008', 'Isabella', 8, 18000, 2, -15);
         $detail = $this->addDetail($order, $taza, null, 'Taza de Isabella');
         $this->setStatus($detail, $taza, 2, hoursAgo: 120);
-        $this->addDetail($order, $medalla, null, 'Isabella');
+        $this->addDetail($order, $medalla, null, 'Isabella', enabled: true);
         $order->payments()->create(['amount' => 9000, 'type' => 'efectivo', 'paid_on' => now()->subDays(5)->toDateString()]);
 
         // 9. Did not attend the photo session: no photo number assigned
         $order = $this->makeOrder($sextoA, 'Irina Sosa', '3804000009', 'Simón', null, 18000, 1, 12, attended: false);
-        $this->addDetail($order, $carpeta, null, 'Simón');
+        $this->addDetail($order, $carpeta, null, 'Simón', enabled: true);
+        $order->payments()->create(['amount' => 18000, 'type' => 'efectivo', 'paid_on' => now()->subDays(2)->toDateString()]);
 
         // Orders on the other schools so the school filters have data
         $order = $this->makeOrder($salaDe5, 'Julia Toledo', '3804000010', 'Bautista', 1, 12000, 1, 18);
         $detail = $this->addDetail($order, $taza, null, 'Taza de Bautista');
         $this->setStatus($detail, $taza, 3, hoursAgo: 12);
+        $order->payments()->create(['amount' => 12000, 'type' => 'transferencia', 'transaction_number' => 'MP58316742900', 'paid_on' => now()->subDays(1)->toDateString()]);
 
+        // 11. Production not enabled: no payment yet, so the clásico is out
+        // of /tracking until the first installment is paid and the office
+        // enables it from the order page (#106)
         $order = $this->makeOrder($quintoHum, 'Karen Ibáñez', '3804000011', 'Renata', 1, 44000, 4, 22);
         $this->addDetail($order, $clasico, $this->muralVariant('vertical', 'pink'), 'Renata - promo 2026');
     }
@@ -157,9 +165,13 @@ class DemoOrderSeeder extends Seeder
     /**
      * @param  array<string, string>|null  $variant
      */
-    private function addDetail(Order $order, Product $product, ?array $variant, string $note): OrderDetail
+    private function addDetail(Order $order, Product $product, ?array $variant, string $note, bool $enabled = false): OrderDetail
     {
-        $order->products()->attach($product->id, ['variant' => $variant, 'note' => $note]);
+        $order->products()->attach($product->id, [
+            'variant' => $variant,
+            'note' => $note,
+            'production_enabled_at' => $enabled ? now() : null,
+        ]);
 
         /** @var OrderDetail $detail */
         $detail = OrderDetail::where('order_id', $order->id)
@@ -181,6 +193,7 @@ class DemoOrderSeeder extends Seeder
             ->firstOrFail();
 
         $detail->production_status_id = $status->id;
+        $detail->production_enabled_at ??= now()->subHours($hoursAgo);
         $detail->status_updated_at = now()->subHours($hoursAgo);
         $detail->priority = $priority;
         $detail->save();

--- a/e2e/production-enabled.spec.ts
+++ b/e2e/production-enabled.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+// Order #11 (Karen Ibáñez / Renata): a single clásico with no payments —
+// production is gated by the first installment (#106) and no other spec
+// touches this order. First installment: 44000 / 4 = 11000.
+test('production is enabled from the order page after the first installment', async ({
+    page,
+}) => {
+    // Not in tracking and not enableable while nothing is paid
+    await page.goto('/tracking');
+    await expect(
+        page.getByRole('row').filter({ hasText: 'Renata' }),
+    ).toHaveCount(0);
+
+    await page.goto('/orders/11');
+    await expect(page.getByText('sin habilitar').first()).toBeVisible();
+    await expect(
+        page.getByText(/se habilita cuando la primera cuota está paga/),
+    ).toBeVisible();
+
+    // Paying the first installment unlocks the enable button
+    await page.getByRole('button', { name: 'Registrar pago' }).click();
+    const modal = page.getByRole('dialog');
+    await modal.locator('#amount').fill('11000');
+    await modal.getByRole('button', { name: 'Registrar pago' }).click();
+
+    const enable = page.getByRole('button', {
+        name: 'Habilitar fabricación',
+    });
+    await expect(enable).toBeVisible();
+    await enable.click();
+    await expect(
+        page.getByText('Estado de fabricación actualizado'),
+    ).toBeVisible();
+    await expect(page.getByText('Sin empezar').first()).toBeVisible();
+
+    // The clásico now shows up on the workshop board as pending
+    await page.goto('/tracking');
+    await expect(
+        page.getByRole('row').filter({ hasText: 'Renata' }),
+    ).toBeVisible();
+
+    // And its stage can be set right from the order page
+    await page.goto('/orders/11');
+    await page.getByRole('combobox', { name: /Estado de fabricación/ }).click();
+    await page.getByRole('option', { name: 'Impreso' }).click();
+    await expect(
+        page.getByText('Estado de fabricación actualizado'),
+    ).toBeVisible();
+});

--- a/resources/js/pages/orders/components/details.test.tsx
+++ b/resources/js/pages/orders/components/details.test.tsx
@@ -29,6 +29,9 @@ const makeProduct = (overrides: Partial<OrderProduct> = {}): OrderProduct =>
         recycled_to: null,
         priority: false,
         production_status: 'Impreso',
+        production_status_id: 21,
+        production_enabled: true,
+        statuses: [{ id: 21, name: 'Impreso', position: 1 }],
         ...overrides,
     }) as unknown as OrderProduct;
 
@@ -40,6 +43,7 @@ const makeOrder = (
         id: 1,
         products,
         cancelled_at: null,
+        first_installment_paid: true,
         ...overrides,
     }) as unknown as Order;
 
@@ -104,5 +108,51 @@ describe('Details', () => {
         );
 
         expect(screen.queryByText('Priorizar')).toBeNull();
+    });
+
+    it('shows "Sin habilitar" and enables production from the badge area', () => {
+        render(
+            <Details
+                order={makeOrder([
+                    makeProduct({
+                        production_enabled: false,
+                        production_status: null,
+                        production_status_id: null,
+                    }),
+                ])}
+            />,
+        );
+
+        expect(screen.getByText('Sin habilitar')).toBeTruthy();
+
+        fireEvent.click(screen.getByText('Habilitar fabricación'));
+
+        expect(put).toHaveBeenCalledWith(
+            'http://localhost/orders.production-status/1',
+            { detail_id: 11, production_status_id: null },
+            expect.anything(),
+        );
+    });
+
+    it('only explains the gate while the first installment is unpaid', () => {
+        render(
+            <Details
+                order={makeOrder(
+                    [
+                        makeProduct({
+                            production_enabled: false,
+                            production_status: null,
+                            production_status_id: null,
+                        }),
+                    ],
+                    { first_installment_paid: false },
+                )}
+            />,
+        );
+
+        expect(screen.queryByText('Habilitar fabricación')).toBeNull();
+        expect(
+            screen.getByText(/se habilita cuando la primera cuota está paga/),
+        ).toBeTruthy();
     });
 });

--- a/resources/js/pages/orders/components/details.tsx
+++ b/resources/js/pages/orders/components/details.tsx
@@ -11,9 +11,12 @@ import { ProductIcon } from '@/features/product-icon';
 import { capitalize, formatPrice } from '@/lib/utils';
 import { Flame } from 'lucide-react';
 import { useDetailPriority } from '../hooks/use-detail-priority';
+import { useDetailProductionStatus } from '../hooks/use-detail-production-status';
+import { ProductionStatusControl } from './production-status-control';
 
 export function Details({ order }: { order: Order }) {
     const { toggle } = useDetailPriority(order.id);
+    const { setStatus } = useDetailProductionStatus(order.id);
     const products = order.products || [];
     const isCancelled = Boolean(order.cancelled_at);
 
@@ -39,6 +42,12 @@ export function Details({ order }: { order: Order }) {
                                     !product.priority,
                                 )
                             }
+                            firstInstallmentPaid={Boolean(
+                                order.first_installment_paid,
+                            )}
+                            onStatusChange={(statusId) =>
+                                setStatus(product.order_detail_id, statusId)
+                            }
                         />
                     ))
                 ) : (
@@ -56,10 +65,14 @@ function DetailItem({
     product,
     canPrioritize,
     onTogglePriority,
+    firstInstallmentPaid,
+    onStatusChange,
 }: {
     product: OrderProduct;
     canPrioritize: boolean;
     onTogglePriority: () => void;
+    firstInstallmentPaid: boolean;
+    onStatusChange: (statusId: number | null) => void;
 }) {
     return (
         <div
@@ -111,7 +124,9 @@ function DetailItem({
                         </Badge>
                     ) : (
                         <Badge variant="outline">
-                            {product.production_status ?? 'Sin empezar'}
+                            {product.production_enabled
+                                ? (product.production_status ?? 'Sin empezar')
+                                : 'Sin habilitar'}
                         </Badge>
                     )}
                     {product.note && (
@@ -121,15 +136,24 @@ function DetailItem({
                     )}
                 </div>
                 {canPrioritize && (
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="mt-2 h-auto px-2 py-1 text-xs"
-                        onClick={onTogglePriority}
-                    >
-                        <Flame className="mr-1 h-3 w-3" />
-                        {product.priority ? 'Quitar prioridad' : 'Priorizar'}
-                    </Button>
+                    <>
+                        <ProductionStatusControl
+                            product={product}
+                            firstInstallmentPaid={firstInstallmentPaid}
+                            onChange={onStatusChange}
+                        />
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="mt-2 h-auto px-2 py-1 text-xs"
+                            onClick={onTogglePriority}
+                        >
+                            <Flame className="mr-1 h-3 w-3" />
+                            {product.priority
+                                ? 'Quitar prioridad'
+                                : 'Priorizar'}
+                        </Button>
+                    </>
                 )}
             </div>
         </div>

--- a/resources/js/pages/orders/components/order-info-card.tsx
+++ b/resources/js/pages/orders/components/order-info-card.tsx
@@ -13,6 +13,7 @@ import { Link } from '@inertiajs/react';
 import { Ban, Edit2 } from 'lucide-react';
 
 const STATUS_STYLES: Record<string, string> = {
+    'sin habilitar': 'bg-zinc-400 hover:bg-zinc-400',
     pendiente: 'bg-gray-500 hover:bg-gray-500',
     'en producción': 'bg-blue-600 hover:bg-blue-600',
     terminado: 'bg-violet-600 hover:bg-violet-600',

--- a/resources/js/pages/orders/components/production-status-control.test.tsx
+++ b/resources/js/pages/orders/components/production-status-control.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProductionStatusControl } from './production-status-control';
+
+const makeProduct = (overrides: Partial<OrderProduct> = {}): OrderProduct =>
+    ({
+        id: 5,
+        order_detail_id: 11,
+        name: 'Mural',
+        production_enabled: true,
+        production_status: null,
+        production_status_id: null,
+        statuses: [
+            { id: 21, name: 'Impreso', position: 1 },
+            { id: 22, name: 'Pegado', position: 2 },
+        ],
+        ...overrides,
+    }) as unknown as OrderProduct;
+
+describe('ProductionStatusControl', () => {
+    it('explains the gate while the first installment is unpaid', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({ production_enabled: false })}
+                firstInstallmentPaid={false}
+                onChange={onChange}
+            />,
+        );
+
+        expect(
+            screen.getByText(/se habilita cuando la primera cuota está paga/),
+        ).toBeTruthy();
+        expect(screen.queryByText('Habilitar fabricación')).toBeNull();
+    });
+
+    it('enables production once the first installment is paid', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({ production_enabled: false })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Habilitar fabricación'));
+
+        expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('shows the current stage and moves the detail to another one', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Impreso',
+                    production_status_id: 21,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        expect(trigger.textContent).toContain('Impreso');
+
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Pegado' }));
+
+        expect(onChange).toHaveBeenCalledWith(22);
+    });
+
+    it('offers "Sin empezar" for an enabled detail without a stage', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct()}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        expect(trigger.textContent).toContain('Sin empezar');
+
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Impreso' }));
+
+        expect(onChange).toHaveBeenCalledWith(21);
+    });
+});

--- a/resources/js/pages/orders/components/production-status-control.tsx
+++ b/resources/js/pages/orders/components/production-status-control.tsx
@@ -1,0 +1,79 @@
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Factory } from 'lucide-react';
+
+const PENDING = 'none';
+
+/**
+ * Production status of a detail, editable from the order page (#106).
+ * Production is gated by the first installment: until it is paid the
+ * detail stays out of /tracking and this control only explains why.
+ */
+export function ProductionStatusControl({
+    product,
+    firstInstallmentPaid,
+    onChange,
+}: {
+    product: OrderProduct;
+    firstInstallmentPaid: boolean;
+    onChange: (statusId: number | null) => void;
+}) {
+    if (!product.production_enabled) {
+        if (!firstInstallmentPaid) {
+            return (
+                <p className="mt-2 text-xs text-muted-foreground">
+                    La fabricación se habilita cuando la primera cuota está
+                    paga.
+                </p>
+            );
+        }
+
+        return (
+            <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 h-auto px-2 py-1 text-xs"
+                onClick={() => onChange(null)}
+            >
+                <Factory className="mr-1 h-3 w-3" />
+                Habilitar fabricación
+            </Button>
+        );
+    }
+
+    const statuses = product.statuses ?? [];
+
+    return (
+        <Select
+            value={
+                product.production_status_id
+                    ? String(product.production_status_id)
+                    : PENDING
+            }
+            onValueChange={(value) =>
+                onChange(value === PENDING ? null : Number(value))
+            }
+        >
+            <SelectTrigger
+                className="mt-2 h-8 w-fit gap-2 text-xs"
+                aria-label={`Estado de fabricación de ${product.name}`}
+            >
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                <SelectItem value={PENDING}>Sin empezar</SelectItem>
+                {statuses.map((status) => (
+                    <SelectItem key={status.id} value={String(status.id)}>
+                        {status.name}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+}

--- a/resources/js/pages/orders/hooks/use-detail-production-status.ts
+++ b/resources/js/pages/orders/hooks/use-detail-production-status.ts
@@ -1,0 +1,26 @@
+import { router } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+export function useDetailProductionStatus(orderId: number) {
+    const setStatus = (detailId: number, statusId: number | null) => {
+        router.put(
+            route('orders.production-status', { order: orderId }),
+            {
+                detail_id: detailId,
+                production_status_id: statusId,
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () =>
+                    toast.success('Estado de fabricación actualizado'),
+                onError: (errors) =>
+                    toast.error(
+                        Object.values(errors)[0] ??
+                            'No se pudo actualizar el estado',
+                    ),
+            },
+        );
+    };
+
+    return { setStatus };
+}

--- a/resources/js/pages/orders/tests/use-detail-production-status.test.tsx
+++ b/resources/js/pages/orders/tests/use-detail-production-status.test.tsx
@@ -1,0 +1,75 @@
+import { router } from '@inertiajs/react';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDetailProductionStatus } from '../hooks/use-detail-production-status';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { put: vi.fn() },
+}));
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast }));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.order ?? ''}`,
+);
+
+const put = vi.mocked(router.put);
+
+const lastPutOptions = () =>
+    put.mock.calls.at(-1)?.[2] as unknown as {
+        preserveScroll?: boolean;
+        onSuccess?: () => void;
+        onError?: (errors: Record<string, string>) => void;
+    };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useDetailProductionStatus', () => {
+    it('enables production with a null status', () => {
+        const { result } = renderHook(() => useDetailProductionStatus(3));
+
+        result.current.setStatus(11, null);
+
+        expect(put).toHaveBeenCalledWith(
+            'http://localhost/orders.production-status/3',
+            { detail_id: 11, production_status_id: null },
+            expect.objectContaining({ preserveScroll: true }),
+        );
+
+        lastPutOptions().onSuccess?.();
+        expect(toast.success).toHaveBeenCalledWith(
+            'Estado de fabricación actualizado',
+        );
+    });
+
+    it('moves the detail to a stage', () => {
+        const { result } = renderHook(() => useDetailProductionStatus(3));
+
+        result.current.setStatus(11, 7);
+
+        expect(put).toHaveBeenCalledWith(
+            'http://localhost/orders.production-status/3',
+            { detail_id: 11, production_status_id: 7 },
+            expect.anything(),
+        );
+    });
+
+    it('surfaces the backend gate error as a toast', () => {
+        const { result } = renderHook(() => useDetailProductionStatus(3));
+
+        result.current.setStatus(11, null);
+        lastPutOptions().onError?.({
+            order: 'La fabricación se habilita cuando la primera cuota está paga.',
+        });
+
+        expect(toast.error).toHaveBeenCalledWith(
+            'La fabricación se habilita cuando la primera cuota está paga.',
+        );
+    });
+});

--- a/resources/js/tests/setup.ts
+++ b/resources/js/tests/setup.ts
@@ -14,6 +14,12 @@ vi.stubGlobal(
     },
 );
 
+// jsdom does not implement the pointer-capture and scrolling APIs that
+// Radix Select relies on to open its listbox
+Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.releasePointerCapture = vi.fn();
+
 // jsdom does not implement matchMedia, required by the sidebar's
 // useIsMobile hook and other responsive components
 Object.defineProperty(window, 'matchMedia', {

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -120,8 +120,11 @@ declare global {
         delivered_at?: string | null;
         production_status?: string | null;
         production_status_id?: number | null;
+        production_enabled?: boolean;
         priority?: boolean | null;
         recycled_to?: 'stock' | 'reciclaje' | null;
+        /** Stages of the product's chain, ordered by position */
+        statuses?: ProductionStatus[];
     }
 
     interface ProductionStatus {
@@ -147,6 +150,7 @@ declare global {
     }
 
     type OrderStatus =
+        | 'sin habilitar'
         | 'pendiente'
         | 'en producción'
         | 'terminado'
@@ -171,6 +175,7 @@ declare global {
         balance?: number;
         can_edit?: boolean;
         can_delete?: boolean;
+        first_installment_paid?: boolean;
         client: Client;
         classroom: Classroom;
         school: School;

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\BO\ComboController;
 use App\Http\Controllers\BO\DashboardController;
 use App\Http\Controllers\BO\DeliveryController;
 use App\Http\Controllers\BO\DetailPriorityController;
+use App\Http\Controllers\BO\DetailProductionStatusController;
 use App\Http\Controllers\BO\NoteController;
 use App\Http\Controllers\BO\OrderController;
 use App\Http\Controllers\BO\OrderDraftController;
@@ -35,6 +36,7 @@ Route::middleware(['auth', 'role:master,administración,oficina'])->group(functi
     Route::post('/orders/{order}/cancel', [OrderController::class, 'cancel'])->name('orders.cancel');
     Route::put('/orders/{order}/delivery', [DeliveryController::class, 'update'])->name('orders.delivery');
     Route::put('/orders/{order}/priority', [DetailPriorityController::class, 'update'])->name('orders.priority');
+    Route::put('/orders/{order}/production-status', [DetailProductionStatusController::class, 'update'])->name('orders.production-status');
     Route::resource('drafts', OrderDraftController::class)->only(['index', 'store', 'destroy']);
     Route::resource('schools', SchoolController::class);
     Route::resource('classrooms', ClassroomController::class)->only(['destroy', 'update', 'store', 'show']);

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -17,15 +17,17 @@ it('computes the dashboard metrics', function () {
     $order = Order::factory()->create(['total_price' => 64000]);
     Payment::factory()->create(['order_id' => $order->id, 'amount' => 16000]);
 
-    OrderDetail::factory()->create(['order_id' => $order->id]); // sin empezar
-    OrderDetail::factory()->create([
+    OrderDetail::factory()->enabled()->create(['order_id' => $order->id]); // sin empezar
+    OrderDetail::factory()->enabled()->create([
         'order_id' => $order->id,
         'production_status_id' => statusFor('taza', 2)->id, // en producción
     ]);
-    OrderDetail::factory()->create([
+    OrderDetail::factory()->enabled()->create([
         'order_id' => $order->id,
         'production_status_id' => statusFor('taza', 4)->id, // último estado
     ]);
+    // Sin habilitar (primera cuota impaga): fuera de las métricas de producción
+    OrderDetail::factory()->create(['order_id' => $order->id]);
 
     // Cancelado: excluido de todas las métricas
     Order::factory()->cancelled()->create(['total_price' => 12000]);

--- a/tests/Feature/DetailProductionStatusTest.php
+++ b/tests/Feature/DetailProductionStatusTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Stockable;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\put;
+
+/**
+ * Order with its first installment (total / plan) already paid, so
+ * production can be enabled (#106).
+ */
+function orderWithFirstInstallmentPaid(): Order
+{
+    $order = Order::factory()->create(['total_price' => 64000, 'payment_plan' => 4]);
+    $order->payments()->create(['amount' => 16000, 'type' => 'efectivo', 'paid_on' => now()->toDateString()]);
+
+    return $order;
+}
+
+it('refuses to enable production before the first installment is paid', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->create(['total_price' => 64000, 'payment_plan' => 4]);
+    $order->payments()->create(['amount' => 15999, 'type' => 'efectivo', 'paid_on' => now()->toDateString()]);
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasErrors('order');
+
+    expect($detail->refresh()->production_enabled_at)->toBeNull();
+});
+
+it('enables a detail as "sin empezar" once the first installment is paid', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasNoErrors();
+
+    $detail->refresh();
+    expect($detail->production_enabled_at)->not->toBeNull()
+        ->and($detail->production_status_id)->toBeNull();
+});
+
+it('keeps a not-enabled detail out of tracking and shows it once enabled', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    get(route('tracking.index'))->assertInertia(
+        fn (Assert $page) => $page->has('details', 0),
+    );
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ]);
+
+    get(route('tracking.index'))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('details', 1)
+            ->where('details.0.id', $detail->id)
+            ->where('details.0.production_status_id', null),
+    );
+});
+
+it('moves a detail to a stage of its product, deducting the stage stock', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = productWithChain(['Impreso', 'Pegado']);
+    $planchas = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => 2]);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ])->assertSessionHasNoErrors();
+
+    $detail->refresh();
+    expect($detail->production_status_id)->toBe(stageOf($product, 2)->id)
+        ->and($detail->production_enabled_at)->not->toBeNull()
+        ->and($planchas->refresh()->quantity)->toBe(8);
+});
+
+it('returns a detail to "sin empezar" without giving the stock back', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = productWithChain(['Impreso', 'Pegado']);
+    $planchas = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => 2]);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasNoErrors();
+
+    $detail->refresh();
+    expect($detail->production_status_id)->toBeNull()
+        ->and($detail->production_enabled_at)->not->toBeNull()
+        ->and($planchas->refresh()->quantity)->toBe(8);
+});
+
+it('rejects a stage that belongs to another product', function () {
+    actingAsRole(UserRole::Office);
+
+    $mural = productWithChain();
+    $taza = productWithChain();
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $taza->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($mural, 1)->id,
+    ])->assertSessionHasErrors('detail_ids');
+
+    expect($detail->refresh()->production_status_id)->toBeNull();
+});
+
+it('rejects a detail that belongs to another order', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $foreign = OrderDetail::factory()->create();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $foreign->id,
+        'production_status_id' => null,
+    ])->assertSessionHasErrors('detail_id');
+
+    expect($foreign->refresh()->production_enabled_at)->toBeNull();
+});
+
+it('rejects delivered and recycled details', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $delivered = OrderDetail::factory()->delivered()->create(['order_id' => $order->id]);
+    $recycled = OrderDetail::factory()->recycled()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $delivered->id,
+        'production_status_id' => null,
+    ])->assertSessionHasErrors('detail_id');
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $recycled->id,
+        'production_status_id' => null,
+    ])->assertSessionHasErrors('detail_id');
+});
+
+it('rejects a cancelled order', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->cancelled()->create();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasErrors('order');
+
+    expect($detail->refresh()->production_enabled_at)->toBeNull();
+});
+
+it('denies the workshop role, which changes stages from tracking instead', function () {
+    actingAsRole(UserRole::Worker);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertForbidden();
+
+    expect($detail->refresh()->production_enabled_at)->toBeNull();
+});

--- a/tests/Feature/TrackingTest.php
+++ b/tests/Feature/TrackingTest.php
@@ -174,15 +174,17 @@ it('never deducts twice when moving back and forth', function () {
         ->and($tiras->movements()->count())->toBe(1);
 });
 
-it('lists only pending details of active orders', function () {
+it('lists only enabled, pending details of active orders', function () {
     actingAsRole(UserRole::Worker);
 
-    $pending = OrderDetail::factory()->create();
+    $pending = OrderDetail::factory()->enabled()->create();
     OrderDetail::factory()->delivered()->create();
     OrderDetail::factory()->recycled()->create();
-    OrderDetail::factory()->create([
+    OrderDetail::factory()->enabled()->create([
         'order_id' => Order::factory()->cancelled()->create()->id,
     ]);
+    // Production not enabled yet: the first installment gates it (#106)
+    OrderDetail::factory()->create();
 
     get(route('tracking.index'))->assertInertia(
         fn (Assert $page) => $page


### PR DESCRIPTION
## Resumen

"Si no se pagó la primera cuota, no se fabrica" (reunión 9/7, §2.5). Sobre el modelo de etapas por producto (#90), el estado previo a la cadena se representa con `order_details.production_enabled_at` (nullable):

- **`NULL` = "sin habilitar"**: el producto **no aparece en /tracking** ni en las métricas de producción del dashboard.
- **Con fecha y sin etapa = "sin empezar"**: entra a seguimiento como pendiente, igual que hasta ahora.

## Cambios

- **Habilitación manual desde el pedido**: nuevo endpoint `PUT /orders/{order}/production-status` (roles de venta). Quien atiende, al registrar el primer pago, habilita la fabricación de cada producto ("Habilitar fabricación") o le asigna directamente una etapa de su cadena.
- **Gate por primera cuota**: `Order::firstInstallmentPaid()` (total / cuotas). Sin la primera cuota paga, el endpoint rechaza con un mensaje claro y la UI solo muestra el aviso. `can_edit` ahora reutiliza el mismo método (misma semántica que antes).
- **Cambio de etapa desde orders/:id**: delega en `MoveDetailsToStage`, así el descuento de insumos por etapas alcanzadas (idempotente) y la devolución por cancelación siguen intactos. Mover a una etapa marca el detalle como habilitado por invariante.
- **UI**: badge "Sin habilitar" por producto, estado agregado nuevo `sin habilitar` en la ficha del pedido, y un select por producto ("Sin empezar" + etapas de su cadena) cuando la fabricación ya está habilitada.
- **Seed demo coherente**: todo pedido con productos en /tracking tiene su primera cuota paga; el pedido #11 (Renata) queda sin pagos como demo del estado nuevo.
- **Tests**: `DetailProductionStatusTest` (10 casos: gate, habilitación, etapa + stock, guards, roles), TrackingTest/DashboardTest actualizados, 3 archivos de vitest y spec e2e nuevo (`production-enabled.spec.ts`, pedido #11: paga → habilita → aparece en tracking → cambia etapa).

## Notas

- La migración de `order_details` se editó in-place (sin producción real): requiere `migrate:fresh --seed`.
- Los detalles ya recycled/entregados no se tocan; los pedidos cancelados rechazan el cambio.

Closes #106
