### PR TITLE
feat(products): flag has_photo para productos con foto editable

### DIFF
--- a/app/Actions/Products/CreateProductAction.php
+++ b/app/Actions/Products/CreateProductAction.php
@@ -35,6 +35,7 @@ class CreateProductAction implements ActionContract
                 'max_payments' => $params->maxPayments,
                 'product_type_id' => $params->productTypeId,
                 'variants' => $params->variants,
+                'has_photo' => $params->hasPhoto,
             ]);
 
             $this->createStage->handle(new ProductionStatusCreationData($product->id, 'Terminado'));

--- a/app/Data/Products/ProductCreationData.php
+++ b/app/Data/Products/ProductCreationData.php
@@ -17,5 +17,6 @@ final readonly class ProductCreationData implements DtoContract
         public int $maxPayments,
         public int $productTypeId,
         public ?array $variants,
+        public bool $hasPhoto,
     ) {}
 }

--- a/app/Http/Controllers/BO/ProductController.php
+++ b/app/Http/Controllers/BO/ProductController.php
@@ -59,6 +59,7 @@ class ProductController extends Controller
             'max_payments' => $data->maxPayments,
             'product_type_id' => $data->productTypeId,
             'variants' => $data->variants,
+            'has_photo' => $data->hasPhoto,
         ]);
 
         return redirect()->route('products.index');

--- a/app/Http/Requests/BO/StoreProductRequest.php
+++ b/app/Http/Requests/BO/StoreProductRequest.php
@@ -31,7 +31,7 @@ class StoreProductRequest extends FormRequest
             'unit_price' => ['required', 'numeric', 'min:1'],
             'max_payments' => ['required', 'numeric', 'min:1'],
             'product_type_id' => ['required', 'exists:product_types,id'],
-            'has_photo' => ['required', 'boolean'],
+            'has_photo' => ['sometimes', 'boolean'],
 
             'variants' => ['sometimes', 'nullable', 'array'],
             'variants.*.label' => ['required', 'string', 'max:50', 'distinct'],
@@ -80,7 +80,7 @@ class StoreProductRequest extends FormRequest
          *     unit_price: int|float|string,
          *     max_payments: int|float|string,
          *     product_type_id: int|string,
-         *     has_photo: bool,
+         *     has_photo?: bool,
          *     variants?: array<int, array{
          *         label: string,
          *         type: string,
@@ -97,7 +97,7 @@ class StoreProductRequest extends FormRequest
             maxPayments: (int) $validated['max_payments'],
             productTypeId: (int) $validated['product_type_id'],
             variants: $validated['variants'] ?? null,
-            hasPhoto: (bool) $validated['has_photo'],
+            hasPhoto: (bool) ($validated['has_photo'] ?? false),
         );
     }
 }

--- a/app/Http/Requests/BO/StoreProductRequest.php
+++ b/app/Http/Requests/BO/StoreProductRequest.php
@@ -31,6 +31,7 @@ class StoreProductRequest extends FormRequest
             'unit_price' => ['required', 'numeric', 'min:1'],
             'max_payments' => ['required', 'numeric', 'min:1'],
             'product_type_id' => ['required', 'exists:product_types,id'],
+            'has_photo' => ['required', 'boolean'],
 
             'variants' => ['sometimes', 'nullable', 'array'],
             'variants.*.label' => ['required', 'string', 'max:50', 'distinct'],
@@ -79,6 +80,7 @@ class StoreProductRequest extends FormRequest
          *     unit_price: int|float|string,
          *     max_payments: int|float|string,
          *     product_type_id: int|string,
+         *     has_photo: bool,
          *     variants?: array<int, array{
          *         label: string,
          *         type: string,
@@ -95,6 +97,7 @@ class StoreProductRequest extends FormRequest
             maxPayments: (int) $validated['max_payments'],
             productTypeId: (int) $validated['product_type_id'],
             variants: $validated['variants'] ?? null,
+            hasPhoto: (bool) $validated['has_photo'],
         );
     }
 }

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -31,6 +31,7 @@ class ProductResource extends JsonResource
             'financed_price' => $this->resource->financed_price,
             'product_type_id' => $this->resource->product_type_id,
             'variants' => $this->resource->variants ?? [],
