### PR TITLE
Editar variantes pendientes desde el pedido (#113)

### DIFF
--- a/app/Actions/Orders/UpdateDetailVariant.php
+++ b/app/Actions/Orders/UpdateDetailVariant.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Orders;
+
+use App\Contracts\ActionContract;
+use App\Models\Order;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class UpdateDetailVariant implements ActionContract
+{
+    public function __construct(private readonly SnapshotDetailVariant $snapshotDetailVariant) {}
+
+    /**
+     * Sets an order detail's variant snapshot from a client selection,
+     * rebuilding it from the product's own definitions — never trusting
+     * client-sent labels/hexes for the option.
+     *
+     * @param  array<string, mixed>  $params  {order: Order, detail_id: int, variant: array<string, string|null>}
+     *
+     * @throws ValidationException
+     */
+    public function handle(array $params): void
+    {
+        /** @var Order $order */
+        $order = $params['order'];
+
+        /** @var int $detailId */
+        $detailId = $params['detail_id'];
+
+        /** @var array<string, string|null> $selection */
+        $selection = $params['variant'];
+
+        DB::transaction(function () use ($order, $detailId, $selection) {
+            $detail = $order->details()->with('product')->find($detailId);
+
+            if ($detail === null) {
+                throw ValidationException::withMessages([
+                    'detail_id' => 'No se encontró el producto en este pedido.',
+                ]);
+            }
+
+            $detail->variant = $this->snapshotDetailVariant->handle([
+                'definitions' => $detail->product->variants ?? [],
+                'selection' => $selection,
+            ]);
+            $detail->save();
+        });
+    }
+}

--- a/app/Http/Controllers/BO/DetailVariantController.php
+++ b/app/Http/Controllers/BO/DetailVariantController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Actions\Orders\UpdateDetailVariant;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\BO\UpdateDetailVariantRequest;
+use App\Models\Order;
+use Illuminate\Http\RedirectResponse;
+
+class DetailVariantController extends Controller
+{
+    /**
+     * Sets a detail's variant, informative only (does not gate production).
+     * Editable regardless of payment status, unlike the rest of the order.
+     */
+    public function update(UpdateDetailVariantRequest $request, Order $order, UpdateDetailVariant $action): RedirectResponse
+    {
+        if ($order->cancelled_at !== null) {
+            return back()->withErrors(['order' => 'No se puede editar un pedido cancelado.']);
+        }
+
+        $validated = $request->validated();
+
+        /** @var int $detailId */
+        $detailId = $validated['detail_id'];
+
+        /** @var array<string, string|null> $variant */
+        $variant = $validated['variant'];
+
+        $action->handle([
+            'order' => $order,
+            'detail_id' => $detailId,
+            'variant' => $variant,
+        ]);
+
+        return back()->with('success', 'Variante actualizada');
+    }
+}

--- a/app/Http/Requests/BO/UpdateDetailVariantRequest.php
+++ b/app/Http/Requests/BO/UpdateDetailVariantRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Rules\VariantSelection;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class UpdateDetailVariantRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'detail_id' => ['required', 'integer'],
+            'variant' => ['required', 'array'],
+        ];
+    }
+
+    /**
+     * The selection is validated against the detail's own product
+     * definitions, which can only be resolved once detail_id is known —
+     * addRules must run here, not in an after() hook.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        /** @var mixed $detailId */
+        $detailId = $this->input('detail_id');
+
+        if (! is_numeric($detailId)) {
+            return;
+        }
+
+        /** @var Order $order */
+        $order = $this->route('order');
+
+        /** @var OrderDetail|null $detail */
+        $detail = $order->details()->with('product')->find((int) $detailId);
+
+        if ($detail === null) {
+            return;
+        }
+
+        $definitions = $detail->product->variants ?? [];
+
+        if (empty($definitions)) {
+            return;
+        }
+
+        $validator->addRules([
+            'variant' => [new VariantSelection($definitions)],
+        ]);
+    }
+}

