### PR TITLE
fix(orders): aclarar destinos de cancelación y bloquear "stock" sin insumos

### DIFF
--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -113,7 +113,15 @@ class OrderController extends Controller
 
     public function show(Order $order): Response
     {
-        $order->load('client', 'products.type', 'products.productionStatuses', 'payments', 'notes', 'classroom.school', 'details.productionStatus');
+        $order->load([
+            'client',
+            'products.type',
+            'products.productionStatuses',
+            'payments',
+            'notes',
+            'classroom.school',
+            'details' => fn ($query) => $query->withCount('stockMovements')->with('productionStatus'),
+        ]);
 
         return Inertia::render('orders/show', [
             'order' => new OrderResource($order),

--- a/app/Http/Resources/OrderResource.php
+++ b/app/Http/Resources/OrderResource.php
@@ -84,6 +84,8 @@ class OrderResource extends JsonResource
                 /** @var OrderDetail|null $detail */
                 $detail = $details->get($product->pivot->id); // @phpstan-ignore-line
 
+                $stockMovementsCount = $detail?->getAttribute('stock_movements_count');
+
                 return [
                     'id' => $product->id,
                     'order_detail_id' => $product->pivot->id, // @phpstan-ignore-line
@@ -103,6 +105,7 @@ class OrderResource extends JsonResource
                     'production_enabled' => $detail?->production_enabled_at !== null,
                     'priority' => $product->pivot->priority,  // @phpstan-ignore-line
                     'recycled_to' => $detail?->recycled_to,
+                    'has_returnable_stock' => is_numeric($stockMovementsCount) && $stockMovementsCount > 0,
                     'statuses' => $product->relationLoaded('productionStatuses')
                         ? $product->productionStatuses->map(fn (ProductionStatus $status) => [
                             'id' => $status->id,

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -48,7 +48,7 @@ class OrderDetail extends Pivot
      */
     public function stockMovements()
     {
-        return $this->hasMany(StockMovement::class);
+        return $this->hasMany(StockMovement::class, 'order_detail_id');
     }
 
     protected $casts = [

--- a/resources/js/pages/orders/components/cancel-order-modal.test.tsx
+++ b/resources/js/pages/orders/components/cancel-order-modal.test.tsx
@@ -18,9 +18,24 @@ const post = vi.mocked(router.post);
 const order = {
     id: 4,
     products: [
-        { order_detail_id: 21, name: 'Mural', recycled_to: null },
-        { order_detail_id: 22, name: 'Taza', recycled_to: null },
-        { order_detail_id: 23, name: 'Medalla', recycled_to: 'stock' },
+        {
+            order_detail_id: 21,
+            name: 'Mural',
+            recycled_to: null,
+            has_returnable_stock: false,
+        },
+        {
+            order_detail_id: 22,
+            name: 'Taza',
+            recycled_to: null,
+            has_returnable_stock: true,
+        },
+        {
+            order_detail_id: 23,
+            name: 'Medalla',
+            recycled_to: 'stock',
+            has_returnable_stock: true,
+        },
     ],
 } as unknown as Order;
 
@@ -63,5 +78,51 @@ describe('CancelOrderModal', () => {
 
         expect(onClose).toHaveBeenCalled();
         expect(post).not.toHaveBeenCalled();
+    });
+
+    it('disables the stock destination when the product has nothing to return', () => {
+        render(<CancelOrderModal order={order} show onClose={vi.fn()} />);
+
+        // Check that the hint is present for the product without returnable stock (Mural)
+        expect(
+            screen.getByText('Sin insumos para devolver a stock'),
+        ).toBeTruthy();
+
+        // Open the select for Mural (first product) using combobox role
+        const selectTriggers = screen.getAllByRole('combobox');
+        fireEvent.click(selectTriggers[0]);
+
+        // The Stock option should be disabled
+        const stockOption = screen.getByRole('option', { name: 'Stock' });
+        expect(stockOption.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('allows the stock destination when the product has returnable supplies', () => {
+        render(<CancelOrderModal order={order} show onClose={vi.fn()} />);
+
+        // Get all product rows and find Taza (second product with has_returnable_stock: true)
+        // The hint should only appear once (for Mural)
+        const hints = screen.queryAllByText(
+            'Sin insumos para devolver a stock',
+        );
+        expect(hints.length).toBe(1);
+
+        // Open the select for Taza (second product) - it should be selectable to Stock
+        const selectTriggers = screen.getAllByRole('combobox');
+        fireEvent.click(selectTriggers[1]);
+
+        // The Stock option should not be disabled for this product
+        const stockOption = screen.getByRole('option', { name: 'Stock' });
+        expect(stockOption.getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('explains each destination distinctly', () => {
+        render(<CancelOrderModal order={order} show onClose={vi.fn()} />);
+
+        // Check for text describing the "Reciclaje" destination
+        expect(screen.getByText(/módulo de reciclaje/i)).toBeTruthy();
+
+        // Check for text describing the "Stock" destination
+        expect(screen.getByText(/inventario.*insumos/i)).toBeTruthy();
     });
 });

--- a/resources/js/pages/orders/components/cancel-order-modal.tsx
+++ b/resources/js/pages/orders/components/cancel-order-modal.tsx
@@ -68,10 +68,13 @@ export function CancelOrderModal({
                     Cancelar pedido #{order.id}
                 </h2>
                 <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    Elegí a dónde vuelve cada producto. Si vuelve a stock, sus
-                    insumos se devuelven al inventario; si va a reciclaje, queda
-                    listado en el módulo de reciclaje y lo ya producido queda en
-                    stock.
+                    Elegí a dónde vuelve cada producto.{' '}
+                    <strong>Reciclaje</strong> deja el producto listado en el
+                    módulo de reciclaje y lo que ya se produjo permanece en
+                    stock. <strong>Stock</strong> devuelve al inventario los
+                    insumos que se habían descontado durante la producción (si
+                    el producto nunca arrancó producción o no tiene insumos, no
+                    hay nada que devolver).
                 </p>
 
                 <ul className="mt-4 space-y-2">
@@ -80,7 +83,14 @@ export function CancelOrderModal({
                             key={product.order_detail_id}
                             className="flex items-center justify-between gap-2 rounded-md border border-input px-3 py-2"
                         >
-                            <span className="text-sm">{product.name}</span>
+                            <div className="flex flex-col">
+                                <span className="text-sm">{product.name}</span>
+                                {!product.has_returnable_stock && (
+                                    <span className="text-xs text-muted-foreground">
+                                        Sin insumos para devolver a stock
+                                    </span>
+                                )}
+                            </div>
                             <Select
                                 value={destinations[product.order_detail_id]}
                                 onValueChange={(value) =>
@@ -98,7 +108,12 @@ export function CancelOrderModal({
                                     <SelectItem value="reciclaje">
                                         Reciclaje
                                     </SelectItem>
-                                    <SelectItem value="stock">Stock</SelectItem>
+                                    <SelectItem
+                                        value="stock"
+                                        disabled={!product.has_returnable_stock}
+                                    >
+                                        Stock
+                                    </SelectItem>
                                 </SelectContent>
                             </Select>
                         </li>

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -117,6 +117,8 @@ declare global {
         production_enabled?: boolean;
         priority?: boolean | null;
         recycled_to?: 'stock' | 'reciclaje' | null;
+        /** Whether this detail has any stock movements to reverse on cancellation */
+        has_returnable_stock?: boolean;
         /** Stages of the product's chain, ordered by position */
         statuses?: ProductionStatus[];
     }

--- a/tests/Feature/OrderShowReturnableStockTest.php
+++ b/tests/Feature/OrderShowReturnableStockTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Resources\OrderResource;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Stockable;
+use App\Services\StockService;
+
+it('marks a product with deducted supplies as returnable', function () {
+    actingAsRole();
+
+    $product = productWithChain(['Pendiente', 'Corte', 'Embolsado']);
+    $stockable = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($stockable->id, ['quantity' => -2]);
+
+    $order = Order::factory()->create();
+    $detail = OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ]);
+    app(StockService::class)->applyForDetail($detail);
+
+    // Load the order the same way the controller does
+    $order->load([
+        'client',
+        'products.type',
+        'products.productionStatuses',
+        'payments',
+        'notes',
+        'classroom.school',
+        'details' => fn ($query) => $query->withCount('stockMovements')->with('productionStatus'),
+    ]);
+
+    $resource = new OrderResource($order);
+    $data = $resource->resolve();
+
+    expect($data['products'])->toHaveCount(1)
+        ->and($data['products'][0]['order_detail_id'])->toBe($detail->id)
+        ->and($data['products'][0]['has_returnable_stock'])->toBe(true);
+});
+
+it('marks a product that never started production as not returnable', function () {
+    actingAsRole();
+
+    $product = productWithChain();
+    $order = Order::factory()->create();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    // Load the order the same way the controller does
+    $order->load([
+        'client',
+        'products.type',
+        'products.productionStatuses',
+        'payments',
+        'notes',
+        'classroom.school',
+        'details' => fn ($query) => $query->withCount('stockMovements')->with('productionStatus'),
+    ]);
+
+    $resource = new OrderResource($order);
+    $data = $resource->resolve();
+
+    expect($data['products'])->toHaveCount(1)
+        ->and($data['products'][0]['order_detail_id'])->toBe($detail->id)
+        ->and($data['products'][0]['has_returnable_stock'])->toBe(false);
+});


### PR DESCRIPTION
## Qué

Al cancelar un pedido, el modal ahora explica qué hace cada destino y evita
elegir "stock" cuando no hay nada para devolver.

- Cada destino del modal ("Stock" vs "Reciclaje") describe su efecto real.
- La opción "Stock" queda deshabilitada, con una aclaración ("Sin insumos para
  devolver a stock"), cuando el producto no tiene insumos que devolver
  (nunca arrancó producción o el producto no tiene stockeables).

## Cómo

- Nuevo campo por producto `has_returnable_stock` en `OrderResource`, calculado
  con `withCount('stockMovements')` en `OrderController::show`.
- Corrección de la relación `OrderDetail::stockMovements()` (FK explícita
  `order_detail_id`), que estaba rota porque `OrderDetail` extiende `Pivot`.
- Ajustes de copy y de estado deshabilitado en `CancelOrderModal`.

## Alcance

Solo mejora de UX. No cambia la lógica de stock/cancelación ni el modelo de
datos. Queda fuera (decisión de producto pendiente): que un producto ya
fabricado vuelva como stockeable propio.

Closes #49