### PR TITLE
fix(orders): borradores comparten numeración con pedidos en el curso

### DIFF
--- a/app/Actions/Orders/AllocatePhotoNumber.php
+++ b/app/Actions/Orders/AllocatePhotoNumber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Orders;
+
+use App\Contracts\ActionContract;
+use App\Models\Order;
+use App\Models\OrderDraft;
+
+class AllocatePhotoNumber implements ActionContract
+{
+    /**
+     * Next photo number for a classroom, drawn from a single sequence shared
+     * between orders and drafts so a new order always counts existing drafts
+     * (and vice versa) and never collides with them.
+     *
+     * @param  array{classroom_id: int}  $params
+     */
+    public function handle(array $params): int
+    {
+        $maxOrderNumber = Order::withTrashed()
+            ->where('classroom_id', $params['classroom_id'])
+            ->max('photo_number');
+
+        $maxDraftNumber = OrderDraft::query()
+            ->where('classroom_id', $params['classroom_id'])
+            ->max('photo_number');
+
+        $max = max(
+            is_numeric($maxOrderNumber) ? (int) $maxOrderNumber : 0,
+            is_numeric($maxDraftNumber) ? (int) $maxDraftNumber : 0,
+        );
+
+        return $max + 1;
+    }
+}

--- a/app/Actions/Orders/CreateOrder.php
+++ b/app/Actions/Orders/CreateOrder.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\DB;
 
 class CreateOrder implements ActionContract
 {
+    public function __construct(private readonly AllocatePhotoNumber $allocatePhotoNumber) {}
+
     /**
      * Create an order with its client and product details, auto-assigning the
      * classroom photo number, and consume the source draft when present.
@@ -28,22 +30,28 @@ class CreateOrder implements ActionContract
 
             $attended = $params['attended_photo_session'] ?? null;
 
+            $classroomId = is_numeric($params['classroom_id']) ? (int) $params['classroom_id'] : 0;
+
+            $draft = isset($params['draft_id']) && is_numeric($params['draft_id'])
+                ? OrderDraft::find((int) $params['draft_id'])
+                : null;
+
             // Photos are numbered by classroom following the order in which
             // orders are taken: assign the next photo number automatically,
-            // unless the child did not attend the photo session.
+            // unless the child did not attend the photo session. Completing a
+            // draft in its own classroom keeps the number it already got.
             $photoNumber = null;
 
             if ($attended !== false) {
-                $maxPhotoNumber = Order::withTrashed()
-                    ->where('classroom_id', $params['classroom_id'])
-                    ->max('photo_number');
-
-                $photoNumber = (is_numeric($maxPhotoNumber) ? (int) $maxPhotoNumber : 0) + 1;
+                $photoNumber = ($draft !== null && $draft->photo_number !== null
+                        && $draft->classroom_id === $classroomId)
+                    ? $draft->photo_number
+                    : $this->allocatePhotoNumber->handle(['classroom_id' => $classroomId]);
             }
 
             $order = Order::create([
                 'client_id' => $client->id,
-                'classroom_id' => $params['classroom_id'],
+                'classroom_id' => $classroomId,
                 'total_price' => $params['total_price'],
                 'payment_plan' => $params['payment_plan'],
                 'due_date' => $params['due_date'],
@@ -62,9 +70,7 @@ class CreateOrder implements ActionContract
                 ]);
             }
 
-            if (isset($params['draft_id'])) {
-                OrderDraft::query()->whereKey($params['draft_id'])->delete();
-            }
+            $draft?->delete();
         });
     }
 }

--- a/app/Actions/Orders/CreateOrderDraft.php
+++ b/app/Actions/Orders/CreateOrderDraft.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Orders;
+
+use App\Contracts\ActionContract;
+use App\Models\OrderDraft;
+use Illuminate\Support\Facades\DB;
+
+class CreateOrderDraft implements ActionContract
+{
+    public function __construct(private readonly AllocatePhotoNumber $allocatePhotoNumber) {}
+
+    /**
+     * @param  array<string, mixed>  $params  validated draft payload
+     */
+    public function handle(array $params): OrderDraft
+    {
+        return DB::transaction(function () use ($params) {
+            $attended = $params['attended_photo_session'] ?? null;
+
+            $classroomId = is_numeric($params['classroom_id']) ? (int) $params['classroom_id'] : 0;
+
+            $photoNumber = $attended !== false
+                ? $this->allocatePhotoNumber->handle(['classroom_id' => $classroomId])
+                : null;
+
+            return OrderDraft::create([...$params, 'photo_number' => $photoNumber]);
+        });
+    }
+}

--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -10,11 +10,13 @@ use App\Actions\Classrooms\UpdateClassroom;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\StoreClassroomRequest;
 use App\Http\Requests\BO\UpdateClassroomRequest;
-use App\Http\Resources\OrderResource;
+use App\Http\Resources\ClassroomStudentResource;
 use App\Models\Classroom;
 use App\Models\Order;
+use App\Models\OrderDraft;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -26,17 +28,44 @@ class ClassroomController extends Controller
         $search = $request->query('search');
 
         $orders = Order::where('classroom_id', $classroom->id)
