### PR TITLE
Etapas que suman stockeables (deltas con signo por etapa)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Request flow: thin controller (`app/Http/Controllers/BO/`) → dedicated `FormRe
 
 ### Production domain (the non-obvious part)
 
-Production stages belong to a **product** (`production_statuses.product_id`), not a product type. Stock consumption is configured per stage via the `production_status_stockable` pivot (stage, stockable, quantity). Advancing an order detail through stages deducts the configured amounts for every stage reached (cumulative on jumps), recorded in `stock_movements` and idempotent per (detail, stockable). Cancellation returns stock exactly per recorded movements. A stockable may hang off only one stage per product. New products are born with a single "Terminado" stage (`CreateProduct` action).
+Production stages belong to a **product** (`production_statuses.product_id`), not a product type. Stock moves are configured per stage via the `production_status_stockable` pivot (stage, stockable, signed quantity — positive adds stock, negative consumes it), mirroring `stock_movements.quantity`. Advancing an order detail through stages applies the configured deltas for every stage reached (cumulative on jumps), recorded in `stock_movements` and idempotent per (detail, stage, stockable) — the same stockable can be produced by one stage and consumed by another on the same product. Cancelling to `stock` reverses the net balance in both directions (returning net-consumed inputs, subtracting back net-produced intermediates); cancelling to `reciclaje` leaves everything as-is, so produced intermediates stay in stock. New products are born with a single "Terminado" stage (`CreateProduct` action).
 
 ### Frontend structure
 

--- a/app/Actions/Orders/CancelOrder.php
+++ b/app/Actions/Orders/CancelOrder.php
@@ -63,7 +63,7 @@ class CancelOrder implements ActionContract
                 $detail->save();
 
                 if ($destination['destination'] === 'stock') {
-                    $this->stockService->returnForDetail($detail, $user);
+                    $this->stockService->reverseForDetail($detail, $user);
                 }
             }
 

--- a/app/Actions/ProductionStatuses/DeleteProductionStatus.php
+++ b/app/Actions/ProductionStatuses/DeleteProductionStatus.php
@@ -18,7 +18,7 @@ class DeleteProductionStatus implements ActionContract
      *
      * @throws ValidationException when the stage is the only one of its
      *                             product, has details currently in it
-     *                             or consumes stockables
+     *                             or moves stockables
      */
     public function handle(array $params): void
     {
@@ -43,7 +43,7 @@ class DeleteProductionStatus implements ActionContract
 
         if ($status->stockables()->exists()) {
             throw ValidationException::withMessages([
-                'status' => 'No se puede eliminar: esta etapa consume insumos. Quitá esa configuración primero.',
+                'status' => 'No se puede eliminar: esta etapa mueve insumos. Quitá esa configuración primero.',
             ]);
         }
 

--- a/app/Actions/Tracking/MoveDetailsToStage.php
+++ b/app/Actions/Tracking/MoveDetailsToStage.php
@@ -17,9 +17,9 @@ class MoveDetailsToStage implements ActionContract
     public function __construct(private StockService $stockService) {}
 
     /**
-     * Move the given details to a production stage, deducting stock for every
-     * stage reached. Rejects the batch if any detail's product does not own the
-     * stage.
+     * Move the given details to a production stage, applying the stock deltas
+     * hung from every stage reached. Rejects the batch if any detail's product
+     * does not own the stage.
      *
      * @param  array<string, mixed>  $params  {detail_ids: array<int, int>, status: ProductionStatus, user: ?User}
      * @return int the number of details updated
@@ -60,7 +60,7 @@ class MoveDetailsToStage implements ActionContract
                 $detail->save();
                 $detail->setRelation('productionStatus', $status);
 
-                $this->stockService->deductForDetail($detail, $user);
+                $this->stockService->applyForDetail($detail, $user);
             }
         });
 

--- a/app/Enums/StockDirection.php
+++ b/app/Enums/StockDirection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum StockDirection: string
+{
+    case Subtract = 'subtract';
+    case Add = 'add';
+}

--- a/app/Http/Controllers/BO/ProductionStatusStockableController.php
+++ b/app/Http/Controllers/BO/ProductionStatusStockableController.php
@@ -17,20 +17,17 @@ class ProductionStatusStockableController extends Controller
      */
     public function store(StoreProductionStatusStockableRequest $request, ProductionStatus $productionStatus): RedirectResponse
     {
-        /** @var array{stockable_id: int, quantity: int} $validated */
-        $validated = $request->validated();
-
         $productionStatus->stockables()->syncWithoutDetaching([
-            $validated['stockable_id'] => ['quantity' => $validated['quantity']],
+            $request->integer('stockable_id') => ['quantity' => $request->delta()],
         ]);
 
-        return back()->with('success', 'Consumo de insumo guardado');
+        return back()->with('success', 'Movimiento de insumo guardado');
     }
 
     public function destroy(ProductionStatus $productionStatus, Stockable $stockable): RedirectResponse
     {
         $productionStatus->stockables()->detach($stockable->id);
 
-        return back()->with('success', 'Consumo de insumo quitado');
+        return back()->with('success', 'Movimiento de insumo quitado');
     }
 }

--- a/app/Http/Requests/BO/StoreProductionStatusStockableRequest.php
+++ b/app/Http/Requests/BO/StoreProductionStatusStockableRequest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\BO;
 
-use App\Models\ProductionStatus;
+use App\Enums\StockDirection;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreProductionStatusStockableRequest extends FormRequest
 {
@@ -29,40 +29,18 @@ class StoreProductionStatusStockableRequest extends FormRequest
         return [
             'stockable_id' => ['required', 'integer', 'exists:stockables,id'],
             'quantity' => ['required', 'integer', 'min:1'],
+            'direction' => ['required', Rule::enum(StockDirection::class)],
         ];
     }
 
     /**
-     * A stockable can be consumed by at most one stage of a product,
-     * so the deduction stays idempotent per (detail, stockable).
-     *
-     * @return array<int, callable>
+     * Signed pivot delta: positive to add stock, negative to consume it.
      */
-    public function after(): array
+    public function delta(): int
     {
-        return [
-            function (Validator $validator) {
-                if ($validator->errors()->isNotEmpty()) {
-                    return;
-                }
+        $quantity = $this->integer('quantity');
+        $direction = StockDirection::from($this->string('direction')->toString());
 
-                /** @var ProductionStatus $status */
-                $status = $this->route('productionStatus');
-
-                $conflict = ProductionStatus::query()
-                    ->where('product_id', $status->product_id)
-                    ->whereKeyNot($status->id)
-                    ->whereHas('stockables', fn ($query) => $query
-                        ->where('stockables.id', $this->integer('stockable_id')))
-                    ->first();
-
-                if ($conflict !== null) {
-                    $validator->errors()->add(
-                        'stockable_id',
-                        "Este insumo ya se consume en la etapa \"{$conflict->name}\" de este producto.",
-                    );
-                }
-            },
-        ];
+        return $direction === StockDirection::Add ? $quantity : -$quantity;
     }
 }

--- a/app/Http/Resources/ProductStagesResource.php
+++ b/app/Http/Resources/ProductStagesResource.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
  * A product with its production chain and the stockables each stage
- * consumes, for the stages management screen.
+ * moves, for the stages management screen.
  *
  * @mixin Product
  */

--- a/app/Models/ProductionStatus.php
+++ b/app/Models/ProductionStatus.php
@@ -22,7 +22,9 @@ class ProductionStatus extends Model
     }
 
     /**
-     * Stockables consumed when a detail reaches this stage.
+     * Stockables whose stock moves when a detail reaches this stage.
+     * Pivot quantity is a signed delta: positive adds stock, negative
+     * consumes it.
      *
      * @return BelongsToMany<Stockable, $this>
      */

--- a/app/Models/Stockable.php
+++ b/app/Models/Stockable.php
@@ -16,7 +16,7 @@ class Stockable extends Model
     use HasFactory;
 
     /**
-     * Stages that consume this stockable, with the consumed quantity.
+     * Stages that move this stockable's stock, with the signed delta.
      *
      * @return BelongsToMany<ProductionStatus, $this>
      */

--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -9,17 +9,17 @@ use App\Models\ProductionStatus;
 use App\Models\Stockable;
 use App\Models\StockMovement;
 use App\Models\User;
-use Illuminate\Support\Collection;
 
 class StockService
 {
     /**
-     * Deduct every stockable consumed by the stages the detail has
-     * reached or passed. Cumulative (batch jumps deduct the skipped
-     * stages) and idempotent per stockable: moving back and forth
-     * never deducts twice, and going back never returns stock.
+     * Apply every stockable delta hung from the stages the detail has
+     * reached or passed (positive deltas add stock, negative deltas
+     * consume it). Cumulative (batch jumps apply the skipped stages) and
+     * idempotent per (stage, stockable): moving back and forth never
+     * applies the same delta twice, and going back never reverses it.
      */
-    public function deductForDetail(OrderDetail $detail, ?User $user = null): void
+    public function applyForDetail(OrderDetail $detail, ?User $user = null): void
     {
         $detail->loadMissing('productionStatus');
 
@@ -29,47 +29,52 @@ class StockService
             return;
         }
 
-        /** @var Collection<int, Stockable> $consumed */
-        $consumed = ProductionStatus::query()
+        $stages = ProductionStatus::query()
             ->where('product_id', $detail->product_id)
             ->where('position', '<=', $position)
+            ->orderBy('position')
             ->with('stockables')
-            ->get()
-            ->flatMap(fn (ProductionStatus $status) => $status->stockables);
+            ->get();
 
-        if ($consumed->isEmpty()) {
+        if ($stages->sum(fn (ProductionStatus $status) => $status->stockables->count()) === 0) {
             return;
         }
 
-        $deducted = StockMovement::query()
+        /** @var array<string, true> $applied */
+        $applied = StockMovement::query()
             ->where('order_detail_id', $detail->id)
             ->where('reason', 'producción')
-            ->pluck('stockable_id')
+            ->get(['production_status_id', 'stockable_id'])
+            ->mapWithKeys(fn (StockMovement $movement) => ["{$movement->production_status_id}:{$movement->stockable_id}" => true])
             ->all();
 
-        foreach ($consumed as $stockable) {
-            if (in_array($stockable->id, $deducted, true)) {
-                continue;
+        foreach ($stages as $status) {
+            foreach ($status->stockables as $stockable) {
+                if (isset($applied["{$status->id}:{$stockable->id}"])) {
+                    continue;
+                }
+
+                $delta = (int) $stockable->getRelationValue('pivot')->quantity; // @phpstan-ignore-line
+
+                $stockable->movements()->create([
+                    'order_detail_id' => $detail->id,
+                    'production_status_id' => $status->id,
+                    'user_id' => $user?->id,
+                    'quantity' => $delta,
+                    'reason' => 'producción',
+                ]);
+
+                $stockable->increment('quantity', $delta);
             }
-
-            $quantity = (int) $stockable->getRelationValue('pivot')->quantity; // @phpstan-ignore-line
-
-            $stockable->movements()->create([
-                'order_detail_id' => $detail->id,
-                'user_id' => $user?->id,
-                'quantity' => -$quantity,
-                'reason' => 'producción',
-            ]);
-
-            $stockable->decrement('quantity', $quantity);
         }
     }
 
     /**
-     * Return to stock exactly what the detail's movements deducted and
-     * was not returned yet.
+     * Reverse the net balance the detail's movements left on each
+     * stockable: net-consumed stock comes back, net-produced stock is
+     * subtracted back out.
      */
-    public function returnForDetail(OrderDetail $detail, ?User $user = null): void
+    public function reverseForDetail(OrderDetail $detail, ?User $user = null): void
     {
         /** @var array<int, int|string> $balances */
         $balances = StockMovement::query()
@@ -80,9 +85,9 @@ class StockService
             ->all();
 
         foreach ($balances as $stockableId => $balance) {
-            $pending = -(int) $balance;
+            $delta = -(int) $balance;
 
-            if ($pending <= 0) {
+            if ($delta === 0) {
                 continue;
             }
 
@@ -95,11 +100,11 @@ class StockService
             $stockable->movements()->create([
                 'order_detail_id' => $detail->id,
                 'user_id' => $user?->id,
-                'quantity' => $pending,
-                'reason' => 'devolución por cancelación',
+                'quantity' => $delta,
+                'reason' => $delta > 0 ? 'devolución por cancelación' : 'ajuste por cancelación',
             ]);
 
-            $stockable->increment('quantity', $pending);
+            $stockable->increment('quantity', $delta);
         }
     }
 }

--- a/database/migrations/2025_01_10_155817_create_production_status_stockable.php
+++ b/database/migrations/2025_01_10_155817_create_production_status_stockable.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('production_status_id')->constrained()->cascadeOnDelete();
             $table->foreignId('stockable_id')->constrained()->cascadeOnDelete();
-            $table->unsignedInteger('quantity')->default(1);
+            $table->integer('quantity');
             $table->unique(['production_status_id', 'stockable_id'], 'status_stockable_unique');
             $table->timestamps();
         });

--- a/database/migrations/2025_02_22_162357_create_stock_movements_table.php
+++ b/database/migrations/2025_02_22_162357_create_stock_movements_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('stockable_id')->constrained()->cascadeOnDelete();
             $table->foreignId('order_detail_id')->nullable()->constrained('order_details')->nullOnDelete();
+            $table->foreignId('production_status_id')->nullable()->constrained()->nullOnDelete();
             $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->integer('quantity');
             $table->string('reason');

--- a/database/seeders/DemoOrderSeeder.php
+++ b/database/seeders/DemoOrderSeeder.php
@@ -102,7 +102,7 @@ class DemoOrderSeeder extends Seeder
         $order = $this->makeOrder($sextoA, 'Gimena Vera', '3804000007', 'Emma', 7, 54000, 4, 18);
         $detail = $this->addDetail($order, $molduraAncha, $this->muralVariant('vertical', 'black'), 'Emma - egresados 2026');
         $this->setStatus($detail, $molduraAncha, 4, hoursAgo: 60);
-        $this->stock->returnForDetail($detail, $this->master);
+        $this->stock->reverseForDetail($detail, $this->master);
         $detail->recycled_to = 'stock';
         $detail->save();
         $detail = $this->addDetail($order, $medalla, null, 'Emma');
@@ -183,8 +183,8 @@ class DemoOrderSeeder extends Seeder
     }
 
     /**
-     * Moves a detail to the given stage mirroring the tracking flow:
-     * the service deducts whatever the reached stages consume.
+     * Moves a detail to the given stage mirroring the tracking flow: the
+     * service applies whatever the reached stages add or consume.
      */
     private function setStatus(OrderDetail $detail, Product $product, int $position, bool $priority = false, int $hoursAgo = 0): void
     {
@@ -199,7 +199,7 @@ class DemoOrderSeeder extends Seeder
         $detail->save();
         $detail->setRelation('productionStatus', $status);
 
-        $this->stock->deductForDetail($detail, $this->master);
+        $this->stock->applyForDetail($detail, $this->master);
     }
 
     /**

--- a/database/seeders/DemoOrderSeeder.php
+++ b/database/seeders/DemoOrderSeeder.php
@@ -54,8 +54,8 @@ class DemoOrderSeeder extends Seeder
         $order->notes()->create(['body' => 'La mamá pidió que la avisemos por WhatsApp cuando esté lista la moldura.']);
         $order->notes()->create(['body' => 'Confirmar dirección de entrega antes de despachar.']);
 
-        // 2. In production: boards glued (2 MDF boards deducted at
-        // "Pegado"), transfer payment
+        // 2. In production: boards glued (2 MDF boards deducted and 1
+        // "armado" produced at "Pegado"), transfer payment
         $order = $this->makeOrder($sextoA, 'Bruno Díaz', '3804000002', 'Thiago', 2, 56000, 4, 20);
         $detail = $this->addDetail($order, $clasico, $this->muralVariant('horizontal', 'black'), 'Thiago - egresados 2026');
         $this->setStatus($detail, $clasico, 3, hoursAgo: 30);
@@ -78,7 +78,8 @@ class DemoOrderSeeder extends Seeder
         $order->payments()->create(['amount' => 12000, 'type' => 'efectivo', 'paid_on' => now()->subDays(5)->toDateString()]);
 
         // 5. Partially delivered: mural handed over (its whole chain
-        // consumed: strip + board + bag), the rest in progress
+        // consumed: strip + board + bag; the armado produced at "Pegado"
+        // is consumed back at "Pintado", net 0), the rest in progress
         $order = $this->makeOrder($sextoA, 'Elena Paz', '3804000005', 'Mora', 5, 52000, 4, 15);
         $detail = $this->addDetail($order, $molduraFina, $this->muralVariant('horizontal', 'pink'), 'Mora - egresados 2026');
         $this->setStatus($detail, $molduraFina, 7, hoursAgo: 72);
@@ -98,7 +99,8 @@ class DemoOrderSeeder extends Seeder
         $order->payments()->create(['amount' => 6000, 'type' => 'efectivo', 'paid_on' => now()->subDays(1)->toDateString()]);
 
         // 7. Cancelled: the glued mural returned its MDF board to stock
-        // (movements -1/+1), medalla sent to recycling; keeps a payment
+        // ("devolución" +1) and gave back the armado it had produced
+        // ("ajuste" -1); medalla sent to recycling; keeps a payment
         $order = $this->makeOrder($sextoA, 'Gimena Vera', '3804000007', 'Emma', 7, 54000, 4, 18);
         $detail = $this->addDetail($order, $molduraAncha, $this->muralVariant('vertical', 'black'), 'Emma - egresados 2026');
         $this->setStatus($detail, $molduraAncha, 4, hoursAgo: 60);

--- a/database/seeders/DemoStockSeeder.php
+++ b/database/seeders/DemoStockSeeder.php
@@ -10,9 +10,12 @@ use App\Models\Stockable;
 use Illuminate\Database\Seeder;
 
 /**
- * Stockables hung from the production stages that consume them.
+ * Stockables hung from the production stages that move them.
  * "Tiras de moldura fina" ends up below its threshold after
  * DemoOrderSeeder runs, exercising the red row and the dashboard alert.
+ * Every mural also assembles a "Murales armados" intermediate at "Pegado"
+ * and consumes it back at "Pintado", so a mural cancelled to reciclaje
+ * before painting leaves the assembled frame in stock, reusable elsewhere.
  */
 class DemoStockSeeder extends Seeder
 {
@@ -24,12 +27,16 @@ class DemoStockSeeder extends Seeder
         $planchas = Stockable::create(['name' => 'Planchas de MDF', 'quantity' => 30, 'unit' => 'Unidad', 'alert_at' => 8]);
         $tiras = Stockable::create(['name' => 'Tiras de moldura fina (3m)', 'quantity' => 5, 'unit' => 'Unidad', 'alert_at' => 5]);
         $cajas = Stockable::create(['name' => 'Cajas para tazas', 'quantity' => 25, 'unit' => 'Unidad', 'alert_at' => 5]);
+        $armados = Stockable::create(['name' => 'Murales armados (sin pintar)', 'quantity' => 0, 'unit' => 'Unidad', 'alert_at' => 0]);
 
         // Every mural gets bagged; the classic one glues two MDF boards,
-        // the moldura ones glue one board and cut a molding strip first
+        // the moldura ones glue one board and cut a molding strip first.
+        // Gluing also assembles the frame, consumed back once it's painted.
         foreach ($murales as $name) {
             $this->consume($name, 'Embolsado', $bolsas, 1);
             $this->consume($name, 'Pegado', $planchas, $name === 'Clásico' ? 2 : 1);
+            $this->produce($name, 'Pegado', $armados, 1);
+            $this->consume($name, 'Pintado', $armados, 1);
         }
 
         $this->consume('Moldura fina', 'Corte de moldura', $tiras, 1);
@@ -41,6 +48,16 @@ class DemoStockSeeder extends Seeder
 
     private function consume(string $productName, string $stageName, Stockable $stockable, int $quantity): void
     {
+        $this->move($productName, $stageName, $stockable, -$quantity);
+    }
+
+    private function produce(string $productName, string $stageName, Stockable $stockable, int $quantity): void
+    {
+        $this->move($productName, $stageName, $stockable, $quantity);
+    }
+
+    private function move(string $productName, string $stageName, Stockable $stockable, int $delta): void
+    {
         $product = Product::where('name', $productName)->firstOrFail();
 
         $stage = ProductionStatus::query()
@@ -48,6 +65,6 @@ class DemoStockSeeder extends Seeder
             ->where('name', $stageName)
             ->firstOrFail();
 
-        $stage->stockables()->attach($stockable->id, ['quantity' => $quantity]);
+        $stage->stockables()->attach($stockable->id, ['quantity' => $delta]);
     }
 }

--- a/e2e/cancel-recycling.spec.ts
+++ b/e2e/cancel-recycling.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
 
 // Order #2 (Bruno Díaz / Thiago): the Clásico was glued, so 2 MDF boards were
-// deducted — cancelling it back to stock must return them; the carpeta goes
-// to the recycling bin.
+// deducted and 1 "armado" was produced — cancelling it back to stock must
+// return the boards and subtract the armado back out; the carpeta goes to
+// the recycling bin.
 test('cancelling returns supplies to stock and lists recycled products', async ({
     page,
 }) => {
@@ -38,6 +39,15 @@ test('cancelling returns supplies to stock and lists recycled products', async (
             .getByRole('row')
             .filter({ hasText: 'Planchas de MDF' })
             .filter({ hasText: 'Devolución por cancelación' })
+            .first(),
+    ).toBeVisible();
+
+    // The armado it had produced is subtracted back out
+    await expect(
+        page
+            .getByRole('row')
+            .filter({ hasText: 'Murales armados' })
+            .filter({ hasText: 'Ajuste por cancelación' })
             .first(),
     ).toBeVisible();
 });

--- a/resources/js/pages/orders/components/cancel-order-modal.tsx
+++ b/resources/js/pages/orders/components/cancel-order-modal.tsx
@@ -70,7 +70,8 @@ export function CancelOrderModal({
                 <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                     Elegí a dónde vuelve cada producto. Si vuelve a stock, sus
                     insumos se devuelven al inventario; si va a reciclaje, queda
-                    listado en el módulo de reciclaje.
+                    listado en el módulo de reciclaje y lo ya producido queda en
+                    stock.
                 </p>
 
                 <ul className="mt-4 space-y-2">

--- a/resources/js/pages/production-statuses/components/attach-stockable-form.tsx
+++ b/resources/js/pages/production-statuses/components/attach-stockable-form.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Plus } from 'lucide-react';
+import { FormEvent, useState } from 'react';
+import { StockableOption, StockDirection } from '../hooks/use-status-actions';
+
+export function AttachStockableForm({
+    stockables,
+    onAttach,
+}: {
+    stockables: StockableOption[];
+    onAttach: (
+        stockableId: number,
+        quantity: number,
+        direction: StockDirection,
+    ) => void;
+}) {
+    const [stockableId, setStockableId] = useState<string>('');
+    const [quantity, setQuantity] = useState<string>('1');
+    const [direction, setDirection] = useState<StockDirection>('subtract');
+
+    const submit = (e: FormEvent) => {
+        e.preventDefault();
+
+        if (!stockableId) return;
+
+        onAttach(
+            Number(stockableId),
+            Math.max(1, Number(quantity) || 1),
+            direction,
+        );
+        setStockableId('');
+        setQuantity('1');
+        setDirection('subtract');
+    };
+
+    return (
+        <form onSubmit={submit} className="flex flex-wrap items-end gap-2">
+            <div className="min-w-40 flex-1">
+                <Select value={stockableId} onValueChange={setStockableId}>
+                    <SelectTrigger>
+                        <SelectValue placeholder="Agregar insumo..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {stockables.map((stockable) => (
+                            <SelectItem
+                                value={String(stockable.id)}
+                                key={stockable.id}
+                            >
+                                {stockable.name} ({stockable.unit})
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <Select
+                value={direction}
+                onValueChange={(value) => setDirection(value as StockDirection)}
+            >
+                <SelectTrigger className="w-36">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="subtract">Resta del stock</SelectItem>
+                    <SelectItem value="add">Suma al stock</SelectItem>
+                </SelectContent>
+            </Select>
+            <Input
+                type="number"
+                min={1}
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                className="w-20"
+                aria-label="Cantidad"
+            />
+            <Button size="sm" variant="outline" type="submit">
+                <Plus className="h-4 w-4" />
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/pages/production-statuses/components/consumption-dialog.tsx
+++ b/resources/js/pages/production-statuses/components/consumption-dialog.tsx
@@ -6,17 +6,14 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
+import { Trash2 } from 'lucide-react';
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
-import { Plus, Trash2 } from 'lucide-react';
-import { FormEvent, useState } from 'react';
-import { StatusRow, StockableOption } from '../hooks/use-status-actions';
+    StatusRow,
+    StockableOption,
+    StockDirection,
+} from '../hooks/use-status-actions';
+import { AttachStockableForm } from './attach-stockable-form';
+import { StockableDelta } from './stockable-delta';
 
 export function ConsumptionDialog({
     status,
@@ -27,27 +24,18 @@ export function ConsumptionDialog({
 }: {
     status: StatusRow;
     stockables: StockableOption[];
-    onAttach: (stockableId: number, quantity: number) => void;
+    onAttach: (
+        stockableId: number,
+        quantity: number,
+        direction: StockDirection,
+    ) => void;
     onDetach: (stockableId: number) => void;
     onClose: () => void;
 }) {
-    const [stockableId, setStockableId] = useState<string>('');
-    const [quantity, setQuantity] = useState<string>('1');
-
     const available = stockables.filter(
         (stockable) =>
             !status.stockables.some((used) => used.id === stockable.id),
     );
-
-    const submit = (e: FormEvent) => {
-        e.preventDefault();
-
-        if (!stockableId) return;
-
-        onAttach(Number(stockableId), Math.max(1, Number(quantity) || 1));
-        setStockableId('');
-        setQuantity('1');
-    };
 
     return (
         <Dialog open onOpenChange={onClose}>
@@ -55,15 +43,15 @@ export function ConsumptionDialog({
                 <DialogHeader>
                     <DialogTitle>Insumos de "{status.name}"</DialogTitle>
                     <DialogDescription>
-                        Estos insumos se descuentan del stock cuando un producto
-                        llega a esta etapa.
+                        Estos insumos se restan o se suman al stock cuando un
+                        producto llega a esta etapa.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-2">
                     {status.stockables.length === 0 && (
                         <p className="text-sm text-gray-500">
-                            Esta etapa no consume insumos.
+                            Esta etapa no mueve insumos.
                         </p>
                     )}
 
@@ -73,12 +61,15 @@ export function ConsumptionDialog({
                             className="flex items-center gap-2 rounded-lg border border-gray-200 p-2 dark:border-gray-700"
                         >
                             <span className="flex-1 text-sm">
-                                {stockable.quantity} × {stockable.name}
+                                <StockableDelta
+                                    quantity={stockable.quantity}
+                                    name={stockable.name}
+                                />
                             </span>
                             <Button
                                 size="sm"
                                 variant="ghost"
-                                title="Quitar consumo"
+                                title="Quitar movimiento"
                                 onClick={() => onDetach(stockable.id)}
                             >
                                 <Trash2 className="h-4 w-4" />
@@ -87,39 +78,10 @@ export function ConsumptionDialog({
                     ))}
                 </div>
 
-                <form onSubmit={submit} className="flex items-end gap-2">
-                    <div className="flex-1">
-                        <Select
-                            value={stockableId}
-                            onValueChange={setStockableId}
-                        >
-                            <SelectTrigger>
-                                <SelectValue placeholder="Agregar insumo..." />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {available.map((stockable) => (
-                                    <SelectItem
-                                        value={String(stockable.id)}
-                                        key={stockable.id}
-                                    >
-                                        {stockable.name} ({stockable.unit})
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
-                    <Input
-                        type="number"
-                        min={1}
-                        value={quantity}
-                        onChange={(e) => setQuantity(e.target.value)}
-                        className="w-20"
-                        aria-label="Cantidad"
-                    />
-                    <Button size="sm" variant="outline" type="submit">
-                        <Plus className="h-4 w-4" />
-                    </Button>
-                </form>
+                <AttachStockableForm
+                    stockables={available}
+                    onAttach={onAttach}
+                />
             </DialogContent>
         </Dialog>
     );

--- a/resources/js/pages/production-statuses/components/product-card.tsx
+++ b/resources/js/pages/production-statuses/components/product-card.tsx
@@ -49,11 +49,12 @@ export function ProductCard({
                 <ConsumptionDialog
                     status={consumptionStatus}
                     stockables={stockables}
-                    onAttach={(stockableId, quantity) =>
+                    onAttach={(stockableId, quantity, direction) =>
                         attachStockable(
                             consumptionStatus.id,
                             stockableId,
                             quantity,
+                            direction,
                         )
                     }
                     onDetach={(stockableId) =>

--- a/resources/js/pages/production-statuses/components/status-item.tsx
+++ b/resources/js/pages/production-statuses/components/status-item.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { FormEvent, useState } from 'react';
 import { StatusRow } from '../hooks/use-status-actions';
+import { StockableDeltaList } from './stockable-delta-list';
 
 export function StatusItem({
     status,
@@ -93,13 +94,7 @@ export function StatusItem({
             </Badge>
             <div className="flex min-w-32 flex-1 flex-col">
                 <span className="text-sm">{status.name}</span>
-                {consumes && (
-                    <span className="text-xs text-gray-500">
-                        {status.stockables
-                            .map((s) => `${s.quantity}× ${s.name}`)
-                            .join(' · ')}
-                    </span>
-                )}
+                <StockableDeltaList stockables={status.stockables} />
             </div>
             {inUse && (
                 <span
@@ -131,7 +126,7 @@ export function StatusItem({
                 <Button
                     size="sm"
                     variant="ghost"
-                    title="Insumos que consume esta etapa"
+                    title="Insumos que mueve esta etapa"
                     onClick={onEditConsumption}
                 >
                     <Package className="h-4 w-4" />
@@ -154,7 +149,7 @@ export function StatusItem({
                             : inUse
                               ? 'Hay productos en esta etapa'
                               : consumes
-                                ? 'Esta etapa consume insumos'
+                                ? 'Esta etapa mueve insumos'
                                 : 'Eliminar'
                     }
                     onClick={onDelete}

--- a/resources/js/pages/production-statuses/components/stockable-delta-list.tsx
+++ b/resources/js/pages/production-statuses/components/stockable-delta-list.tsx
@@ -1,0 +1,25 @@
+import { Fragment } from 'react';
+import { StageStockable } from '../hooks/use-status-actions';
+import { StockableDelta } from './stockable-delta';
+
+export function StockableDeltaList({
+    stockables,
+}: {
+    stockables: StageStockable[];
+}) {
+    if (stockables.length === 0) return null;
+
+    return (
+        <div className="flex flex-wrap items-center gap-x-1.5 text-xs">
+            {stockables.map((stockable, index) => (
+                <Fragment key={stockable.id}>
+                    {index > 0 && <span className="text-gray-400">·</span>}
+                    <StockableDelta
+                        quantity={stockable.quantity}
+                        name={stockable.name}
+                    />
+                </Fragment>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/pages/production-statuses/components/stockable-delta.tsx
+++ b/resources/js/pages/production-statuses/components/stockable-delta.tsx
@@ -1,0 +1,21 @@
+export function StockableDelta({
+    quantity,
+    name,
+}: {
+    quantity: number;
+    name: string;
+}) {
+    const isAdd = quantity > 0;
+
+    return (
+        <span
+            className={
+                isAdd
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : 'text-gray-500'
+            }
+        >
+            {isAdd ? `+${quantity}` : quantity}× {name}
+        </span>
+    );
+}

--- a/resources/js/pages/production-statuses/hooks/use-status-actions.ts
+++ b/resources/js/pages/production-statuses/hooks/use-status-actions.ts
@@ -1,10 +1,13 @@
 import { router } from '@inertiajs/react';
 import { toast } from 'sonner';
 
+export type StockDirection = 'subtract' | 'add';
+
 export type StageStockable = {
     id: number;
     name: string;
     unit: string;
+    /** Signed pivot delta: positive adds stock, negative consumes it. */
     quantity: number;
 };
 
@@ -79,17 +82,18 @@ export function useStatusActions(product: ProductStagesRow) {
         statusId: number,
         stockableId: number,
         quantity: number,
+        direction: StockDirection,
         onSuccess?: () => void,
     ) => {
         router.post(
             route('production-statuses.stockables.store', {
                 productionStatus: statusId,
             }),
-            { stockable_id: stockableId, quantity },
+            { stockable_id: stockableId, quantity, direction },
             {
                 preserveScroll: true,
                 onSuccess: () => {
-                    toast.success('Consumo de insumo guardado');
+                    toast.success('Movimiento de insumo guardado');
                     onSuccess?.();
                 },
                 onError,
@@ -105,7 +109,7 @@ export function useStatusActions(product: ProductStagesRow) {
             }),
             {
                 preserveScroll: true,
-                onSuccess: () => toast.success('Consumo de insumo quitado'),
+                onSuccess: () => toast.success('Movimiento de insumo quitado'),
                 onError,
             },
         );

--- a/resources/js/pages/production-statuses/index.tsx
+++ b/resources/js/pages/production-statuses/index.tsx
@@ -30,8 +30,9 @@ export default function ProductionStatusesIndex({
                 </h1>
                 <p className="mt-1 text-gray-500">
                     Cada producto tiene su propia cadena de etapas. Colgá de
-                    cada etapa los insumos que consume (con su cantidad): se
-                    descuentan del stock cuando el producto llega a esa etapa.
+                    cada etapa los insumos que mueve (con su cantidad): se
+                    restan o se suman al stock cuando el producto llega a esa
+                    etapa.
                 </p>
             </section>
 

--- a/resources/js/pages/production-statuses/tests/consumption-dialog.test.tsx
+++ b/resources/js/pages/production-statuses/tests/consumption-dialog.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConsumptionDialog } from '../components/consumption-dialog';
+import { StatusRow, StockableOption } from '../hooks/use-status-actions';
+
+const status: StatusRow = {
+    id: 1,
+    name: 'Pegado',
+    position: 2,
+    details_count: 0,
+    stockables: [
+        { id: 10, name: 'Planchas de MDF', unit: 'Unidad', quantity: -2 },
+        { id: 11, name: 'Murales armados', unit: 'Unidad', quantity: 1 },
+    ],
+};
+
+const stockables: StockableOption[] = [
+    { id: 10, name: 'Planchas de MDF', unit: 'Unidad' },
+    { id: 11, name: 'Murales armados', unit: 'Unidad' },
+    { id: 12, name: 'Bolsas de regalo', unit: 'Unidad' },
+];
+
+describe('ConsumptionDialog', () => {
+    it('renders signed rows for what the stage moves', () => {
+        render(
+            <ConsumptionDialog
+                status={status}
+                stockables={stockables}
+                onAttach={vi.fn()}
+                onDetach={vi.fn()}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/-2× Planchas de MDF/)).toBeTruthy();
+        expect(screen.getByText(/\+1× Murales armados/)).toBeTruthy();
+    });
+
+    it('defaults new movements to "subtract" but attaches "add" when chosen', () => {
+        const onAttach = vi.fn();
+        render(
+            <ConsumptionDialog
+                status={status}
+                stockables={stockables}
+                onAttach={onAttach}
+                onDetach={vi.fn()}
+                onClose={vi.fn()}
+            />,
+        );
+
+        const [stockableTrigger, directionTrigger] =
+            screen.getAllByRole('combobox');
+
+        expect(directionTrigger.textContent).toContain('Resta del stock');
+
+        fireEvent.keyDown(stockableTrigger, { key: 'Enter' });
+        fireEvent.click(
+            screen.getByRole('option', { name: /Bolsas de regalo/ }),
+        );
+
+        fireEvent.keyDown(directionTrigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Suma al stock' }));
+
+        const form = document.querySelector('form');
+        expect(form).not.toBeNull();
+        fireEvent.submit(form as HTMLFormElement);
+
+        expect(onAttach).toHaveBeenCalledWith(12, 1, 'add');
+    });
+});

--- a/resources/js/pages/production-statuses/tests/status-item.test.tsx
+++ b/resources/js/pages/production-statuses/tests/status-item.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StatusItem } from '../components/status-item';
+import { StatusRow } from '../hooks/use-status-actions';
+
+const status: StatusRow = {
+    id: 1,
+    name: 'Pegado',
+    position: 2,
+    details_count: 0,
+    stockables: [
+        { id: 10, name: 'Planchas de MDF', unit: 'Unidad', quantity: -2 },
+        { id: 11, name: 'Murales armados', unit: 'Unidad', quantity: 1 },
+    ],
+};
+
+describe('StatusItem', () => {
+    it('prefixes consumed stockables with a minus and produced ones with a plus', () => {
+        render(
+            <StatusItem
+                status={status}
+                isFirst={false}
+                isLast={false}
+                isOnly={false}
+                onMoveUp={vi.fn()}
+                onMoveDown={vi.fn()}
+                onRename={vi.fn()}
+                onEditConsumption={vi.fn()}
+                onDelete={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/-2× Planchas de MDF/)).toBeTruthy();
+        expect(screen.getByText(/\+1× Murales armados/)).toBeTruthy();
+    });
+
+    it('renders no summary line for a stage that moves nothing', () => {
+        render(
+            <StatusItem
+                status={{ ...status, stockables: [] }}
+                isFirst={false}
+                isLast={false}
+                isOnly={false}
+                onMoveUp={vi.fn()}
+                onMoveDown={vi.fn()}
+                onRename={vi.fn()}
+                onEditConsumption={vi.fn()}
+                onDelete={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByText(/×/)).toBeNull();
+    });
+});

--- a/resources/js/pages/stock/movements.tsx
+++ b/resources/js/pages/stock/movements.tsx
@@ -129,8 +129,9 @@ export default function StockMovements({
                         <CardHeader className="text-center">
                             <CardTitle>Sin movimientos</CardTitle>
                             <CardDescription>
-                                Los descuentos automáticos por producción y las
-                                devoluciones por cancelación van a aparecer acá.
+                                Los movimientos automáticos por producción y los
+                                ajustes o devoluciones por cancelación van a
+                                aparecer acá.
                             </CardDescription>
                         </CardHeader>
                     </Card>

--- a/tests/Feature/DetailProductionStatusTest.php
+++ b/tests/Feature/DetailProductionStatusTest.php
@@ -82,7 +82,7 @@ it('moves a detail to a stage of its product, deducting the stage stock', functi
 
     $product = productWithChain(['Impreso', 'Pegado']);
     $planchas = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => 2]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => -2]);
 
     $order = orderWithFirstInstallmentPaid();
     $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
@@ -103,7 +103,7 @@ it('returns a detail to "sin empezar" without giving the stock back', function (
 
     $product = productWithChain(['Impreso', 'Pegado']);
     $planchas = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => 2]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => -2]);
 
     $order = orderWithFirstInstallmentPaid();
     $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);

--- a/tests/Feature/OrderCancelTest.php
+++ b/tests/Feature/OrderCancelTest.php
@@ -33,7 +33,7 @@ it('returns exactly the deducted supplies when sent back to stock', function () 
 
     $product = productWithChain(['Pendiente', 'Corte', 'Embolsado']);
     $stockable = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($stockable->id, ['quantity' => 2]);
+    stageOf($product, 2)->stockables()->attach($stockable->id, ['quantity' => -2]);
 
     $order = Order::factory()->create();
     $deducted = OrderDetail::factory()->create([
@@ -41,7 +41,7 @@ it('returns exactly the deducted supplies when sent back to stock', function () 
         'product_id' => $product->id,
         'production_status_id' => stageOf($product, 2)->id,
     ]);
-    app(StockService::class)->deductForDetail($deducted);
+    app(StockService::class)->applyForDetail($deducted);
     $notDeducted = OrderDetail::factory()->create([
         'order_id' => $order->id,
         'product_id' => $product->id,
@@ -61,6 +61,59 @@ it('returns exactly the deducted supplies when sent back to stock', function () 
     expect($stockable->refresh()->quantity)->toBe(10)
         ->and($stockable->movements()->where('reason', 'devolución por cancelación')->count())->toBe(1)
         ->and($stockable->movements()->where('reason', 'devolución por cancelación')->first()?->quantity)->toBe(2);
+});
+
+it('subtracts a produced intermediate back out when cancelled to stock', function () {
+    actingAsRole();
+
+    $product = productWithChain(['Pegado']);
+    $armados = Stockable::factory()->create(['quantity' => 0]);
+    stageOf($product, 1)->stockables()->attach($armados->id, ['quantity' => 1]);
+
+    $order = Order::factory()->create();
+    $detail = OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'production_status_id' => stageOf($product, 1)->id,
+    ]);
+    app(StockService::class)->applyForDetail($detail);
+
+    expect($armados->refresh()->quantity)->toBe(1);
+
+    post(route('orders.cancel', $order), [
+        'destinations' => [
+            ['detail_id' => $detail->id, 'destination' => 'stock'],
+        ],
+    ]);
+
+    expect($armados->refresh()->quantity)->toBe(0)
+        ->and($armados->movements()->where('reason', 'ajuste por cancelación')->count())->toBe(1)
+        ->and($armados->movements()->where('reason', 'ajuste por cancelación')->first()?->quantity)->toBe(-1);
+});
+
+it('keeps a produced intermediate in stock when cancelled to recycling', function () {
+    actingAsRole();
+
+    $product = productWithChain(['Pegado']);
+    $armados = Stockable::factory()->create(['quantity' => 0]);
+    stageOf($product, 1)->stockables()->attach($armados->id, ['quantity' => 1]);
+
+    $order = Order::factory()->create();
+    $detail = OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'production_status_id' => stageOf($product, 1)->id,
+    ]);
+    app(StockService::class)->applyForDetail($detail);
+
+    post(route('orders.cancel', $order), [
+        'destinations' => [
+            ['detail_id' => $detail->id, 'destination' => 'reciclaje'],
+        ],
+    ]);
+
+    expect($armados->refresh()->quantity)->toBe(1)
+        ->and($armados->movements()->count())->toBe(1);
 });
 
 it('rejects details that belong to another order', function () {

--- a/tests/Feature/ProductionStatusTest.php
+++ b/tests/Feature/ProductionStatusTest.php
@@ -111,7 +111,7 @@ it('refuses to delete a stage that consumes stockables', function () {
     actingAsRole(UserRole::Admin);
 
     $status = statusFor('Clásico', 3);
-    $status->stockables()->attach(Stockable::factory()->create()->id, ['quantity' => 2]);
+    $status->stockables()->attach(Stockable::factory()->create()->id, ['quantity' => -2]);
 
     delete(route('production-statuses.destroy', $status))
         ->assertSessionHasErrors('status');
@@ -168,22 +168,57 @@ it('hangs a stockable consumption from a stage and updates its quantity', functi
     post(route('production-statuses.stockables.store', $status), [
         'stockable_id' => $stockable->id,
         'quantity' => 2,
+        'direction' => 'subtract',
     ])->assertSessionHasNoErrors();
 
     expect($status->stockables()->count())->toBe(1)
-        ->and((int) $status->stockables()->first()?->pivot->quantity)->toBe(2);
+        ->and((int) $status->stockables()->first()?->pivot->quantity)->toBe(-2);
 
     // Posting again updates the quantity in place
     post(route('production-statuses.stockables.store', $status), [
         'stockable_id' => $stockable->id,
         'quantity' => 5,
+        'direction' => 'subtract',
     ])->assertSessionHasNoErrors();
 
     expect($status->stockables()->count())->toBe(1)
-        ->and((int) $status->stockables()->first()?->pivot->quantity)->toBe(5);
+        ->and((int) $status->stockables()->first()?->pivot->quantity)->toBe(-5);
 });
 
-it('rejects consuming the same stockable on two stages of one product', function () {
+it('hangs a stockable production from a stage with a positive pivot', function () {
+    actingAsRole(UserRole::Admin);
+
+    $status = statusFor('Clásico', 3);
+    $stockable = Stockable::factory()->create();
+
+    post(route('production-statuses.stockables.store', $status), [
+        'stockable_id' => $stockable->id,
+        'quantity' => 1,
+        'direction' => 'add',
+    ])->assertSessionHasNoErrors();
+
+    expect((int) $status->stockables()->first()?->pivot->quantity)->toBe(1);
+});
+
+it('rejects a zero quantity or a missing direction', function () {
+    actingAsRole(UserRole::Admin);
+
+    $status = statusFor('Clásico', 3);
+    $stockable = Stockable::factory()->create();
+
+    post(route('production-statuses.stockables.store', $status), [
+        'stockable_id' => $stockable->id,
+        'quantity' => 0,
+        'direction' => 'subtract',
+    ])->assertSessionHasErrors('quantity');
+
+    post(route('production-statuses.stockables.store', $status), [
+        'stockable_id' => $stockable->id,
+        'quantity' => 1,
+    ])->assertSessionHasErrors('direction');
+});
+
+it('allows the same stockable on two stages of one product', function () {
     actingAsRole(UserRole::Admin);
 
     $stockable = Stockable::factory()->create();
@@ -192,7 +227,8 @@ it('rejects consuming the same stockable on two stages of one product', function
     post(route('production-statuses.stockables.store', statusFor('Clásico', 6)), [
         'stockable_id' => $stockable->id,
         'quantity' => 1,
-    ])->assertSessionHasErrors('stockable_id');
+        'direction' => 'subtract',
+    ])->assertSessionHasNoErrors();
 });
 
 it('allows consuming the same stockable on stages of different products', function () {
@@ -204,6 +240,7 @@ it('allows consuming the same stockable on stages of different products', functi
     post(route('production-statuses.stockables.store', statusFor('Taza', 4)), [
         'stockable_id' => $stockable->id,
         'quantity' => 1,
+        'direction' => 'subtract',
     ])->assertSessionHasNoErrors();
 });
 

--- a/tests/Feature/TrackingTest.php
+++ b/tests/Feature/TrackingTest.php
@@ -89,8 +89,8 @@ it('deducts the stockables hung from the reached stages', function () {
     $product = productWithChain(['Pendiente', 'Corte', 'Embolsado']);
     $tiras = Stockable::factory()->create(['quantity' => 10]);
     $bolsas = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => 2]);
-    stageOf($product, 3)->stockables()->attach($bolsas->id, ['quantity' => 1]);
+    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => -2]);
+    stageOf($product, 3)->stockables()->attach($bolsas->id, ['quantity' => -1]);
 
     $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
 
@@ -130,8 +130,8 @@ it('deducts the skipped stages on a batch jump', function () {
     $product = productWithChain(['Pendiente', 'Corte', 'Embolsado']);
     $tiras = Stockable::factory()->create(['quantity' => 10]);
     $bolsas = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => 2]);
-    stageOf($product, 3)->stockables()->attach($bolsas->id, ['quantity' => 1]);
+    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => -2]);
+    stageOf($product, 3)->stockables()->attach($bolsas->id, ['quantity' => -1]);
 
     $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
 
@@ -150,7 +150,7 @@ it('never deducts twice when moving back and forth', function () {
 
     $product = productWithChain(['Pendiente', 'Corte', 'Embolsado']);
     $tiras = Stockable::factory()->create(['quantity' => 10]);
-    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => 2]);
+    stageOf($product, 2)->stockables()->attach($tiras->id, ['quantity' => -2]);
 
     $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
 
@@ -175,6 +175,80 @@ it('never deducts twice when moving back and forth', function () {
 
     expect($tiras->refresh()->quantity)->toBe(8)
         ->and($tiras->movements()->count())->toBe(1);
+});
+
+it('adds stock for a stage with a positive delta', function () {
+    actingAsRole(UserRole::Worker);
+
+    $product = productWithChain(['Pegado', 'Pintado']);
+    $armados = Stockable::factory()->create(['quantity' => 0]);
+    stageOf($product, 1)->stockables()->attach($armados->id, ['quantity' => 1]);
+
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    post(route('tracking.batch'), [
+        'detail_ids' => [$detail->id],
+        'production_status_id' => stageOf($product, 1)->id,
+    ]);
+
+    expect($armados->refresh()->quantity)->toBe(1)
+        ->and($armados->movements()->count())->toBe(1)
+        ->and($armados->movements()->first()?->quantity)->toBe(1)
+        ->and($armados->movements()->first()?->production_status_id)->toBe(stageOf($product, 1)->id);
+});
+
+it('mixes a subtraction and an addition on the same stage', function () {
+    actingAsRole(UserRole::Worker);
+
+    $product = productWithChain(['Pegado']);
+    $mdf = Stockable::factory()->create(['quantity' => 10]);
+    $armados = Stockable::factory()->create(['quantity' => 0]);
+    stageOf($product, 1)->stockables()->attach($mdf->id, ['quantity' => -2]);
+    stageOf($product, 1)->stockables()->attach($armados->id, ['quantity' => 1]);
+
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    post(route('tracking.batch'), [
+        'detail_ids' => [$detail->id],
+        'production_status_id' => stageOf($product, 1)->id,
+    ]);
+
+    expect($mdf->refresh()->quantity)->toBe(8)
+        ->and($armados->refresh()->quantity)->toBe(1);
+});
+
+it('stays idempotent per stage across a pipeline of adds and subtracts', function () {
+    actingAsRole(UserRole::Worker);
+
+    $product = productWithChain(['Pendiente', 'Pegado', 'Pintado']);
+    $armados = Stockable::factory()->create(['quantity' => 0]);
+    stageOf($product, 2)->stockables()->attach($armados->id, ['quantity' => 1]);
+    stageOf($product, 3)->stockables()->attach($armados->id, ['quantity' => -1]);
+
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    // Jumping straight to the last stage applies both stages exactly once
+    post(route('tracking.batch'), [
+        'detail_ids' => [$detail->id],
+        'production_status_id' => stageOf($product, 3)->id,
+    ]);
+
+    expect($armados->refresh()->quantity)->toBe(0)
+        ->and($armados->movements()->count())->toBe(2);
+
+    // Going back and forward again does not apply either stage twice
+    post(route('tracking.batch'), [
+        'detail_ids' => [$detail->id],
+        'production_status_id' => stageOf($product, 1)->id,
+    ]);
+
+    post(route('tracking.batch'), [
+        'detail_ids' => [$detail->id],
+        'production_status_id' => stageOf($product, 3)->id,
+    ]);
+
+    expect($armados->refresh()->quantity)->toBe(0)
+        ->and($armados->movements()->count())->toBe(2);
 });
 
 it('lists only enabled, pending details of active orders', function () {


### PR DESCRIPTION
## Resumen

- Las etapas de producción ahora pueden sumar stockeables además de restarlos: el pivot `production_status_stockable.quantity` pasa a ser un delta con signo (positivo suma, negativo resta), igual que `stock_movements.quantity`.
- Se agrega `production_status_id` a `stock_movements` para que la idempotencia sea por (detalle, etapa, stockeable) en lugar de (detalle, stockeable), permitiendo que un mismo stockeable se produzca en una etapa y se consuma en otra del mismo producto.
- Al cancelar a "stock" se revierte el balance neto en ambos sentidos (lo consumido vuelve, lo producido se resta); al cancelar a "reciclaje" no se revierte nada, así lo ya producido queda en stock.
- Seed demo: los 4 murales arman un "Murales armados (sin pintar)" en "Pegado" y lo consumen en "Pintado".
- Frontend: nuevo selector de dirección (resta/suma) al colgar un insumo de una etapa, con montos con signo en toda la pantalla de etapas de producción.

Closes #156

## Plan de pruebas

- [x] `sail artisan migrate:fresh --seed`
- [x] `sail php ./vendor/bin/pest` (167 tests, incluye PageSmokeTest)
- [x] `sail npm run test` (283 tests)
- [x] `npm run test:e2e` (15 tests, incluye el nuevo caso de ajuste por cancelación)
- [x] `validate-code --full` (pint, phpstan nivel 9, prettier, eslint, tsc)