--- a/e2e/variants.spec.ts
+++ b/e2e/variants.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+// Order #12 (Lucía Ferreyra, Sala de 5) carries a Banda with its Talle
+// variant left pending at order time — the exact case #113 covers.
+test('defines a pending variant from the order page and it persists', async ({
+    page,
+}) => {
+    await page.goto('/orders/12');
+
+    await expect(page.getByText('A definir: Talle')).toBeVisible();
+
+    await page.getByText('Editar variantes').click();
+    await expect(page.getByText('Editar variantes de Banda')).toBeVisible();
+
+    const trigger = page.getByRole('combobox', { name: 'Talle' });
+    await trigger.click();
+    await page.getByRole('option', { name: 'M' }).click();
+    await page.getByRole('button', { name: 'Guardar cambios' }).click();
+
+    await expect(page.getByText('Variante actualizada')).toBeVisible();
+    await expect(page.getByText('A definir: Talle')).toHaveCount(0);
+    await expect(page.getByText('M', { exact: true })).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByText('M', { exact: true })).toBeVisible();
+    await expect(page.getByText('A definir: Talle')).toHaveCount(0);
+});

--- a/resources/js/pages/orders/components/detail-item.tsx
+++ b/resources/js/pages/orders/components/detail-item.tsx
@@ -2,22 +2,33 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ProductIcon } from '@/features/product-icon';
 import { capitalize, formatPrice } from '@/lib/utils';
-import { Flame } from 'lucide-react';
+import { Flame, Pencil } from 'lucide-react';
+import { useState } from 'react';
+import { useEditVariantForm } from '../hooks/use-edit-variant-form';
+import { EditVariantModal } from './edit-variant-modal';
 import { ProductionStatusControl } from './production-status-control';