-            ->with('client', 'products.type', 'classroom.school')
+            ->with('client')
+            ->withCount('products')
             ->search($search)
-            ->orderByRaw('orders.photo_number is null')
-            ->orderBy('photo_number')
-            ->orderBy('id')
-            ->paginate(20)
-            ->withQueryString();
+            ->get();
+
+        $drafts = OrderDraft::where('classroom_id', $classroom->id)
+            ->search($search)
+            ->get();
+
+        // Merged, interleaved by photo number: the listing follows the paper
+        // sheet, where drafts and orders share the same sequence.
+        $students = $orders->toBase()->concat($drafts->toBase())
+            ->sortBy(fn (Order|OrderDraft $row): array => [
+                $row->photo_number === null ? 1 : 0,
+                (int) $row->photo_number,
+                $row->created_at?->getTimestamp() ?? 0,
+                $row->id,
+            ])->values();
+
+        $page = LengthAwarePaginator::resolveCurrentPage();
+        $perPage = 20;
+
+        $paginator = new LengthAwarePaginator(
+            $students->forPage($page, $perPage),
+            $students->count(),
+            $perPage,
+            $page,
+            [
+                'path' => LengthAwarePaginator::resolveCurrentPath(),
+                'pageName' => 'page',
+            ],
+        );
+
+        $paginator->appends($request->query());
 
         return Inertia::render('classrooms/show', [
             'classroom' => $classroom->load('teacher', 'school'),
-            'orders' => OrderResource::collection($orders),
+            'students' => ClassroomStudentResource::collection($paginator),
             'filters' => ['search' => $search],
         ]);
     }

--- a/app/Http/Controllers/BO/OrderDraftController.php
+++ b/app/Http/Controllers/BO/OrderDraftController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\BO;
 
+use App\Actions\Orders\CreateOrderDraft;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\StoreOrderDraftRequest;
 use App\Http\Resources\OrderDraftResource;
@@ -25,9 +26,9 @@ class OrderDraftController extends Controller
         ]);
     }
 
-    public function store(StoreOrderDraftRequest $request): RedirectResponse
+    public function store(StoreOrderDraftRequest $request, CreateOrderDraft $action): RedirectResponse
     {
-        OrderDraft::create($request->validated());
+        $action->handle($request->validated());
 
         return back()->with('success', 'Borrador guardado exitosamente');
     }

--- a/app/Http/Resources/ClassroomStudentResource.php
+++ b/app/Http/Resources/ClassroomStudentResource.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Client;
+use App\Models\Order;
+use App\Models\OrderDraft;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * A single flat row for the classroom's children listing, normalizing an
+ * Order or an OrderDraft into the same shape: neither the heavy OrderResource
+ * payload nor the draft's own resource fit the table as-is.
+ */
+class ClassroomStudentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $row = $this->resource;
+
+        if ($row instanceof OrderDraft) {
+            return [
+                'kind' => 'draft',
+                'id' => $row->id,
+                'photo_number' => $row->photo_number,
+                'child_name' => $row->child_name,
+                'client_name' => $row->client_name,
+                'client_phone' => $row->client_phone,
+                'products_count' => count($row->products ?? []),
+                'total_price' => $row->total_price,
+                'payment_plan' => $row->payment_plan,
+                'due_date' => $row->due_date?->isoFormat('D [de] MMM Y'),
+            ];
+        }
+
+        /** @var Order $row */
+        /** @var Client $client */
+        $client = $row->client;
+
+        $productsCount = $row->getAttribute('products_count');
+
+        return [
+            'kind' => 'order',
+            'id' => $row->id,
+            'photo_number' => $row->photo_number,
+            'child_name' => $row->child_name,
+            'client_name' => $client->name,
+            'client_phone' => $client->phone,
+            'products_count' => is_numeric($productsCount) ? (int) $productsCount : 0,
+            'total_price' => $row->total_price,
+            'payment_plan' => $row->payment_plan,
+            'due_date' => $row->due_date->isoFormat('D [de] MMM Y'),
+        ];
+    }
+}

--- a/app/Http/Resources/OrderDraftResource.php
+++ b/app/Http/Resources/OrderDraftResource.php
@@ -22,6 +22,7 @@ class OrderDraftResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'photo_number' => $this->photo_number,
             'child_name' => $this->child_name,
             'client_name' => $this->client_name,
             'client_phone' => $this->client_phone,

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -29,12 +29,6 @@ class Order extends Model
     private const MIN_PHONE_DIGITS = 4;
 
     /**
-     * Phones are stored as free text, so the column is stripped of its
-     * separators on the fly to be comparable with a normalized search term.
-     */
-    private const CLIENT_PHONE_DIGITS = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(clients.phone, ' ', ''), '-', ''), '(', ''), ')', ''), '+', ''), '.', '')";
-
-    /**
      * @return BelongsTo<Client, $this>
      */
     public function client()