+            'has_photo' => $this->resource->has_photo,
         ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -45,5 +45,6 @@ class Product extends Model
 
     protected $casts = [
         'variants' => 'array',
+        'has_photo' => 'boolean',
     ];
 }

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -27,6 +27,7 @@ class ProductFactory extends Factory
             'max_payments' => 1,
             'financed_price' => null,
             'product_type_id' => fn () => ProductType::where('name', 'taza')->firstOrFail()->id,
+            'has_photo' => false,
         ];
     }
 

--- a/database/migrations/2025_01_10_155746_create_products_table.php
+++ b/database/migrations/2025_01_10_155746_create_products_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->json('variants')->nullable();
+            $table->boolean('has_photo')->default(false);
             $table->integer('unit_price');
             $table->integer('max_payments');
             $table->integer('financed_price')->nullable();

--- a/resources/js/pages/products/components/product-form.tsx
+++ b/resources/js/pages/products/components/product-form.tsx
@@ -1,5 +1,6 @@
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -98,6 +99,20 @@ export function ProductForm({
                 />
 
                 <InputError message={errors.max_payments} className="mt-2" />
+            </div>
+
+            <div className="mt-6 flex items-center gap-2">
+                <Checkbox
+                    id="has_photo"
+                    checked={data.has_photo}
+                    onCheckedChange={(checked) =>
+                        setData('has_photo', checked === true)
+                    }
+                />
+
+                <Label htmlFor="has_photo">Incluye foto</Label>
+
+                <InputError message={errors.has_photo} className="mt-2" />
             </div>
 
             <VariantsEditor form={form} />

--- a/resources/js/pages/products/form.ts
+++ b/resources/js/pages/products/form.ts
@@ -1,4 +1,7 @@
-export type FormData = Pick<Product, 'name' | 'product_type_id'> & {
+export type FormData = Pick<
+    Product,
+    'name' | 'product_type_id' | 'has_photo'
+> & {
     unit_price: string;
     max_payments: string;
     variants: VariantDefinition[] | null;

--- a/resources/js/pages/products/hooks/use-product-form.ts
+++ b/resources/js/pages/products/hooks/use-product-form.ts
@@ -10,6 +10,7 @@ export function useProductForm(product?: Product) {
         max_payments: product ? String(product.max_payments) : '0',
         product_type_id: product?.product_type_id ?? 0,
         variants: product?.variants ?? null,
+        has_photo: product?.has_photo ?? false,
     });
 
     const submit: FormEventHandler = (e) => {

--- a/resources/js/pages/products/tests/product-form.test.tsx
+++ b/resources/js/pages/products/tests/product-form.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProductForm } from '../components/product-form';
+import { FormData } from '../form';
+import { useProductForm } from '../hooks/use-product-form';
+
+vi.mock('@inertiajs/react', async () => {
+    const { useState } = await import('react');
+
+    // Stateful stand-in: the hook relies on setData re-rendering with the
+    // new values, so a static mock would hide bugs
+    function useForm(initial: FormData) {
+        const [data, setData] = useState(initial);
+
+        return {
+            data,
+            setData: (
+                keyOrData:
+                    | keyof FormData
+                    | FormData
+                    | ((previous: FormData) => FormData),
+                value?: unknown,
+            ) => {
+                if (typeof keyOrData === 'string') {
+                    setData((prev) => ({ ...prev, [keyOrData]: value }));
+                } else if (typeof keyOrData === 'function') {
+                    setData(keyOrData);
+                } else {
+                    setData(keyOrData);
+                }
+            },
+            post: vi.fn(),
+            put: vi.fn(),
+            processing: false,
+            errors: {},
+            clearErrors: vi.fn(),
+        };
+    }
+
+    return {
+        useForm,
+        Link: ({ children, href }: { children: ReactNode; href: string }) => (
+            <a href={href}>{children}</a>
+        ),
+    };
+});
+
+const productTypes: ProductType[] = [
+    { id: 1, name: 'taza' },
+    { id: 2, name: 'banda' },
+    { id: 3, name: 'mural' },
+];
+
+// Harness component that initializes the form and renders ProductForm
+function ProductFormHarness({ product }: { product?: Product }) {
+    const form = useProductForm(product);
+
+    return (
+        <ProductForm
+            form={form}
+            product_types={productTypes}
+            typeSelectProps={{ defaultValue: String(productTypes[0].id) }}
+            submitLabel="Guardar"
+        />
+    );
+}
+
+// Radix renders the checkbox as a button, so its state lives in aria-checked
+function checkboxState() {
+    return screen
+        .getByRole('checkbox', { name: 'Incluye foto' })
+        .getAttribute('aria-checked');
+}
+
+describe('ProductForm - has_photo checkbox', () => {
+    // No vi.unstubAllGlobals() here: it would also drop the ResizeObserver
+    // stub that setup.ts installs and every Radix component depends on
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal(
+            'route',
+            (name: string, params?: { product?: number }) =>
+                `http://localhost/${name}${params?.product ? `/${params.product}` : ''}`,
+        );
+    });
+
+    it('renders the "Incluye foto" checkbox unchecked by default', () => {
+        render(<ProductFormHarness />);
+
+        expect(screen.getByLabelText('Incluye foto')).toBeTruthy();
+        expect(checkboxState()).toBe('false');
+    });
+
+    it("reflects an existing product's has_photo value", () => {
+        const product: Product = {
+            id: 1,
+            name: 'Test Product',
+            unit_price: 5000,
+            financed_price: 6000,
+            max_payments: 2,
+            product_type_id: 1,
+            type: { id: 1, name: 'taza' },
+            has_photo: true,
+        };
+
+        render(<ProductFormHarness product={product} />);
+
+        expect(checkboxState()).toBe('true');
+    });
+
+    it('toggles has_photo when clicked', () => {
+        render(<ProductFormHarness />);
+
+        expect(checkboxState()).toBe('false');
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Incluye foto' }));
+
+        expect(checkboxState()).toBe('true');
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Incluye foto' }));
+
+        expect(checkboxState()).toBe('false');
+    });
+});

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -104,6 +104,7 @@ declare global {
         type: ProductType;
         /** Nullable in the database: products without variants exist */
         variants?: VariantDefinition[] | null;
+        has_photo: boolean;
     }
 
     interface OrderProduct extends Product {

--- a/tests/Feature/ProductHasPhotoTest.php
+++ b/tests/Feature/ProductHasPhotoTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use App\Models\ProductType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+uses(RefreshDatabase::class);
+
+it('creates a product with has_photo true', function () {
+    actingAsRole(UserRole::Admin);
+
+    $type = ProductType::where('name', 'banda')->firstOrFail();
+
+    post(route('products.store'), [
+        'name' => 'Banda con foto',
+        'unit_price' => 9000,
+        'max_payments' => 1,
+        'product_type_id' => $type->id,
+        'has_photo' => true,
+    ])->assertSessionHasNoErrors();
+
+    $product = Product::where('name', 'Banda con foto')->firstOrFail();
+
+    expect($product->has_photo)->toBe(true)
+        ->and(is_bool($product->has_photo))->toBeTrue();
+});
+
+it('defaults has_photo to false when the field is omitted', function () {
+    actingAsRole(UserRole::Admin);
+
+    $type = ProductType::where('name', 'taza')->firstOrFail();
+
+    post(route('products.store'), [
+        'name' => 'Taza sin foto',
+        'unit_price' => 8000,
+        'max_payments' => 1,
+        'product_type_id' => $type->id,
+    ])->assertSessionHasNoErrors();
+
+    $product = Product::where('name', 'Taza sin foto')->firstOrFail();
+
+    expect($product->has_photo)->toBe(false);
+});
+
+it('creates a product with has_photo false', function () {
+    actingAsRole(UserRole::Admin);
+
+    $type = ProductType::where('name', 'portaretrato')->firstOrFail();
+
+    post(route('products.store'), [
+        'name' => 'Portaretrato sin foto',
+        'unit_price' => 5000,
+        'max_payments' => 1,
+        'product_type_id' => $type->id,
+        'has_photo' => false,
+    ])->assertSessionHasNoErrors();
+
+    $product = Product::where('name', 'Portaretrato sin foto')->firstOrFail();
+
+    expect($product->has_photo)->toBe(false);
+});
+
+it('updates has_photo on an existing product', function () {
+    actingAsRole(UserRole::Admin);
+
+    $type = ProductType::where('name', 'taza')->firstOrFail();
+    $product = Product::factory()->create([
+        'product_type_id' => $type->id,
+        'has_photo' => false,
+    ]);
+
+    put(route('products.update', $product), [
+        'name' => $product->name,
+        'unit_price' => $product->unit_price,
+        'max_payments' => $product->max_payments,
+        'product_type_id' => $product->product_type_id,
+        'has_photo' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect($product->refresh()->has_photo)->toBe(true);
+
+    put(route('products.update', $product), [
+        'name' => $product->name,
+        'unit_price' => $product->unit_price,
+        'max_payments' => $product->max_payments,
+        'product_type_id' => $product->product_type_id,
+        'has_photo' => false,
+    ])->assertSessionHasNoErrors();
+
+    expect($product->refresh()->has_photo)->toBe(false);
+});
+
+it('rejects a non-boolean has_photo', function () {
+    actingAsRole(UserRole::Admin);
+
+    $type = ProductType::where('name', 'banda')->firstOrFail();
+
+    post(route('products.store'), [
+        'name' => 'Banda con foto inválida',
+        'unit_price' => 9000,
+        'max_payments' => 1,
+        'product_type_id' => $type->id,
+        'has_photo' => 'maybe',
+    ])->assertSessionHasErrors('has_photo');
+});
+
+it('exposes has_photo in the product resource', function () {
+    $product = Product::factory()->create(['has_photo' => true]);
+
+    $resource = (new ProductResource($product))->toArray(request());
+
+    expect($resource)
+        ->toHaveKey('has_photo')
+        ->and($resource['has_photo'])->toBe(true);
+});


### PR DESCRIPTION
Closes #174

## Qué

Agrega el flag `has_photo` a `products`, que indica si el producto lleva una foto editable. Queda disponible para los issues derivados de #171 sin necesidad de hardcodear ids ni nombres de producto.

## Cambios

- **Migración** (editada in-place según la convención del proyecto): columna `has_photo` boolean, `default(false)`, not nullable, en `products`.
- **Form de producto en BO**: checkbox "Incluye foto" en creación y edición, que persiste el campo.
- **`ProductResource`**: expone `has_photo`.
- La cadena completa: `StoreProductRequest` → `ProductCreationData` → `CreateProductAction`.

`StoreProductRequest` valida `has_photo` como `['sometimes', 'boolean']` con default `false`. El form manda siempre el valor explícito, pero el `sometimes` mantiene compatibilidad con quien postee sin el campo.

## Fuera de alcance

El flag **no se consume todavía** en ninguna vista ni lógica de negocio — eso es de los issues derivados siguientes. Tampoco se tocó `product_types`.

## Tests

- `tests/Feature/ProductHasPhotoTest.php` (6): persistencia de `true`/`false`, default `false` al omitir el campo, update, rechazo de valor no booleano y exposición en el resource.
- `resources/js/pages/products/tests/product-form.test.tsx` (3): checkbox desmarcado por defecto, reflejo del valor de un producto existente y toggle al click.

`validate-code --full` en verde: 219 Pest, 326 Vitest, pint, phpstan, prettier, eslint y tsc.