+import { VariantBadges } from './variant-badges';
 
 export function DetailItem({
+    orderId,
     product,
     canPrioritize,
     onTogglePriority,
     firstInstallmentPaid,
     onStatusChange,
+    canEditVariant,
 }: {
+    orderId: number;
     product: OrderProduct;
     canPrioritize: boolean;
     onTogglePriority: () => void;
     firstInstallmentPaid: boolean;
     onStatusChange: (statusId: number | null) => void;
+    canEditVariant: boolean;
 }) {
+    const [showEditVariant, setShowEditVariant] = useState(false);
+    const editVariantForm = useEditVariantForm(orderId, product);
+
     return (
         <div
             key={product.id}
@@ -79,6 +90,18 @@ export function DetailItem({
                         </span>
                     )}
                 </div>
+                <VariantBadges variant={product.variant} />
+                {canEditVariant && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="mt-2 h-auto px-2 py-1 text-xs"
+                        onClick={() => setShowEditVariant(true)}
+                    >
+                        <Pencil className="mr-1 h-3 w-3" />
+                        Editar variantes
+                    </Button>
+                )}
                 {canPrioritize && (
                     <>
                         <ProductionStatusControl
@@ -100,6 +123,12 @@ export function DetailItem({
                     </>
                 )}
             </div>
+            <EditVariantModal
+                show={showEditVariant}
+                onClose={() => setShowEditVariant(false)}
+                product={product}
+                form={editVariantForm}
+            />
         </div>
     );
 }

--- a/resources/js/pages/orders/components/details.test.tsx
+++ b/resources/js/pages/orders/components/details.test.tsx
@@ -7,6 +7,16 @@ vi.mock('@inertiajs/react', () => ({
     router: { put: vi.fn() },
 }));
 
+vi.mock('../hooks/use-edit-variant-form', () => ({
+    useEditVariantForm: () => ({
+        data: { detail_id: 0, variant: {} },
+        setData: vi.fn(),
+        errors: {},
+        processing: false,
+        submit: vi.fn(),
+    }),
+}));
+
 vi.stubGlobal(
     'route',
     (name: string, params?: Record<string, unknown>) =>
@@ -154,5 +164,86 @@ describe('Details', () => {
         expect(
             screen.getByText(/se habilita cuando la primera cuota está paga/),
         ).toBeTruthy();
+    });
+
+    it('shows the edit variant button only for products with variant definitions', () => {
+        const { rerender } = render(
+            <Details order={makeOrder([makeProduct()])} />,
+        );
+
+        expect(screen.queryByText('Editar variantes')).toBeNull();
+
+        rerender(
+            <Details
+                order={makeOrder([
+                    makeProduct({
+                        variants: [
+                            {
+                                label: 'Talle',
+                                type: 'text',
+                                nullable: true,
+                                options: [{ label: 'Único' }],
+                            },
+                        ],
+                    }),
+                ])}
+            />,
+        );
+
+        expect(screen.getByText('Editar variantes')).toBeTruthy();
+    });
+
+    it('hides the edit variant button for cancelled or recycled details', () => {
+        const withVariants = makeProduct({
+            variants: [
+                {
+                    label: 'Talle',
+                    type: 'text',
+                    nullable: true,
+                    options: [{ label: 'Único' }],
+                },
+            ],
+        });
+
+        const { rerender } = render(
+            <Details
+                order={makeOrder([withVariants], {
+                    cancelled_at: '2026-07-01T00:00:00Z',
+                })}
+            />,
+        );
+
+        expect(screen.queryByText('Editar variantes')).toBeNull();
+
+        rerender(
+            <Details
+                order={makeOrder([{ ...withVariants, recycled_to: 'stock' }])}
+            />,
+        );
+
+        expect(screen.queryByText('Editar variantes')).toBeNull();
+    });
+
+    it('opens the edit variant modal from the button', () => {
+        render(
+            <Details
+                order={makeOrder([
+                    makeProduct({
+                        variants: [
+                            {
+                                label: 'Talle',
+                                type: 'text',
+                                nullable: true,
+                                options: [{ label: 'Único' }],
+                            },
+                        ],
+                    }),
+                ])}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Editar variantes'));
+
+        expect(screen.getByText('Editar variantes de Mural')).toBeTruthy();
     });
 });

--- a/resources/js/pages/orders/components/details.tsx
+++ b/resources/js/pages/orders/components/details.tsx
@@ -24,6 +24,7 @@ export function Details({ order }: { order: Order }) {
                 {products.length ? (
                     products.map((product) => (
                         <DetailItem
+                            orderId={order.id}
                             product={product}
                             key={product.id}
                             canPrioritize={
@@ -42,6 +43,11 @@ export function Details({ order }: { order: Order }) {
                             )}
                             onStatusChange={(statusId) =>
                                 setStatus(product.order_detail_id, statusId)
+                            }
+                            canEditVariant={
+                                !isCancelled &&
+                                !product.recycled_to &&
+                                Boolean(product.variants?.length)
                             }
                         />
                     ))

--- a/resources/js/pages/orders/components/edit-variant-modal.test.tsx
+++ b/resources/js/pages/orders/components/edit-variant-modal.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditVariantFormController } from '../hooks/use-edit-variant-form';
+import { EditVariantModal } from './edit-variant-modal';
+
+const mockSubmit = vi.fn();
+
+const product = {
+    id: 5,
+    order_detail_id: 11,
+    name: 'Banda',
+    variants: [
+        {
+            label: 'Talle',
+            type: 'text',
+            nullable: true,
+            options: [{ label: 'Único' }, { label: 'M' }],
+        },
+    ],
+} as unknown as OrderProduct;
+
+const mockForm: EditVariantFormController = {
+    data: { detail_id: 11, variant: { Talle: 'M' } },
+    setData: vi.fn(),
+    errors: {},
+    processing: false,
+    submit: mockSubmit,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('EditVariantModal', () => {
+    it('renders the modal when show is true', () => {
+        render(
+            <EditVariantModal
+                show
+                onClose={vi.fn()}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        expect(screen.getByText('Editar variantes de Banda')).toBeTruthy();
+    });
+
+    it('does not render when show is false', () => {
+        render(
+            <EditVariantModal
+                show={false}
+                onClose={vi.fn()}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        expect(screen.queryByText('Editar variantes de Banda')).toBeNull();
+    });
+
+    it('shows the current selection', () => {
+        render(
+            <EditVariantModal
+                show
+                onClose={vi.fn()}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        expect(screen.getByRole('combobox').textContent).toContain('M');
+    });
+
+    it('sets null when "Definir después" is selected', () => {
+        render(
+            <EditVariantModal
+                show
+                onClose={vi.fn()}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(
+            screen.getByRole('option', { name: 'Definir después' }),
+        );
+
+        expect(mockForm.setData).toHaveBeenCalledWith('variant', {
+            Talle: null,
+        });
+    });
+
+    it('sets the option label when a value is picked', () => {
+        render(
+            <EditVariantModal
+                show
+                onClose={vi.fn()}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Único' }));
+
+        expect(mockForm.setData).toHaveBeenCalledWith('variant', {
+            Talle: 'Único',
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = vi.fn();
+
+        render(
+            <EditVariantModal
+                show
+                onClose={onClose}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Cancelar'));
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls submit and onClose when Save is clicked', () => {
+        const onClose = vi.fn();
+
+        render(
+            <EditVariantModal
+                show
+                onClose={onClose}
+                product={product}
+                form={mockForm}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Guardar cambios'));
+
+        expect(mockSubmit).toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/resources/js/pages/orders/components/edit-variant-modal.tsx
+++ b/resources/js/pages/orders/components/edit-variant-modal.tsx
@@ -1,0 +1,120 @@
+import InputError from '@/components/input-error';
+import { Modal } from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Spinner } from '@/components/ui/spinner';
+import { FormEventHandler } from 'react';
+import { EditVariantFormController } from '../hooks/use-edit-variant-form';
+
+// Radix Select forbids an empty string value, so "left pending" needs a
+// sentinel that gets mapped back to null before it reaches the form data
+const PENDING_SENTINEL = '__pending__';
+
+export function EditVariantModal({
+    show,
+    onClose,
+    product,
+    form,
+}: {
+    show: boolean;
+    onClose: () => void;
+    product: OrderProduct;
+    form: EditVariantFormController;
+}) {
+    const { data, setData, errors, processing, submit } = form;
+
+    const handleSubmit: FormEventHandler = (e) => {
+        e.preventDefault();
+        submit(e);
+        onClose();
+    };
+
+    return (
+        <Modal show={show} onClose={onClose} maxWidth="md">
+            <form onSubmit={handleSubmit} className="p-6">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    Editar variantes de {product.name}
+                </h2>
+
+                {(product.variants ?? []).map((definition) => (
+                    <div className="mt-4" key={definition.label}>
+                        <Label htmlFor={`variant-${definition.label}`}>
+                            {definition.label}
+                        </Label>
+                        <Select
+                            value={
+                                data.variant[definition.label] ??
+                                PENDING_SENTINEL
+                            }
+                            onValueChange={(value) =>
+                                setData('variant', {
+                                    ...data.variant,
+                                    [definition.label]:
+                                        value === PENDING_SENTINEL
+                                            ? null
+                                            : value,
+                                })
+                            }
+                        >
+                            <SelectTrigger
+                                id={`variant-${definition.label}`}
+                                className="mt-1 w-full"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {definition.nullable && (
+                                    <SelectItem value={PENDING_SENTINEL}>
+                                        Definir después
+                                    </SelectItem>
+                                )}
+                                {definition.options.map((option) => (
+                                    <SelectItem
+                                        key={option.label}
+                                        value={option.label}
+                                    >
+                                        <span className="flex items-center gap-2">
+                                            {option.color && (
+                                                <span
+                                                    className="h-3 w-3 rounded-full border border-black/10"
+                                                    style={{
+                                                        backgroundColor:
+                                                            option.color,
+                                                    }}
+                                                />
+                                            )}
+                                            {option.label}
+                                        </span>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                ))}
+                <InputError message={errors.variant} className="mt-2" />
+
+                <div className="mt-6 grid grid-cols-[1fr_1fr] gap-2">
+                    <Button
+                        disabled={processing}
+                        variant="outline"
+                        onClick={onClose}
+                        type="button"
+                    >
+                        Cancelar
+                    </Button>
+
+                    <Button disabled={processing}>
+                        {processing ? <Spinner /> : 'Guardar cambios'}
+                    </Button>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/resources/js/pages/orders/hooks/use-edit-variant-form.ts
+++ b/resources/js/pages/orders/hooks/use-edit-variant-form.ts
@@ -1,0 +1,29 @@
+import { selectionFromSnapshot } from '@/lib/variants';
+import { useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import { toast } from 'sonner';
+
+export function useEditVariantForm(orderId: number, product: OrderProduct) {
+    const { data, setData, put, processing, errors } = useForm<{
+        detail_id: number;
+        variant: VariantSelection;
+    }>({
+        detail_id: product.order_detail_id,
+        variant: selectionFromSnapshot(product.variant),
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+
+        put(route('orders.variant', { order: orderId }), {
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success('Variante actualizada');
+            },
+        });
+    };
+
+    return { data, setData, errors, processing, submit };
+}
+
+export type EditVariantFormController = ReturnType<typeof useEditVariantForm>;

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\BO\DashboardController;
 use App\Http\Controllers\BO\DeliveryController;
 use App\Http\Controllers\BO\DetailPriorityController;
 use App\Http\Controllers\BO\DetailProductionStatusController;
+use App\Http\Controllers\BO\DetailVariantController;
 use App\Http\Controllers\BO\NoteController;
 use App\Http\Controllers\BO\OrderController;
 use App\Http\Controllers\BO\OrderDraftController;
@@ -38,6 +39,7 @@ Route::middleware(['auth', 'role:master,administración,oficina'])->group(functi
     Route::put('/orders/{order}/delivery', [DeliveryController::class, 'update'])->name('orders.delivery');
     Route::put('/orders/{order}/priority', [DetailPriorityController::class, 'update'])->name('orders.priority');
     Route::put('/orders/{order}/production-status', [DetailProductionStatusController::class, 'update'])->name('orders.production-status');
+    Route::put('/orders/{order}/variant', [DetailVariantController::class, 'update'])->name('orders.variant');
     Route::resource('drafts', OrderDraftController::class)->only(['index', 'store', 'destroy']);
     Route::resource('schools', SchoolController::class);
     Route::resource('classrooms', ClassroomController::class)->only(['destroy', 'update', 'store', 'show']);

--- a/tests/Feature/UpdateDetailVariantTest.php
+++ b/tests/Feature/UpdateDetailVariantTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Order;
+use App\Models\Product;
+
+use function Pest\Laravel\put;
+
+/**
+ * @return array<int, array{label: string, type: string, nullable: bool, options: array<int, array{label: string}>}>
+ */
+function bandaVariants(): array
+{
+    return [
+        ['label' => 'Talle', 'type' => 'text', 'nullable' => true, 'options' => [
+            ['label' => 'Único'],
+            ['label' => 'S'],
+            ['label' => 'M'],
+        ]],
+    ];
+}
+
+/**
+ * @return array<int, array{label: string, type: string, nullable: bool, options: array<int, array{label: string, color?: string}>}>
+ */
+function muralVariants(): array
+{
+    return [
+        ['label' => 'Color', 'type' => 'color', 'nullable' => false, 'options' => [
+            ['label' => 'Negro', 'color' => '#1c1917'],
+            ['label' => 'Rosa', 'color' => '#f9a8d4'],
+        ]],
+    ];
+}
+
+it('sets a pending nullable variant', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create();
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => 'M'],
+    ])->assertSessionHasNoErrors();
+
+    $variant = $detail->refresh()->variant;
+
+    expect($variant[0]['value']['label'])->toBe('M')
+        ->and($variant[0]['value']['color'])->toBeNull();
+});
+
+it('clears a nullable variant back to pending', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create();
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => ['label' => 'M']],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => null],
+    ])->assertSessionHasNoErrors();
+
+    expect($detail->refresh()->variant[0]['value'])->toBeNull();
+});
+
+it('rejects nulling a non-nullable variant', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => muralVariants()]);
+    $order = Order::factory()->create();
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Color', 'type' => 'color', 'value' => ['label' => 'Negro', 'color' => '#1c1917']],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Color' => null],
+    ])->assertSessionHasErrors('variant');
+
+    $value = $detail->refresh()->variant[0]['value'];
+
+    expect($value['label'])->toBe('Negro')
+        ->and($value['color'])->toBe('#1c1917');
+});
+
+it('rejects a value outside the product options', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create();
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => 'XL'],
+    ])->assertSessionHasErrors('variant');
+});
+
+it('blocks updates for a cancelled order', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create(['cancelled_at' => now()]);
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => 'M'],
+    ])->assertSessionHasErrors('order');
+
+    expect($detail->refresh()->variant[0]['value'])->toBeNull();
+});
+
+it('rejects a detail that belongs to another order', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create();
+    $otherOrder = Order::factory()->create();
+    $otherOrder->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $foreignDetail = $otherOrder->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $foreignDetail->id,
+        'variant' => ['Talle' => 'M'],
+    ])->assertSessionHasErrors('detail_id');
+
+    expect($foreignDetail->refresh()->variant[0]['value'])->toBeNull();
+});
+
+it('is forbidden for the workshop role', function () {
+    actingAsRole(UserRole::Worker);
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create();
+    $order->products()->attach($product->id, ['note' => 'Nota', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => 'M'],
+    ])->assertForbidden();
+});
+
+it('does not touch the note, price or production status', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['variants' => bandaVariants()]);
+    $order = Order::factory()->create(['total_price' => 9000, 'payment_plan' => 1]);
+    $order->products()->attach($product->id, ['note' => 'Nota original', 'variant' => [
+        ['label' => 'Talle', 'type' => 'text', 'value' => null],
+    ]]);
+    $detail = $order->details()->firstOrFail();
+
+    put(route('orders.variant', $order), [
+        'detail_id' => $detail->id,
+        'variant' => ['Talle' => 'M'],
+    ])->assertSessionHasNoErrors();
+
+    expect($detail->refresh()->note)->toBe('Nota original')
+        ->and($order->refresh()->total_price)->toBe(9000)
+        ->and($order->refresh()->payment_plan)->toBe(1);
+});