@@ -117,7 +111,7 @@ class Order extends Model
                     $client->where('clients.name', 'like', $like);
 
                     if ($phone !== null) {
-                        $client->orWhereRaw(self::CLIENT_PHONE_DIGITS.' like ?', [$phone]);
+                        $client->orWhereRaw(Phone::digitsExpression('clients.phone').' like ?', [$phone]);
                     }
                 });
         });

--- a/app/Models/OrderDraft.php
+++ b/app/Models/OrderDraft.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\Phone;
 use Database\Factories\OrderDraftFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,12 +16,46 @@ class OrderDraft extends Model
     /** @use HasFactory<OrderDraftFactory> */
     use HasFactory;
 
+    /** Below this many digits a search term is a draft number, not a phone. */
+    private const MIN_PHONE_DIGITS = 4;
+
     /**
      * @return BelongsTo<Classroom, $this>
      */
     public function classroom()
     {
         return $this->belongsTo(Classroom::class);
+    }
+
+    /**
+     * Mirrors Order::scopeSearch over the draft's own denormalized columns
+     * (no client relation to join here).
+     *
+     * @param  Builder<OrderDraft>  $query
+     * @return Builder<OrderDraft>
+     */
+    public function scopeSearch(Builder $query, ?string $term): Builder
+    {
+        $term = trim((string) $term);
+
+        if ($term === '') {
+            return $query;
+        }
+
+        $like = '%'.addcslashes($term, '%_\\').'%';
+        $digits = Phone::localDigits($term);
+        $phone = strlen($digits) >= self::MIN_PHONE_DIGITS ? '%'.$digits.'%' : null;
+
+        return $query->where(function (Builder $query) use ($like, $phone) {
+            $query->where('order_drafts.id', 'like', $like)
+                ->orWhere('order_drafts.photo_number', 'like', $like)
+                ->orWhere('order_drafts.child_name', 'like', $like)
+                ->orWhere('order_drafts.client_name', 'like', $like);
+
+            if ($phone !== null) {
+                $query->orWhereRaw(Phone::digitsExpression('order_drafts.client_phone').' like ?', [$phone]);
+            }
+        });
     }
 
     protected $casts = [

--- a/app/Support/Phone.php
+++ b/app/Support/Phone.php
@@ -32,4 +32,16 @@ class Phone
 
         return $digits;
     }
+
+    /**
+     * SQL expression stripping a phone column's separators so it's
+     * comparable, digit by digit, with a normalized search term.
+     *
+     * @param  literal-string  $column
+     * @return literal-string
+     */
+    public static function digitsExpression(string $column): string
+    {
+        return "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE({$column}, ' ', ''), '-', ''), '(', ''), ')', ''), '+', ''), '.', '')";
+    }
 }

