### PR TITLE
feat(tracking): filtro por curso en el seguimiento

### DIFF
--- a/app/Http/Controllers/BO/TrackingController.php
+++ b/app/Http/Controllers/BO/TrackingController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\BO;
 use App\Actions\Tracking\MoveDetailsToStage;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\BatchUpdateTrackingRequest;
+use App\Models\Classroom;
 use App\Models\Order;
 use App\Models\OrderDetail;
 use App\Models\Product;
@@ -26,8 +27,8 @@ class TrackingController extends Controller
         /** @var string|null $search */
         $search = $request->query('search');
 
-        /** @var string|null $school_id */
-        $school_id = $request->query('school_id');
+        $school_id = $request->filled('school_id') ? $request->integer('school_id') : null;
+        $classroom_id = $request->filled('classroom_id') ? $request->integer('classroom_id') : null;
 
         /** @var string|null $product_type_id */
         $product_type_id = $request->query('product_type_id');
@@ -42,11 +43,15 @@ class TrackingController extends Controller
             // Production starts with the first paid installment: details not
             // yet enabled from the order page stay out of the workshop board
             ->whereNotNull('production_enabled_at')
-            ->whereHas('order', function ($query) use ($school_id, $search) {
+            ->whereHas('order', function ($query) use ($school_id, $classroom_id, $search) {
                 $query->whereNull('cancelled_at');
 
-                if (! empty($school_id)) {
+                if ($school_id !== null) {
                     $query->whereHas('classroom', fn ($q) => $q->where('school_id', $school_id));
+                }
+
+                if ($classroom_id !== null) {
+                    $query->where('classroom_id', $classroom_id);
                 }
 
                 if (! empty($search)) {
@@ -78,7 +83,7 @@ class TrackingController extends Controller
             ->with('type', 'productionStatuses')
             ->get();
 
-        $schools = School::query()->whereHas('classrooms')->get();
+        $schools = School::query()->with('classrooms')->whereHas('classrooms')->get();
 
         return Inertia::render('tracking/index', [
             'details' => $details->map(function (OrderDetail $detail) {
@@ -121,10 +126,16 @@ class TrackingController extends Controller
             'schools' => $schools->map(fn (School $school) => [
                 'id' => $school->id,
                 'name' => $school->name,
+                'classrooms' => $school->classrooms->map(fn (Classroom $classroom) => [
+                    'id' => $classroom->id,
+                    'name' => $classroom->name,
+                    'school_id' => $classroom->school_id,
+                ]),
             ]),
             'filters' => [
                 'search' => $search,
                 'school_id' => $school_id,
+                'classroom_id' => $classroom_id,
                 'product_type_id' => $product_type_id,
                 'production_status_id' => $production_status_id,
             ],

--- a/resources/js/pages/tracking/components/tracking-filters.tsx
+++ b/resources/js/pages/tracking/components/tracking-filters.tsx
@@ -13,9 +13,16 @@ import { useState } from 'react';
 
 export type Filters = {
     search: string | null;
-    school_id: string | null;
+    school_id: number | null;
+    classroom_id: number | null;
     product_type_id: string | null;
     production_status_id: string | null;
+};
+
+export type SchoolWithClassrooms = {
+    id: number;
+    name: string;
+    classrooms: Array<{ id: number; name: string; school_id: number }>;
 };
 
 export function TrackingFilters({
@@ -25,14 +32,36 @@ export function TrackingFilters({
     onApply,
 }: {
     filters: Filters;
-    schools: Array<{ id: number; name: string }>;
+    schools: SchoolWithClassrooms[];
     productTypes: ProductType[];
     onApply: (overrides: Partial<Filters> & { search?: string }) => void;
 }) {
     const [search, setSearch] = useState(filters.search ?? '');
 
+    // A classroom implies its school, so the school select also reflects
+    // visits that only carried classroom_id
+    const selectedSchool =
+        schools.find((school) => school.id === filters.school_id) ??
+        schools.find((school) =>
+            school.classrooms.some(
+                (classroom) => classroom.id === filters.classroom_id,
+            ),
+        );
+
+    const classroomItems = selectedSchool
+        ? selectedSchool.classrooms.map((classroom) => ({
+              id: classroom.id,
+              label: classroom.name,
+          }))
+        : schools.flatMap((school) =>
+              school.classrooms.map((classroom) => ({
+                  id: classroom.id,
+                  label: `${school.name} — ${classroom.name}`,
+              })),
+          );
+
     return (
-        <div className="flex flex-col gap-2 md:flex-row md:items-center">
+        <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
             <form
                 className="flex items-center gap-2"
                 onSubmit={(e) => {
@@ -52,11 +81,13 @@ export function TrackingFilters({
             </form>
 
             <Select
-                value={filters.school_id ? String(filters.school_id) : 'all'}
+                value={selectedSchool ? String(selectedSchool.id) : 'all'}
                 onValueChange={(value) =>
+                    // Changing school invalidates any classroom filter
                     onApply({
                         search,
-                        school_id: value === 'all' ? null : value,
+                        school_id: value === 'all' ? null : Number(value),
+                        classroom_id: null,
                     })
                 }
             >
@@ -68,6 +99,33 @@ export function TrackingFilters({
                     {schools.map((school) => (
                         <SelectItem value={String(school.id)} key={school.id}>
                             {school.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <Select
+                value={
+                    filters.classroom_id ? String(filters.classroom_id) : 'all'
+                }
+                onValueChange={(value) =>
+                    onApply({
+                        search,
+                        classroom_id: value === 'all' ? null : Number(value),
+                    })
+                }
+            >
+                <SelectTrigger className="md:w-56">
+                    <SelectValue placeholder="Curso" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="all">Todos los cursos</SelectItem>
+                    {classroomItems.map((classroom) => (
+                        <SelectItem
+                            value={String(classroom.id)}
+                            key={classroom.id}
+                        >
+                            {classroom.label}
                         </SelectItem>
                     ))}
                 </SelectContent>

--- a/resources/js/pages/tracking/index.tsx
+++ b/resources/js/pages/tracking/index.tsx
@@ -13,7 +13,11 @@ import {
     TrackingDetail,
     TrackingProduct,
 } from './components/product-group';
-import { Filters, TrackingFilters } from './components/tracking-filters';
+import {
+    Filters,
+    SchoolWithClassrooms,
+    TrackingFilters,
+} from './components/tracking-filters';
 import { useSelection } from './hooks/use-selection';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -33,7 +37,7 @@ export default function Tracking({
     details: TrackingDetail[];
     products: TrackingProduct[];
     productTypes: ProductType[];
-    schools: Array<{ id: number; name: string }>;
+    schools: SchoolWithClassrooms[];
     filters: Filters;
 }>) {
     const { selected, toggle, toggleGroupItems, clear } = useSelection();
@@ -53,6 +57,7 @@ export default function Tracking({
 
         if (next.search) params.search = next.search;
         if (next.school_id) params.school_id = String(next.school_id);
+        if (next.classroom_id) params.classroom_id = String(next.classroom_id);
         if (next.product_type_id)
             params.product_type_id = String(next.product_type_id);
         if (next.production_status_id)

--- a/resources/js/pages/tracking/tests/tracking-filters.test.tsx
+++ b/resources/js/pages/tracking/tests/tracking-filters.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    Filters,
+    SchoolWithClassrooms,
+    TrackingFilters,
+} from '../components/tracking-filters';
+
+const schools: SchoolWithClassrooms[] = [
+    {
+        id: 1,
+        name: 'Escuela Normal',
+        classrooms: [
+            { id: 10, name: '5 A', school_id: 1 },
+            { id: 11, name: '5 B', school_id: 1 },
+        ],
+    },
+    {
+        id: 2,
+        name: 'San José',
+        classrooms: [{ id: 20, name: '1 A', school_id: 2 }],
+    },
+];
+
+const productTypes = [{ id: 1, name: 'mural' }] as ProductType[];
+
+const noFilters: Filters = {
+    search: null,
+    school_id: null,
+    classroom_id: null,
+    product_type_id: null,
+    production_status_id: null,
+};
+
+const onApply = vi.fn();
+
+function renderFilters(filters: Partial<Filters> = {}) {
+    return render(
+        <TrackingFilters
+            filters={{ ...noFilters, ...filters }}
+            schools={schools}
+            productTypes={productTypes}
+            onApply={onApply}
+        />,
+    );
+}
+
+function openSelect(currentValue: string) {
+    fireEvent.keyDown(screen.getByText(currentValue), { key: 'Enter' });
+}
+
+beforeEach(() => {
+    onApply.mockClear();
+});
+
+describe('TrackingFilters', () => {
+    it('derives the school from a classroom-only filter', () => {
+        renderFilters({ classroom_id: 10 });
+
+        expect(screen.getByText('Escuela Normal')).toBeTruthy();
+        expect(screen.getByText('5 A')).toBeTruthy();
+    });
+
+    it('drops the classroom filter when the school changes', () => {
+        renderFilters({ school_id: 1, classroom_id: 10 });
+
+        openSelect('Escuela Normal');
+        fireEvent.click(screen.getByRole('option', { name: 'San José' }));
+
+        expect(onApply).toHaveBeenCalledWith({
+            search: '',
+            school_id: 2,
+            classroom_id: null,
+        });
+    });
+
+    it('scopes the classroom list to the filtered school', () => {
+        renderFilters({ school_id: 1 });
+
+        openSelect('Todos los cursos');
+
+        expect(screen.getByRole('option', { name: '5 A' })).toBeTruthy();
+        expect(screen.getByRole('option', { name: '5 B' })).toBeTruthy();
+        expect(screen.queryByRole('option', { name: /1 A/ })).toBeNull();
+    });
+
+    it('prefixes classrooms with their school when no school is filtered', () => {
+        renderFilters();
+
+        openSelect('Todos los cursos');
+
+        expect(
+            screen.getByRole('option', { name: 'Escuela Normal — 5 A' }),
+        ).toBeTruthy();
+        expect(
+            screen.getByRole('option', { name: 'San José — 1 A' }),
+        ).toBeTruthy();
+    });
+
+    it('applies the classroom filter', () => {
+        renderFilters({ school_id: 1 });
+
+        openSelect('Todos los cursos');
+        fireEvent.click(screen.getByRole('option', { name: '5 B' }));
+
+        expect(onApply).toHaveBeenCalledWith({
+            search: '',
+            classroom_id: 11,
+        });
+    });
+});

--- a/tests/Feature/TrackingTest.php
+++ b/tests/Feature/TrackingTest.php
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 use App\Enums\UserRole;
+use App\Models\Classroom;
 use App\Models\Order;
 use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\School;
 use App\Models\Stockable;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -191,5 +194,55 @@ it('lists only enabled, pending details of active orders', function () {
             ->component('tracking/index')
             ->has('details', 1)
             ->where('details.0.id', $pending->id),
+    );
+});
+
+it('filters the board by classroom, narrower than its school', function () {
+    actingAsRole(UserRole::Worker);
+
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
+    $sibling = Classroom::factory()->create(['school_id' => $school->id]);
+
+    $detail = OrderDetail::factory()->enabled()->create([
+        'order_id' => Order::factory()->create(['classroom_id' => $classroom->id])->id,
+    ]);
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => Order::factory()->create(['classroom_id' => $sibling->id])->id,
+    ]);
+    OrderDetail::factory()->enabled()->create();
+
+    get(route('tracking.index', ['school_id' => $school->id]))->assertInertia(
+        fn (Assert $page) => $page->has('details', 2),
+    );
+
+    get(route('tracking.index', ['classroom_id' => $classroom->id]))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('details', 1)
+            ->where('details.0.id', $detail->id),
+    );
+});
+
+it('combines the classroom filter with the product type filter', function () {
+    actingAsRole(UserRole::Worker);
+
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $mural = Product::factory()->mural()->create();
+    $detail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $mural->id,
+    ]);
+    // Same classroom, default product type (taza): the type filter drops it
+    OrderDetail::factory()->enabled()->create(['order_id' => $order->id]);
+
+    get(route('tracking.index', [
+        'classroom_id' => $classroom->id,
+        'product_type_id' => $mural->product_type_id,
+    ]))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('details', 1)
+            ->where('details.0.id', $detail->id),
     );
 });


### PR DESCRIPTION
## Contexto

#107 pedía poder filtrar el seguimiento por **escuela** y por **curso** (reunión 9/7, video 2 ~01:13). El filtro por escuela ya existía en /tracking, así que este PR agrega el filtro por **curso**, combinable con la búsqueda, la escuela y el tipo de producto (el agrupado por producto no cambia).

## Cambios

- **Backend**: `TrackingController@index` acepta `classroom_id` (y parsea `school_id`/`classroom_id` como enteros, igual que en orders). La prop `schools` ahora incluye los cursos de cada escuela y `filters` expone `classroom_id`.
- **Frontend**: select de curso en los filtros del seguimiento, con la misma semántica que el filtro de orders (#155):
  - elegir un curso implica su escuela (el select de escuela la refleja),
  - cambiar de escuela limpia el filtro de curso,
  - sin escuela elegida, los cursos se listan como «Escuela — Curso»; con escuela, solo los suyos.

## Tests

- Pest: filtro por curso (más angosto que su escuela) y combinación curso + tipo de producto en `TrackingTest`.
- Vitest: `tracking-filters.test.tsx` cubre la derivación de escuela, la limpieza del curso al cambiar de escuela, el scope de la lista y la aplicación del filtro.
- Verificado en navegador (Playwright local): flujo completo de filtrado y sin scroll horizontal en 320/351/390 px.

Closes #107