### PR DESCRIPTION
## Resumen

Las variantes `nullable` (como el Talle de las bandas) pueden quedar sin definir al cargar el pedido y completarse después, desde `orders/:id`. Se agrega el endpoint dedicado y el modal de edición, con el mismo acceso que el resto del pedido (`role:master,administración,oficina`).

- **Backend**: ruta `PUT /orders/{order}/variant` (mismo patrón plano que `orders.priority`/`orders.production-status`, `detail_id` en el body), `UpdateDetailVariantRequest` (valida la selección contra las definiciones del producto de ese detalle), acción `UpdateDetailVariant` (reconstruye el snapshot server-side, nunca confía en el cliente), `DetailVariantController`. Solo bloquea pedidos cancelados — es informativa, no bloquea producción y es editable aunque la primera cuota esté paga.
- **Frontend**: badges de variante en el detalle del pedido (hoy no se mostraban) + botón "Editar variantes" cuando el producto tiene definiciones y el detalle no está cancelado/reciclado. Modal con un `Select` por variante (swatch para las de color, opción "Definir después" para las nullable).
- **Tests**: `UpdateDetailVariantTest` (8 casos: setear/limpiar variante nullable, rechazo de nulear una no-nullable, valor fuera de opciones, pedido cancelado, detalle de otro pedido, rol taller sin acceso, no toca note/precio/estado), cobertura Vitest del modal y de `Details`, y un spec e2e nuevo usando el pedido demo #12 (Sala de 5, con el Talle pendiente sembrado para este caso).

## Test plan

- [x] `validate-code --full`: Pint, PHPStan, Prettier, ESLint, tsc, Pest (208), Vitest (320) — todo verde.
- [x] Suite e2e completa (17 specs, incluyendo el nuevo `variants.spec.ts`) verde.
- [x] Recorrido manual: abrir el pedido #12, ver "A definir: Talle", editar a "M" desde el modal, confirmar el toast y que sobrevive un reload.

Closes #113