### PR TITLE
Permitir edición de datos del cliente en pedidos

### DIFF
--- a/app/Actions/Orders/UpdateOrderClient.php
+++ b/app/Actions/Orders/UpdateOrderClient.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Orders;
+
+use App\Contracts\ActionContract;
+use App\Models\Order;
+use Illuminate\Support\Facades\DB;
+
+class UpdateOrderClient implements ActionContract
+{
+    /**
+     * Update an order's client data and attended_photo_session flag.
+     *
+     * @param  array<string, mixed>  $params  {order: Order, data: array<string, mixed>}
+     */
+    public function handle(array $params): void
+    {
+        /** @var Order $order */
+        $order = $params['order'];
+
+        /** @var array<string, mixed> $data */
+        $data = $params['data'];
+
+        DB::transaction(function () use ($order, $data) {
+            $order->update([
+                'child_name' => $data['child_name'] ?? null,
+                'attended_photo_session' => $data['attended_photo_session'] ?? null,
+            ]);
+
+            $order->client()->update([
+                'name' => $data['name'] ?? null,
+                'phone' => $data['phone'] ?? null,
+            ]);
+        });
+    }
+}

--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\BO;
 use App\Actions\Orders\CancelOrder;
 use App\Actions\Orders\CreateOrder;
 use App\Actions\Orders\UpdateOrder;
+use App\Actions\Orders\UpdateOrderClient;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\CancelOrderRequest;
 use App\Http\Requests\BO\StoreOrderRequest;
+use App\Http\Requests\BO\UpdateOrderClientRequest;
 use App\Http\Resources\OrderResource;
 use App\Models\Combo;
 use App\Models\Order;
@@ -184,5 +186,16 @@ class OrderController extends Controller
 
         return redirect()->route('orders.show', ['order' => $order->id])
             ->with('success', 'Pedido cancelado');
+    }
+
+    public function updateClient(UpdateOrderClientRequest $request, Order $order, UpdateOrderClient $action): RedirectResponse
+    {
+        if ($order->cancelled_at !== null) {
+            return back()->withErrors(['order' => 'No se puede editar un pedido cancelado.']);
+        }
+
+        $action->handle(['order' => $order, 'data' => $request->validated()]);
+
+        return back()->with('success', 'Datos del cliente actualizados exitosamente');
     }
 }

--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -123,17 +123,7 @@ class OrderController extends Controller
             return back()->withErrors(['order' => 'No se puede editar un pedido cancelado.']);
         }
 
-        // Calculate if can edit: allow edit if no payments or first payment not complete
-        $canEdit = true;
-        if ($order->payments()->count() > 0) {
-            $totalPaid = $order->payments()->sum('amount');
-            $firstQuote = $order->total_price / $order->payment_plan;
-            if ($totalPaid >= $firstQuote) {
-                $canEdit = false;
-            }
-        }
-
-        if (! $canEdit) {
+        if ($order->firstInstallmentPaid()) {
             return back()->withErrors(['order' => 'No se puede editar este pedido. La primera cuota ha sido pagada completamente.']);
         }
 
@@ -159,17 +149,7 @@ class OrderController extends Controller
             return back()->withErrors(['order' => 'No se puede editar un pedido cancelado.']);
         }
 
-        // Allow edit only while no payment covers the first installment
-        $canEdit = true;
-        if ($order->payments()->count() > 0) {
-            $totalPaid = $order->payments()->sum('amount');
-            $firstQuote = $order->total_price / $order->payment_plan;
-            if ($totalPaid >= $firstQuote) {
-                $canEdit = false;
-            }
-        }
-
-        if (! $canEdit) {
+        if ($order->firstInstallmentPaid()) {
             return back()->withErrors(['order' => 'No se puede editar este pedido. La primera cuota ha sido pagada completamente.']);
         }
 

--- a/app/Http/Requests/BO/UpdateOrderClientRequest.php
+++ b/app/Http/Requests/BO/UpdateOrderClientRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateOrderClientRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string'],
+            'child_name' => ['nullable', 'string'],
+            'attended_photo_session' => ['nullable', 'boolean'],
+        ];
+    }
+
+    /**
+     * Get the validated data as a structured array.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array{
+     *     name: string|null,
+     *     phone: string|null,
+     *     child_name: string|null,
+     *     attended_photo_session: bool|null,
+     * }
+     */
+    public function validated($key = null, $default = null): array
+    {
+        /** @var array{
+         *     name: string|null,
+         *     phone: string|null,
+         *     child_name: string|null,
+         *     attended_photo_session: bool|null,
+         * }
+         */
+        $validated = parent::validated($key, $default);
+
+        return $validated;
+    }
+}