--- a/database/factories/OrderDraftFactory.php
+++ b/database/factories/OrderDraftFactory.php
@@ -20,6 +20,7 @@ class OrderDraftFactory extends Factory
     {
         return [
             'classroom_id' => Classroom::factory(),
+            'photo_number' => null,
             'child_name' => fake()->firstName(),
             'client_name' => fake()->name(),
             'client_phone' => '3804123456',

--- a/database/migrations/2025_02_08_000001_create_order_drafts_table.php
+++ b/database/migrations/2025_02_08_000001_create_order_drafts_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
         Schema::create('order_drafts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('classroom_id')->constrained();
+            $table->integer('photo_number')->nullable();
             $table->string('child_name')->nullable();
             $table->string('client_name')->nullable();
             $table->string('client_phone')->nullable();

--- a/database/seeders/DemoDraftSeeder.php
+++ b/database/seeders/DemoDraftSeeder.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
+use App\Actions\Orders\CreateOrderDraft;
 use App\Models\Classroom;
 use App\Models\Combo;
-use App\Models\OrderDraft;
 use App\Models\Product;
 use Illuminate\Database\Seeder;
 
 /**
  * One complete draft (prefills the whole order form when loaded) and one
- * barely started.
+ * barely started. Created through CreateOrderDraft so photo_number is
+ * allocated via the real path, same as any other draft.
  */
 class DemoDraftSeeder extends Seeder
 {
@@ -26,7 +27,9 @@ class DemoDraftSeeder extends Seeder
         $carpeta = Product::where('name', 'Carpeta 2 fotos')->firstOrFail();
         $medalla = Product::where('name', 'Medalla')->firstOrFail();
 
-        OrderDraft::create([
+        $action = app(CreateOrderDraft::class);
+
+        $action->handle([
             'classroom_id' => $sextoB->id,
             'child_name' => 'Felipe',
             'client_name' => 'Laura Benítez',
@@ -52,7 +55,7 @@ class DemoDraftSeeder extends Seeder
             ],
         ]);
 
-        OrderDraft::create([
+        $action->handle([
             'classroom_id' => $salaDe5->id,
             'child_name' => 'Guadalupe',
             'products' => [],

--- a/e2e/drafts.spec.ts
+++ b/e2e/drafts.spec.ts
@@ -58,3 +58,72 @@ test('draft: save, preload via "Ver", saving the order consumes it', async ({
         page.getByRole('row').filter({ hasText: 'Cliente Borrador E2E' }),
     ).toHaveCount(0);
 });
+
+// Issue #160: a draft must show up in its classroom listing with a photo
+// number and a "Completar pedido" action, and keep that number once the
+// order is completed from there.
+test('draft: shows up in the classroom listing and keeps its number once completed', async ({
+    page,
+}) => {
+    await page.goto('/orders/create');
+    await fillSchoolStep(page);
+    await fillClientStep(page, {
+        name: 'Cliente Curso E2E',
+        phone: '3804777777',
+        child: 'Renata',
+    });
+    await nextStep(page);
+    await page.locator('#total_price').fill('30000');
+    await page.locator('#payment_plan').fill('1');
+    await page.getByRole('button', { name: 'Guardar como borrador' }).click();
+    await page.waitForURL('/drafts');
+
+    // Navigate to the classroom (Escuela Normal / 6TO A) through the UI
+    await page.goto('/schools');
+    await page
+        .getByRole('row', { name: /Escuela Normal/ })
+        .getByRole('link')
+        .first()
+        .click();
+    await page.waitForURL(/\/schools\/\d+/);
+    await page
+        .getByRole('row', { name: /6TO A/i })
+        .getByRole('link', { name: 'Ver alumnos' })
+        .click();
+    await page.waitForURL(/\/classrooms\/\d+/);
+    const classroomUrl = page.url();
+
+    const draftRow = page
+        .getByRole('row')
+        .filter({ hasText: 'Cliente Curso E2E' });
+    await expect(draftRow).toBeVisible();
+    await expect(draftRow.getByText('Borrador')).toBeVisible();
+
+    const photoNumber = await draftRow.locator('td').first().innerText();
+    expect(photoNumber).toMatch(/^\d+$/);
+
+    // Complete the draft into a real order
+    await draftRow.getByRole('link', { name: 'Completar pedido' }).click();
+    await page.waitForURL(/\/orders\/create/);
+    await stepTriggers(page).filter({ hasText: 'Productos' }).first().click();
+    await addSimpleProduct(page, 'Taza', 'Taza de Renata');
+    await stepTriggers(page).filter({ hasText: 'Pedido' }).first().click();
+    await page.getByRole('button', { name: 'Guardar', exact: true }).click();
+    await page.waitForURL('/orders');
+
+    // Same classroom row now shows the same number, with "Ver" instead
+    await page.goto(classroomUrl);
+
+    const completedRow = page
+        .getByRole('row')
+        .filter({ hasText: 'Cliente Curso E2E' });
+    await expect(completedRow).not.toContainText('Borrador');
+    await expect(completedRow.locator('td').first()).toHaveText(photoNumber);
+    await expect(completedRow.getByRole('link', { name: 'Ver' })).toBeVisible();
+
+    // Gone from /drafts
+    await page.goto('/drafts');
+    await expect(
+        page.getByRole('row').filter({ hasText: 'Cliente Curso E2E' }),
+    ).toHaveCount(0);
+});

--- a/resources/js/pages/classrooms/components/students-table.test.tsx
+++ b/resources/js/pages/classrooms/components/students-table.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { StudentsTable } from './students-table';
+import { ClassroomStudent, StudentsTable } from './students-table';
 
 vi.mock('@inertiajs/react', () => ({
     Link: ({
@@ -22,25 +22,28 @@ vi.mock('@inertiajs/react', () => ({
 vi.stubGlobal(
     'route',
     (name: string, params?: Record<string, unknown>) =>
-        `http://localhost/${name}/${params?.order ?? ''}`,
+        `http://localhost/${name}/${params?.order ?? params?.draft ?? ''}`,
 );
 
-const makeOrder = (overrides: Partial<Order> = {}): Order =>
-    ({
-        id: 7,
-        photo_number: 12,
-        child_name: 'Maylén Ortiz',
-        total_price: 15000,
-        payment_plan: 3,
-        due_date: '2026-08-01',
-        client: { id: 1, name: 'Marta López', phone: '3804000003' },
-        products: [{}, {}],
-        ...overrides,
-    }) as unknown as Order;
+const makeStudent = (
+    overrides: Partial<ClassroomStudent> = {},
+): ClassroomStudent => ({
+    kind: 'order',
+    id: 7,
+    photo_number: 12,
+    child_name: 'Maylén Ortiz',
+    client_name: 'Marta López',
+    client_phone: '3804000003',
+    products_count: 2,
+    total_price: 15000,
+    payment_plan: 3,
+    due_date: '1 de ago 2026',
+    ...overrides,
+});
 
 describe('StudentsTable', () => {
     it('renders the child order number with a link to the order', () => {
-        render(<StudentsTable orders={[makeOrder()]} />);
+        render(<StudentsTable students={[makeStudent()]} />);
 
         const row = screen.getAllByRole('row')[1];
 
@@ -54,8 +57,8 @@ describe('StudentsTable', () => {
     it('falls back to a dash without an order number or child name', () => {
         render(
             <StudentsTable
-                orders={[
-                    makeOrder({ photo_number: null, child_name: undefined }),
+                students={[
+                    makeStudent({ photo_number: null, child_name: null }),
                 ]}
             />,
         );
@@ -66,9 +69,41 @@ describe('StudentsTable', () => {
 
     it('marks the searched order number', () => {
         const { container } = render(
-            <StudentsTable orders={[makeOrder()]} search="12" />,
+            <StudentsTable students={[makeStudent()]} search="12" />,
         );
 
         expect(container.querySelector('mark')?.textContent).toBe('12');
+    });
+
+    it('shows a draft badge and a "Completar pedido" link with the draft id', () => {
+        render(
+            <StudentsTable
+                students={[
+                    makeStudent({ kind: 'draft', id: 3, photo_number: 5 }),
+                ]}
+            />,
+        );
+
+        const row = screen.getAllByRole('row')[1];
+
+        expect(within(row).getByText('Borrador')).toBeTruthy();
+        expect(
+            within(row)
+                .getByRole('link', { name: 'Completar pedido' })
+                .getAttribute('href'),
+        ).toBe('http://localhost/orders.create/3');
+    });
+
+    it('does not collide keys when an order and a draft share the same id', () => {
+        render(
+            <StudentsTable
+                students={[
+                    makeStudent({ kind: 'order', id: 1, photo_number: 1 }),
+                    makeStudent({ kind: 'draft', id: 1, photo_number: 2 }),
+                ]}
+            />,
+        );
+
+        expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 rows
     });
 });

--- a/resources/js/pages/classrooms/components/students-table.tsx
+++ b/resources/js/pages/classrooms/components/students-table.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/components/ui/badge';
 import { buttonVariants } from '@/components/ui/button';
 import {
     Table,
@@ -12,13 +13,26 @@ import { PhoneLink } from '@/features/phone-link';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
 
+export interface ClassroomStudent {
+    kind: 'order' | 'draft';
+    id: number;
+    photo_number: number | null;
+    child_name: string | null;
+    client_name: string | null;
+    client_phone: string | null;
+    products_count: number;
+    total_price: number;
+    payment_plan: number;
+    due_date: string | null;
+}
+
 interface StudentsTableProps {
-    orders: Order[];
+    students: ClassroomStudent[];
     /** The applied search term, marked in the columns it matched. */
     search?: string | null;
 }
 
-export function StudentsTable({ orders, search }: StudentsTableProps) {
+export function StudentsTable({ students, search }: StudentsTableProps) {
     return (
         <Table>
             <TableHeader>
@@ -35,12 +49,12 @@ export function StudentsTable({ orders, search }: StudentsTableProps) {
                 </TableRow>
             </TableHeader>
             <TableBody>
-                {orders.map((order) => (
-                    <TableRow key={order.id}>
+                {students.map((student) => (
+                    <TableRow key={`${student.kind}-${student.id}`}>
                         <TableCell className="font-medium">
-                            {order.photo_number != null ? (
+                            {student.photo_number != null ? (
                                 <Highlight
-                                    text={String(order.photo_number)}
+                                    text={String(student.photo_number)}
                                     term={search}
                                 />
                             ) : (
@@ -48,19 +62,24 @@ export function StudentsTable({ orders, search }: StudentsTableProps) {
                             )}
                         </TableCell>
                         <TableCell>
-                            {order.child_name ? (
-                                <Highlight
-                                    text={order.child_name}
-                                    term={search}
-                                />
-                            ) : (
-                                '—'
-                            )}
+                            <div className="flex items-center gap-2">
+                                {student.child_name ? (
+                                    <Highlight
+                                        text={student.child_name}
+                                        term={search}
+                                    />
+                                ) : (
+                                    '—'
+                                )}
+                                {student.kind === 'draft' && (
+                                    <Badge variant="secondary">Borrador</Badge>
+                                )}
+                            </div>
                         </TableCell>
                         <TableCell>
-                            {order.client.name ? (
+                            {student.client_name ? (
                                 <Highlight
-                                    text={order.client.name}
+                                    text={student.client_name}
                                     term={search}
                                 />
                             ) : (
@@ -69,34 +88,53 @@ export function StudentsTable({ orders, search }: StudentsTableProps) {
                         </TableCell>
                         <TableCell>
                             <PhoneLink
-                                phone={order.client.phone}
+                                phone={student.client_phone}
                                 term={search}
                             />
                         </TableCell>
-                        <TableCell>{order.products.length}</TableCell>
-                        <TableCell>{formatPrice(order.total_price)}</TableCell>
+                        <TableCell>{student.products_count}</TableCell>
                         <TableCell>
-                            {order.payment_plan} (
-                            {formatPrice(
-                                order.total_price / order.payment_plan,
-                            )}
-                            )
+                            {formatPrice(student.total_price)}
                         </TableCell>
-                        <TableCell>{order.due_date}</TableCell>
                         <TableCell>
-                            <Link
-                                className={cn(
-                                    buttonVariants({
-                                        size: 'sm',
-                                        variant: 'outline',
-                                    }),
-                                )}
-                                href={route('orders.show', {
-                                    order: order.id,
-                                })}
-                            >
-                                Ver
-                            </Link>
+                            {student.payment_plan > 0
+                                ? `${student.payment_plan} (${formatPrice(
+                                      student.total_price /
+                                          student.payment_plan,
+                                  )})`
+                                : '—'}
+                        </TableCell>
+                        <TableCell>{student.due_date ?? '—'}</TableCell>
+                        <TableCell>
+                            {student.kind === 'draft' ? (
+                                <Link
+                                    className={cn(
+                                        buttonVariants({
+                                            size: 'sm',
+                                            variant: 'outline',
+                                        }),
+                                    )}
+                                    href={route('orders.create', {
+                                        draft: student.id,
+                                    })}
+                                >
+                                    Completar pedido
+                                </Link>
+                            ) : (
+                                <Link
+                                    className={cn(
+                                        buttonVariants({
+                                            size: 'sm',
+                                            variant: 'outline',
+                                        }),
+                                    )}
+                                    href={route('orders.show', {
+                                        order: student.id,
+                                    })}
+                                >
+                                    Ver
+                                </Link>
+                            )}
                         </TableCell>
                     </TableRow>
                 ))}

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -11,15 +11,15 @@ import { cn } from '@/lib/utils';
 import { BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/react';
 import { ArrowLeft, ImagePlus, ShoppingCart } from 'lucide-react';
-import { StudentsTable } from './components/students-table';
+import { ClassroomStudent, StudentsTable } from './components/students-table';
 
 export default function ClassroomShow({
     classroom,
-    orders,
+    students,
     filters,
 }: PageProps<{
     classroom: Classroom & { teacher?: Teacher; school: School };
-    orders: Paginated<Order>;
+    students: Paginated<ClassroomStudent>;
     filters: { search: string | null };
 }>) {
     const breadcrumbs: BreadcrumbItem[] = [
@@ -89,7 +89,7 @@ export default function ClassroomShow({
             <section className="p-6">
                 <div className="mb-4 flex items-center justify-between">
                     <h2 className="text-2xl font-bold">
-                        Alumnos ({orders.data.length})
+                        Alumnos ({students.data.length})
                     </h2>
                     <Link
                         href={route('photos.index', {
@@ -116,9 +116,9 @@ export default function ClassroomShow({
                     />
                 </div>
 
-                {orders.data.length > 0 ? (
+                {students.data.length > 0 ? (
                     <StudentsTable
-                        orders={orders.data}
+                        students={students.data}
                         search={filters.search}
                     />
                 ) : (

--- a/resources/js/pages/drafts/index.tsx
+++ b/resources/js/pages/drafts/index.tsx
@@ -19,21 +19,24 @@ import { BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
 import { FileText, Plus, Trash2 } from 'lucide-react';
 
+interface DraftRow {
+    id: number;
+    photo_number: number | null;
+    child_name?: string;
+    client_name?: string;
+    client_phone?: string;
+    attended_photo_session?: boolean;
+    total_price: number;
+    payment_plan: number;
+    due_date: string;
+    classroom: Classroom & { school?: School };
+    created_at: string;
+}
+
 export default function DraftsIndex({
     drafts,
 }: PageProps<{
-    drafts: Paginated<{
-        id: number;
-        child_name?: string;
-        client_name?: string;
-        client_phone?: string;
-        attended_photo_session?: boolean;
-        total_price: number;
-        payment_plan: number;
-        due_date: string;
-        classroom: Classroom & { school?: School };
-        created_at: string;
-    }>;
+    drafts: Paginated<DraftRow>;
 }>) {
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -87,7 +90,7 @@ export default function DraftsIndex({
                     <Table>
                         <TableHeader>
                             <TableRow>
-                                <TableHead className="w-25">#</TableHead>
+                                <TableHead className="w-25">N°</TableHead>
                                 <TableHead>Nombre Niño</TableHead>
                                 <TableHead>Cliente</TableHead>
                                 <TableHead>Escuela (Aula)</TableHead>
@@ -102,7 +105,7 @@ export default function DraftsIndex({
                             {drafts.data.map((draft) => (
                                 <TableRow key={draft.id}>
                                     <TableCell className="font-medium">
-                                        {draft.id}
+                                        {draft.photo_number ?? '—'}
                                     </TableCell>
                                     <TableCell>
                                         {draft.child_name || 'N/A'}

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Classroom;
+use App\Models\Client;
+use App\Models\Order;
+use App\Models\OrderDraft;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    actingAsRole();
+});
+
+it('interleaves orders and drafts sorted by photo number, nulls last', function () {
+    $classroom = Classroom::factory()->create();
+
+    $second = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 2]);
+    $unnumbered = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => null]);
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
+
+    get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
+        fn (Assert $page) => $page
+            ->component('classrooms/show')
+            ->has('students.data', 3)
+            ->where('students.data.0.id', $draft->id)
+            ->where('students.data.0.kind', 'draft')
+            ->where('students.data.1.id', $second->id)
+            ->where('students.data.1.kind', 'order')
+            ->where('students.data.2.id', $unnumbered->id),
+    );
+});
+
+it('matches a draft by child name and still matches orders', function () {
+    $classroom = Classroom::factory()->create();
+
+    $order = Order::factory()->create(['classroom_id' => $classroom->id, 'child_name' => 'Joaquín Pérez']);
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'child_name' => 'Mateo Díaz']);
+    OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'child_name' => 'Otro Nombre']);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id, 'search' => 'Joaquín']));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    expect(array_map(fn (array $row) => (int) $row['id'], $students))->toBe([$order->id]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id, 'search' => 'Mateo']));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    expect(array_map(fn (array $row) => (int) $row['id'], $students))->toBe([$draft->id]);
+});
+
+it('matches a draft by phone digits', function () {
+    $classroom = Classroom::factory()->create();
+
+    $client = Client::factory()->create(['phone' => '3804000003']);
+    Order::factory()->create(['classroom_id' => $classroom->id, 'client_id' => $client->id]);
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'client_phone' => '380 400-0099']);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id, 'search' => '3804000099']));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+
+    expect(array_map(fn (array $row) => (int) $row['id'], $students))->toBe([$draft->id]);
+});
+
+it('counts both orders and drafts in the pagination total', function () {
+    $classroom = Classroom::factory()->create();
+
+    Order::factory()->count(2)->create(['classroom_id' => $classroom->id]);
+    OrderDraft::factory()->count(3)->create(['classroom_id' => $classroom->id]);
+
+    get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
+        fn (Assert $page) => $page->where('students.meta.total', 5),
+    );
+});

--- a/tests/Feature/OrderDraftTest.php
+++ b/tests/Feature/OrderDraftTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Classroom;
+use App\Models\Order;
+use App\Models\OrderDraft;
+use App\Models\Product;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+
+/**
+ * @return array<string, mixed>
+ */
+function validDraftPayload(Classroom $classroom, array $overrides = []): array
+{
+    return [
+        'classroom_id' => $classroom->id,
+        'child_name' => 'Niño Test',
+        'client_name' => 'Cliente Test',
+        'client_phone' => '3804123456',
+        'attended_photo_session' => true,
+        'total_price' => 12000,
+        'payment_plan' => 1,
+        'due_date' => now()->addMonth()->format('Y-m-d'),
+        ...$overrides,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function validOrderPayloadFor(Classroom $classroom, Product $product, array $overrides = []): array
+{
+    return [
+        'name' => 'Cliente Test',
+        'phone' => '3804123456',
+        'classroom_id' => $classroom->id,
+        'total_price' => 12000,
+        'payment_plan' => 1,
+        'due_date' => now()->addMonth()->format('Y-m-d'),
+        'child_name' => 'Niño Test',
+        'attended_photo_session' => true,
+        'order_details' => [
+            ['product_id' => $product->id, 'note' => 'sin nota'],
+        ],
+        ...$overrides,
+    ];
+}
+
+beforeEach(function () {
+    actingAsRole();
+});
+
+it('allocates the next number shared with orders', function () {
+    $classroom = Classroom::factory()->create();
+
+    Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
+
+    post(route('drafts.store'), validDraftPayload($classroom))
+        ->assertSessionHasNoErrors();
+
+    expect(OrderDraft::latest('id')->first()?->photo_number)->toBe(2);
+});
+
+it('does not assign a photo number when the child did not attend the session', function () {
+    $classroom = Classroom::factory()->create();
+
+    post(route('drafts.store'), validDraftPayload($classroom, ['attended_photo_session' => false]))
+        ->assertSessionHasNoErrors();
+
+    expect(OrderDraft::latest('id')->first()?->photo_number)->toBeNull();
+});
+
+it('interleaves orders and drafts within a classroom, following creation order', function () {
+    $sextoA = Classroom::factory()->create();
+    $sextoB = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    // 6to A: Carla(1), Juan(2), Felipe(draft, 3), Matías(4)
+    post(route('orders.store'), validOrderPayloadFor($sextoA, $product, ['child_name' => 'Carla']));
+    post(route('orders.store'), validOrderPayloadFor($sextoA, $product, ['child_name' => 'Juan']));
+    post(route('drafts.store'), validDraftPayload($sextoA, ['child_name' => 'Felipe']));
+    post(route('orders.store'), validOrderPayloadFor($sextoA, $product, ['child_name' => 'Matías']));
+
+    // 6to B: Pedro(draft, 1), Carlos(2)
+    post(route('drafts.store'), validDraftPayload($sextoB, ['child_name' => 'Pedro']));
+    post(route('orders.store'), validOrderPayloadFor($sextoB, $product, ['child_name' => 'Carlos']));
+
+    expect(Order::where('classroom_id', $sextoA->id)->where('child_name', 'Carla')->first()?->photo_number)->toBe(1)
+        ->and(Order::where('classroom_id', $sextoA->id)->where('child_name', 'Juan')->first()?->photo_number)->toBe(2)
+        ->and(OrderDraft::where('classroom_id', $sextoA->id)->where('child_name', 'Felipe')->first()?->photo_number)->toBe(3)
+        ->and(Order::where('classroom_id', $sextoA->id)->where('child_name', 'Matías')->first()?->photo_number)->toBe(4)
+        ->and(OrderDraft::where('classroom_id', $sextoB->id)->where('child_name', 'Pedro')->first()?->photo_number)->toBe(1)
+        ->and(Order::where('classroom_id', $sextoB->id)->where('child_name', 'Carlos')->first()?->photo_number)->toBe(2);
+});
+
+it('skips the number already taken by a draft when a plain order is created', function () {
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
+
+    post(route('orders.store'), validOrderPayloadFor($classroom, $product))
+        ->assertSessionHasNoErrors();
+
+    expect(Order::latest('id')->first()?->photo_number)->toBe(2);
+});
+
+it('reuses the draft photo number when completing it in its own classroom', function () {
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 7]);
+
+    post(route('orders.store'), [
+        ...validOrderPayloadFor($classroom, $product),
+        'draft_id' => $draft->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(Order::latest('id')->first()?->photo_number)->toBe(7)
+        ->and(OrderDraft::find($draft->id))->toBeNull();
+});
+
+it('allocates a fresh number when completing a draft into a different classroom', function () {
+    $originalClassroom = Classroom::factory()->create();
+    $targetClassroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    Order::factory()->create(['classroom_id' => $targetClassroom->id, 'photo_number' => 1]);
+    $draft = OrderDraft::factory()->create(['classroom_id' => $originalClassroom->id, 'photo_number' => 7]);
+
+    post(route('orders.store'), [
+        ...validOrderPayloadFor($targetClassroom, $product),
+        'draft_id' => $draft->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(Order::latest('id')->first()?->photo_number)->toBe(2);
+});
+
+it('does not assign a photo number when completing a draft with attended_photo_session false', function () {
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 7]);
+
+    post(route('orders.store'), [
+        ...validOrderPayloadFor($classroom, $product, ['attended_photo_session' => false]),
+        'draft_id' => $draft->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(Order::latest('id')->first()?->photo_number)->toBeNull();
+});
+
+it('exposes the photo number on the drafts index', function () {
+    $classroom = Classroom::factory()->create();
+
+    OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 3]);
+
+    $response = get(route('drafts.index'));
+    $response->assertOk();
+
+    /** @var array<int, array<string, mixed>> $drafts */
+    $drafts = $response->viewData('page')['props']['drafts']['data'];
+
+    expect($drafts[0]['photo_number'])->toBe(3);
+});

--- a/tests/Feature/OrderFilterTest.php
+++ b/tests/Feature/OrderFilterTest.php
@@ -101,10 +101,10 @@ it('lists the classroom students by their order number', function () {
     $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
     $response->assertOk();
 
-    /** @var array<int, array<string, mixed>> $orders */
-    $orders = $response->viewData('page')['props']['orders']['data'];
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
 
-    expect(array_map(fn (array $order) => (int) $order['id'], $orders))
+    expect(array_map(fn (array $student) => (int) $student['id'], $students))
         ->toBe([$first->id, $second->id, $unnumbered->id]);
 });
 

--- a/tests/Feature/OrderSearchTest.php
+++ b/tests/Feature/OrderSearchTest.php
@@ -30,10 +30,12 @@ function searchedOrderIds(string $term, ?Classroom $classroom = null): array
     $response = get($route);
     $response->assertOk();
 
-    /** @var array<int, array<string, mixed>> $orders */
-    $orders = $response->viewData('page')['props']['orders']['data'];
+    $prop = $classroom === null ? 'orders' : 'students';
 
-    return array_map(fn (array $order) => (int) $order['id'], $orders);
+    /** @var array<int, array<string, mixed>> $rows */
+    $rows = $response->viewData('page')['props'][$prop]['data'];
+
+    return array_map(fn (array $row) => (int) $row['id'], $rows);
 }
 
 beforeEach(function () {


### PR DESCRIPTION
## Resumen

- El `photo_number` ahora se asigna al crear el borrador o el pedido, desde una única secuencia por curso compartida entre `orders` y `order_drafts` (antes solo se calculaba al crear el pedido, ignorando los borradores existentes).
- Un pedido nuevo cuenta los borradores existentes al numerar (no colisiona con ellos); completar un borrador en su mismo curso conserva su número.
- `classrooms/show` ahora mezcla pedidos y borradores en un único listado intercalado por número, con badge "Borrador" y acción "Completar pedido" (antes los borradores no aparecían).
- `/drafts` muestra el número asignado.

## Test plan

- [x] `sail artisan migrate:fresh --seed`
- [x] `validate-code --full`: Pint, PhpStan, Pest (177 tests), Prettier, ESLint, tsc, Vitest (287 tests)
- [x] Playwright e2e (`e2e/drafts.spec.ts`, incluye caso nuevo de borrador → curso → completar)
- [x] Verificación manual en navegador: Felipe aparece en 6to B con N° 1, badge "Borrador" y botón "Completar pedido"; `/drafts` muestra la columna N°

Closes #160