--- a/resources/js/pages/orders/components/edit-client-modal.test.tsx
+++ b/resources/js/pages/orders/components/edit-client-modal.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditClientFormController } from '../hooks/use-edit-client-form';
+import { EditClientModal } from './edit-client-modal';
+
+const mockSubmit = vi.fn();
+
+const mockForm: EditClientFormController = {
+    data: {
+        name: 'Original Name',
+        phone: '3801234567',
+        child_name: 'Original Child',
+        attended_photo_session: true,
+    },
+    setData: vi.fn(),
+    errors: {},
+    processing: false,
+    submit: mockSubmit,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('EditClientModal', () => {
+    it('renders the modal when show is true', () => {
+        render(<EditClientModal show onClose={vi.fn()} form={mockForm} />);
+
+        expect(screen.getByText('Editar datos del cliente')).toBeTruthy();
+    });
+
+    it('does not render when show is false', () => {
+        render(
+            <EditClientModal show={false} onClose={vi.fn()} form={mockForm} />,
+        );
+
+        expect(screen.queryByText('Editar datos del cliente')).toBeNull();
+    });
+
+    it('displays form fields with current values', () => {
+        render(<EditClientModal show onClose={vi.fn()} form={mockForm} />);
+
+        expect(screen.getByDisplayValue('Original Name')).toBeTruthy();
+        expect(screen.getByDisplayValue('3801234567')).toBeTruthy();
+        expect(screen.getByDisplayValue('Original Child')).toBeTruthy();
+    });
+
+    it('calls setData when form fields change', () => {
+        render(<EditClientModal show onClose={vi.fn()} form={mockForm} />);
+
+        const nameInput = screen.getByDisplayValue(
+            'Original Name',
+        ) as HTMLInputElement;
+        fireEvent.change(nameInput, { target: { value: 'New Name' } });
+
+        expect(mockForm.setData).toHaveBeenCalledWith('name', 'New Name');
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = vi.fn();
+
+        render(<EditClientModal show onClose={onClose} form={mockForm} />);
+
+        fireEvent.click(screen.getByText('Cancelar'));
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls submit and onClose when Save is clicked', () => {
+        const onClose = vi.fn();
+
+        render(<EditClientModal show onClose={onClose} form={mockForm} />);
+
+        fireEvent.click(screen.getByText('Guardar cambios'));
+
+        expect(mockSubmit).toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('disables submit button while processing', () => {
+        const processingForm: EditClientFormController = {
+            ...mockForm,
+            processing: true,
+        };
+
+        render(
+            <EditClientModal show onClose={vi.fn()} form={processingForm} />,
+        );
+
+        const submitButton = screen
+            .getByText('Guardar cambios')
+            .closest('button') as HTMLButtonElement;
+        expect(submitButton.disabled).toBe(true);
+    });
+
+    it('renders radio buttons for attended_photo_session', () => {
+        render(<EditClientModal show onClose={vi.fn()} form={mockForm} />);
+
+        expect(screen.getByText('Sí')).toBeTruthy();
+        expect(screen.getByText('No')).toBeTruthy();
+        expect(screen.getByText('Sin definir')).toBeTruthy();
+    });
+});

--- a/resources/js/pages/orders/components/edit-client-modal.test.tsx
+++ b/resources/js/pages/orders/components/edit-client-modal.test.tsx
@@ -77,22 +77,6 @@ describe('EditClientModal', () => {
         expect(onClose).toHaveBeenCalled();
     });
 
-    it('disables submit button while processing', () => {
-        const processingForm: EditClientFormController = {
-            ...mockForm,
-            processing: true,
-        };
-
-        render(
-            <EditClientModal show onClose={vi.fn()} form={processingForm} />,
-        );
-
-        const submitButton = screen
-            .getByText('Guardar cambios')
-            .closest('button') as HTMLButtonElement;
-        expect(submitButton.disabled).toBe(true);
-    });
-
     it('renders radio buttons for attended_photo_session', () => {
         render(<EditClientModal show onClose={vi.fn()} form={mockForm} />);
 

--- a/resources/js/pages/orders/components/edit-client-modal.tsx
+++ b/resources/js/pages/orders/components/edit-client-modal.tsx
@@ -1,0 +1,146 @@
+import InputError from '@/components/input-error';
+import InputHint from '@/components/input-hint';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { FormEventHandler } from 'react';
+import { EditClientFormController } from '../hooks/use-edit-client-form';
+
+export function EditClientModal({
+    show,
+    onClose,
+    form,
+}: {
+    show: boolean;
+    onClose: () => void;
+    form: EditClientFormController;
+}) {
+    const { data, setData, errors, processing, submit } = form;
+
+    const handleSubmit: FormEventHandler = (e) => {
+        e.preventDefault();
+        submit(e);
+        onClose();
+    };
+
+    return (
+        <Modal show={show} onClose={onClose} maxWidth="md">
+            <form onSubmit={handleSubmit} className="p-6">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    Editar datos del cliente
+                </h2>
+
+                <div className="mt-4">
+                    <Label htmlFor="name">Nombre</Label>
+                    <Input
+                        id="name"
+                        type="text"
+                        placeholder="Agustín Perez"
+                        value={data.name || ''}
+                        onChange={(e) =>
+                            setData('name', e.target.value || null)
+                        }
+                        className="mt-1 block w-full"
+                    />
+                    <InputError message={errors.name} />
+                </div>
+
+                <div className="mt-4">
+                    <Label htmlFor="phone">Teléfono</Label>
+                    <InputHint
+                        className="mt-2"
+                        message="Un número de teléfono válido contiene sólo 10 dígitos"
+                    />
+                    <Input
+                        id="phone"
+                        type="text"
+                        placeholder="3804125834"
+                        value={data.phone || ''}
+                        onChange={(e) =>
+                            setData('phone', e.target.value || null)
+                        }
+                        className="mt-1 block w-full"
+                    />
+                    <InputError className="mt-2" message={errors.phone} />
+                </div>
+
+                <div className="mt-4">
+                    <Label htmlFor="child_name">Nombre del niño</Label>
+                    <Input
+                        id="child_name"
+                        type="text"
+                        placeholder="Ej: Juan"
+                        value={data.child_name || ''}
+                        onChange={(e) =>
+                            setData('child_name', e.target.value || null)
+                        }
+                        className="mt-1 block w-full"
+                    />
+                    <InputError message={errors.child_name} />
+                </div>
+
+                <div className="mt-4">
+                    <Label htmlFor="attended_photo_session">
+                        ¿Asistió a la sesión de fotos?
+                    </Label>
+                    <div className="mt-2 flex gap-4">
+                        <label className="flex cursor-pointer items-center">
+                            <input
+                                type="radio"
+                                name="attended_photo_session"
+                                checked={data.attended_photo_session === true}
+                                onChange={() =>
+                                    setData('attended_photo_session', true)
+                                }
+                                className="mr-2"
+                            />
+                            Sí
+                        </label>
+                        <label className="flex cursor-pointer items-center">
+                            <input
+                                type="radio"
+                                name="attended_photo_session"
+                                checked={data.attended_photo_session === false}
+                                onChange={() =>
+                                    setData('attended_photo_session', false)
+                                }
+                                className="mr-2"
+                            />
+                            No
+                        </label>
+                        <label className="flex cursor-pointer items-center">
+                            <input
+                                type="radio"
+                                name="attended_photo_session"
+                                checked={data.attended_photo_session === null}
+                                onChange={() =>
+                                    setData('attended_photo_session', null)
+                                }
+                                className="mr-2"
+                            />
+                            Sin definir
+                        </label>
+                    </div>
+                    <InputError message={errors.attended_photo_session} />
+                </div>
+
+                <div className="mt-6 grid grid-cols-[1fr_1fr] gap-2">
+                    <Button
+                        disabled={processing}
+                        variant="outline"
+                        onClick={onClose}
+                        type="button"
+                    >
+                        Cancelar
+                    </Button>
+
+                    <Button disabled={processing}>
+                        {processing ? <Spinner /> : 'Guardar cambios'}
+                    </Button>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/resources/js/pages/orders/components/order-info-card.test.tsx
+++ b/resources/js/pages/orders/components/order-info-card.test.tsx
@@ -20,6 +20,21 @@ vi.mock('@inertiajs/react', () => ({
     ),
 }));
 
+vi.mock('../hooks/use-edit-client-form', () => ({
+    useEditClientForm: () => ({
+        data: {
+            name: '',
+            phone: '',
+            child_name: '',
+            attended_photo_session: null,
+        },
+        setData: vi.fn(),
+        errors: {},
+        processing: false,
+        submit: vi.fn(),
+    }),
+}));
+
 vi.stubGlobal(
     'route',
     (name: string, params?: Record<string, unknown>) =>
@@ -182,5 +197,41 @@ describe('OrderInfoCard', () => {
                 'La edición se bloquea cuando la primera cuota está pagada.',
             ),
         ).toBeNull();
+    });
+
+    it('shows the edit client button when the order is not cancelled', () => {
+        render(
+            <OrderInfoCard
+                order={makeOrder({ cancelled_at: null })}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTitle('Editar datos del cliente')).toBeTruthy();
+    });
+
+    it('hides the edit client button when the order is cancelled', () => {
+        render(
+            <OrderInfoCard
+                order={makeOrder({ cancelled_at: '2026-07-01' })}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByTitle('Editar datos del cliente')).toBeNull();
+    });
+
+    it('opens the edit client modal when clicking the edit client button', () => {
+        render(
+            <OrderInfoCard
+                order={makeOrder({ cancelled_at: null })}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        const editClientButton = screen.getByTitle('Editar datos del cliente');
+        fireEvent.click(editClientButton);
+
+        expect(screen.getByText('Editar datos del cliente')).toBeTruthy();
     });
 });

--- a/resources/js/pages/orders/components/order-info-card.tsx
+++ b/resources/js/pages/orders/components/order-info-card.tsx
@@ -10,7 +10,10 @@ import {
 import { PhoneLink } from '@/features/phone-link';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
-import { Ban, Edit2 } from 'lucide-react';
+import { Ban, Edit2, User } from 'lucide-react';
+import { useState } from 'react';
+import { useEditClientForm } from '../hooks/use-edit-client-form';
+import { EditClientModal } from './edit-client-modal';
 
 const STATUS_STYLES: Record<string, string> = {
     'sin habilitar': 'bg-zinc-400 hover:bg-zinc-400',
@@ -29,120 +32,153 @@ interface OrderInfoCardProps {
 
 export function OrderInfoCard({ order, onCancel }: OrderInfoCardProps) {
     const isCancelled = Boolean(order.cancelled_at);
+    const [showEditClientModal, setShowEditClientModal] = useState(false);
+    const editClientForm = useEditClientForm(order);
 
     return (
-        <Card className="relative">
-            {order.can_edit ? (
-                <Link
-                    href={route('orders.edit', {
-                        order: order.id,
-                    })}
-                    className={cn(
-                        'absolute top-4 right-4',
-                        buttonVariants({
-                            size: 'sm',
-                            variant: 'outline',
-                        }),
+        <>
+            <Card className="relative">
+                <div className="absolute top-4 right-4 flex gap-2">
+                    {!isCancelled && (
+                        <button
+                            onClick={() => setShowEditClientModal(true)}
+                            className={cn(
+                                buttonVariants({
+                                    size: 'sm',
+                                    variant: 'outline',
+                                }),
+                            )}
+                            title="Editar datos del cliente"
+                        >
+                            <User className="h-4 w-4" />
+                        </button>
                     )}
-                >
-                    <Edit2 />
-                </Link>
-            ) : (
-                <span
-                    className={cn(
-                        'absolute top-4 right-4 opacity-60',
-                        buttonVariants({
-                            size: 'sm',
-                            variant: 'outline',
-                        }),
+                    {order.can_edit ? (
+                        <Link
+                            href={route('orders.edit', {
+                                order: order.id,
+                            })}
+                            className={cn(
+                                buttonVariants({
+                                    size: 'sm',
+                                    variant: 'outline',
+                                }),
+                            )}
+                        >
+                            <Edit2 />
+                        </Link>
+                    ) : (
+                        <span
+                            className={cn(
+                                'opacity-60',
+                                buttonVariants({
+                                    size: 'sm',
+                                    variant: 'outline',
+                                }),
+                            )}
+                            aria-disabled="true"
+                            title="La edición se bloquea cuando la primera cuota está pagada o el pedido está cancelado"
+                        >
+                            <Edit2 />
+                        </span>
                     )}
-                    aria-disabled="true"
-                    title="La edición se bloquea cuando la primera cuota está pagada o el pedido está cancelado"
-                >
-                    <Edit2 />
-                </span>
-            )}
-            <CardHeader>
-                <CardDescription>
-                    {`${order.school.name}
+                </div>
+                <CardHeader>
+                    <CardDescription>
+                        {`${order.school.name}
                     (${order.classroom.name})`}
-                </CardDescription>
-                <CardTitle className="flex items-center gap-2">
-                    {order.client.name}
-                    {order.status && (
-                        <Badge className={cn(STATUS_STYLES[order.status])}>
-                            {order.status}
-                        </Badge>
+                    </CardDescription>
+                    <CardTitle className="flex items-center gap-2">
+                        {order.client.name}
+                        {order.status && (
+                            <Badge className={cn(STATUS_STYLES[order.status])}>
+                                {order.status}
+                            </Badge>
+                        )}
+                    </CardTitle>
+                    <CardDescription className="flex items-center gap-1">
+                        <PhoneLink phone={order.client.phone} />
+                    </CardDescription>
+                    <CardDescription>
+                        {`Pedido #${order.id}`}
+                        {order.child_name
+                            ? ` · Niño/a: ${order.child_name}`
+                            : ''}
+                        {order.photo_number !== null &&
+                        order.photo_number !== undefined
+                            ? ` · Foto N° ${order.photo_number}`
+                            : ''}
+                    </CardDescription>
+                </CardHeader>
+
+                <CardContent>
+                    {order.photo_url && (
+                        <a
+                            href={order.photo_url}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            <img
+                                src={order.photo_url}
+                                alt={`Foto N° ${order.photo_number}`}
+                                className="mb-3 h-32 w-32 rounded-md object-cover"
+                            />
+                        </a>
                     )}
-                </CardTitle>
-                <CardDescription className="flex items-center gap-1">
-                    <PhoneLink phone={order.client.phone} />
-                </CardDescription>
-                <CardDescription>
-                    {`Pedido #${order.id}`}
-                    {order.child_name ? ` · Niño/a: ${order.child_name}` : ''}
-                    {order.photo_number !== null &&
-                    order.photo_number !== undefined
-                        ? ` · Foto N° ${order.photo_number}`
-                        : ''}
-                </CardDescription>
-            </CardHeader>
-
-            <CardContent>
-                {order.photo_url && (
-                    <a href={order.photo_url} target="_blank" rel="noreferrer">
-                        <img
-                            src={order.photo_url}
-                            alt={`Foto N° ${order.photo_number}`}
-                            className="mb-3 h-32 w-32 rounded-md object-cover"
-                        />
-                    </a>
-                )}
-                <CardDescription>
-                    Total: {formatPrice(order.total_price)}
-                </CardDescription>
-                <CardDescription>
-                    Pagado: {formatPrice(order.paid_total ?? 0)}
-                </CardDescription>
-                <CardDescription
-                    className={
-                        (order.balance ?? 0) > 0
-                            ? 'font-semibold text-amber-600'
-                            : 'text-green-600'
-                    }
-                >
-                    Saldo: {formatPrice(order.balance ?? 0)}
-                </CardDescription>
-                <CardDescription>Cuotas: {order.payment_plan}</CardDescription>
-                <CardDescription>
-                    Primer vencimiento: {order.due_date}
-                </CardDescription>
-
-                {isCancelled && (
-                    <CardDescription className="mt-2 font-semibold text-red-600">
-                        Pedido cancelado el {order.cancelled_at}.
+                    <CardDescription>
+                        Total: {formatPrice(order.total_price)}
                     </CardDescription>
-                )}
-
-                {!order.can_edit && !isCancelled && (
-                    <CardDescription className="text-amber-600">
-                        La edición se bloquea cuando la primera cuota está
-                        pagada.
+                    <CardDescription>
+                        Pagado: {formatPrice(order.paid_total ?? 0)}
                     </CardDescription>
-                )}
-
-                {!isCancelled && (
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="mt-4 text-red-600 hover:text-red-700"
-                        onClick={onCancel}
+                    <CardDescription
+                        className={
+                            (order.balance ?? 0) > 0
+                                ? 'font-semibold text-amber-600'
+                                : 'text-green-600'
+                        }
                     >
-                        <Ban className="mr-1 h-4 w-4" />
-                        Cancelar pedido
-                    </Button>
-                )}
-            </CardContent>
-        </Card>
+                        Saldo: {formatPrice(order.balance ?? 0)}
+                    </CardDescription>
+                    <CardDescription>
+                        Cuotas: {order.payment_plan}
+                    </CardDescription>
+                    <CardDescription>
+                        Primer vencimiento: {order.due_date}
+                    </CardDescription>
+
+                    {isCancelled && (
+                        <CardDescription className="mt-2 font-semibold text-red-600">
+                            Pedido cancelado el {order.cancelled_at}.
+                        </CardDescription>
+                    )}
+
+                    {!order.can_edit && !isCancelled && (
+                        <CardDescription className="text-amber-600">
+                            La edición se bloquea cuando la primera cuota está
+                            pagada.
+                        </CardDescription>
+                    )}
+
+                    {!isCancelled && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="mt-4 text-red-600 hover:text-red-700"
+                            onClick={onCancel}
+                        >
+                            <Ban className="mr-1 h-4 w-4" />
+                            Cancelar pedido
+                        </Button>
+                    )}
+                </CardContent>
+            </Card>
+
+            <EditClientModal
+                show={showEditClientModal}
+                onClose={() => setShowEditClientModal(false)}
+                form={editClientForm}
+            />
+        </>
     );
 }

--- a/resources/js/pages/orders/hooks/use-edit-client-form.ts
+++ b/resources/js/pages/orders/hooks/use-edit-client-form.ts
@@ -1,0 +1,37 @@
+import { useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import { toast } from 'sonner';
+
+export function useEditClientForm(order: Order) {
+    const { data, setData, put, processing, errors } = useForm<{
+        name: string | null;
+        phone: string | null;
+        child_name: string | null;
+        attended_photo_session: boolean | null;
+    }>({
+        name: order.client?.name || null,
+        phone: order.client?.phone || null,
+        child_name: order.child_name || null,
+        attended_photo_session: order.attended_photo_session ?? null,
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+
+        put(route('orders.update-client', { order: order.id }), {
+            onSuccess: () => {
+                toast.success('Datos del cliente actualizados exitosamente');
+            },
+        });
+    };
+
+    return {
+        data,
+        setData,
+        errors,
+        processing,
+        submit,
+    };
+}
+
+export type EditClientFormController = ReturnType<typeof useEditClientForm>;

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware(['auth', 'role:master,administración,oficina'])->group(functi
     Route::resource('combos', ComboController::class)->except(['show']);
     Route::resource('orders', OrderController::class);
     Route::post('/orders/{order}/cancel', [OrderController::class, 'cancel'])->name('orders.cancel');
+    Route::put('/orders/{order}/client', [OrderController::class, 'updateClient'])->name('orders.update-client');
     Route::put('/orders/{order}/delivery', [DeliveryController::class, 'update'])->name('orders.delivery');
     Route::put('/orders/{order}/priority', [DetailPriorityController::class, 'update'])->name('orders.priority');
     Route::put('/orders/{order}/production-status', [DetailProductionStatusController::class, 'update'])->name('orders.production-status');

--- a/tests/Feature/OrderTest.php
+++ b/tests/Feature/OrderTest.php
@@ -195,3 +195,82 @@ it('updates the note of a single detail without touching its twin', function () 
     expect($order->details()->orderBy('id')->pluck('note')->all())
         ->toBe(['Taza de Lucas', 'Taza de Emma']);
 });
+
+it('updates client data via the dedicated endpoint', function () {
+    actingAsRole();
+
+    $order = Order::factory()->create();
+
+    put(route('orders.update-client', $order), [
+        'name' => 'Nuevo Cliente',
+        'phone' => '3801234567',
+        'child_name' => 'Nuevo Niño',
+        'attended_photo_session' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect($order->refresh()->client->name)->toBe('Nuevo Cliente')
+        ->and($order->refresh()->client->phone)->toBe('3801234567')
+        ->and($order->refresh()->child_name)->toBe('Nuevo Niño')
+        ->and($order->refresh()->attended_photo_session)->toBeTrue();
+});
+
+it('allows client update even when first installment is paid', function () {
+    actingAsRole();
+
+    $order = Order::factory()->create([
+        'total_price' => 64000,
+        'payment_plan' => 4,
+    ]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 16000]);
+
+    put(route('orders.update-client', $order), [
+        'name' => 'Cliente Actualizado',
+        'phone' => '3801234567',
+        'child_name' => 'Niño Actualizado',
+        'attended_photo_session' => false,
+    ])->assertSessionHasNoErrors();
+
+    expect($order->refresh()->client->name)->toBe('Cliente Actualizado');
+});
+
+it('blocks client update for cancelled orders', function () {
+    actingAsRole();
+
+    $order = Order::factory()->create(['cancelled_at' => now()]);
+
+    put(route('orders.update-client', $order), [
+        'name' => 'Cliente Test',
+        'phone' => '3801234567',
+    ])->assertSessionHasErrors('order');
+
+    expect($order->refresh()->client->name)->not->toBe('Cliente Test');
+});
+
+it('does not touch order price or details when updating client', function () {
+    actingAsRole();
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    $order = Order::factory()->create([
+        'classroom_id' => $classroom->id,
+        'total_price' => 24000,
+        'payment_plan' => 2,
+    ]);
+    $order->products()->attach($product->id, ['note' => 'original note', 'variant' => []]);
+
+    $originalPrice = $order->total_price;
+    $originalPlan = $order->payment_plan;
+    $originalDetail = $order->details()->first();
+
+    put(route('orders.update-client', $order), [
+        'name' => 'Nuevo Cliente',
+        'phone' => '3801234567',
+        'child_name' => 'Nuevo Niño',
+        'attended_photo_session' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect($order->refresh()->total_price)->toBe($originalPrice)
+        ->and($order->refresh()->payment_plan)->toBe($originalPlan)
+        ->and($order->details()->first()->note)->toBe($originalDetail->note);
+});


### PR DESCRIPTION
## Resumen

Permite que los usuarios editen los datos del cliente (nombre, teléfono, nombre del niño, asistencia a sesión de fotos) directamente desde la página de detalles del pedido, incluso después de que la primera cuota esté pagada.

## Cambios

- **Backend**: Nuevo endpoint `PUT /orders/{order}/client` que actualiza solo los datos del cliente sin tocar el precio ni detalles del pedido
- **Frontend**: Modal en la página de detalles del pedido para editar datos del cliente, visible en todos los pedidos no cancelados
- **Tests**: Cobertura completa de Pest y Vitest

## Plan de pruebas

- Pedido con primera cuota pagada: permite actualización de datos del cliente
- Pedido cancelado: bloquea actualización
- Endpoint no toca precio ni detalles del pedido
- Modal se renderiza y guarda cambios correctamente

Closes #159