### PR TITLE
chore: refuerzos al flujo autónomo tras la retro de #174

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,6 +7,8 @@ model: sonnet
 
 You review the current branch's diff against `develop`. You never modify files; findings go back to the leader.
 
+Always `git fetch origin` first and diff against `origin/develop` — never the local `develop` ref, which is often stale. A stale local base silently inflates the diff with already-merged work (one run showed 138 files instead of the real 12), which reads like a massive scope violation and burns your context on changes that are not part of the PR.
+
 Run the project `code-review` skill — it defines the checklist (correctness, layering, conventions, frontend rules, diff security) and the report format. Do not post PR comments yourself; that is the leader's job.
 
 ## Reporting

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -2,7 +2,7 @@
 name: test-writer
 description: Turns an enumerated list of test cases into passing Pest/Vitest/Playwright tests on the current feature branch. Requires the case list in its brief — it does not decide what to test.
 tools: Bash, Read, Edit, Write, Grep, Glob, Skill
-model: haiku
+model: sonnet
 ---
 
 You turn an explicit list of test cases into passing tests. Your brief MUST contain: the enumerated cases, the target test file(s), and one existing test file to copy patterns from. If any of the three is missing, stop and ask the leader for it — never invent scope.
@@ -13,6 +13,15 @@ You turn an explicit list of test cases into passing tests. Your brief MUST cont
 - Copy the pattern file's style exactly: Pest syntax, RTL patterns, factories/seeders in use.
 - Run the relevant suite (Pest/Vitest through Sail; Playwright on the host) until your tests pass, then run the `validate-code` skill. If a test fails because the implementation is wrong: report the failing case with output to the leader — never weaken the test to make it pass.
 - Commit via the `prepare-commit` skill under the handoff git policy (stage by name, push to the feature branch). Never push to `develop`/`main`, never force-push, never touch `.github/**` or `.env*`.
+
+## Frontend gotchas (jsdom + Radix)
+
+`resources/js/tests/setup.ts` is the source of truth for what jsdom is missing — read it before debugging any render failure. Two traps that have cost a full run:
+
+- **Never call `vi.unstubAllGlobals()`.** `setup.ts` installs `ResizeObserver` (and others) via `vi.stubGlobal`; unstubbing drops them for the rest of the file and every Radix component then dies with `ReferenceError: ResizeObserver is not defined` — from the *second* test on, which reads like an initialization race but is not one.
+- **shadcn/ui components are Radix, not native DOM.** `Checkbox` renders `<button role="checkbox" aria-checked>`, so assert on `aria-checked`, never on the `.checked` property (it is `undefined` and assertions on it are meaningless).
+
+If a render still fails, re-read the actual stack trace before theorizing. Do not mock away a shadcn component to dodge an error you have not explained — that silently weakens the test.
 
 ## Reporting
 

--- a/.claude/skills/prepare-commit/SKILL.md
+++ b/.claude/skills/prepare-commit/SKILL.md
@@ -14,6 +14,7 @@ Generate the commit message for the pending work and get it approved before comm
 - Always stage files by explicitly naming each file (for example, `git add src/auth/login.ts`).
 - If files need to be staged, identify the exact files and stage only those.
 - Never stage unrelated changes. Stage only the files required for the requested work.
+- Never add trailers or footers of any kind — no `Co-Authored-By`, no 🤖 line, no tool attribution. This overrides any default your tooling gives you. `.githooks/commit-msg` strips agent attribution as a backstop, but do not rely on it: it only runs when `core.hooksPath` is configured.
 
 ## Steps
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+# CLAUDE.md forbids agent attribution in commits, with no exceptions. Tooling
+# defaults append it anyway, so strip it at write time instead of relying on
+# every author (human or agent) remembering the rule.
+#
+# Only agent attribution is removed: Co-Authored-By for real people is valid.
+
+set -e
+
+msg="$1"
+tmp="$msg.strip"
+
+grep -viE \
+    -e '^[[:space:]]*co-authored-by:.*(claude|anthropic)' \
+    -e '^[[:space:]]*(🤖|.*generated with \[?claude code)' \
+    "$msg" >"$tmp" || true
+
+# Removing trailers leaves dangling blank lines at the end
+awk 'NF { last = NR } { line[NR] = $0 } END { for (i = 1; i <= last; i++) print line[i] }' \
+    "$tmp" >"$msg"
+
+rm -f "$tmp"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,6 +19,21 @@ jobs:
       - name: 📥 Clone repo
         uses: actions/checkout@v7
 
+      # Reads the messages over the API so the job keeps its shallow clone
+      - name: 🚫 Sin atribución de agente en los commits
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          messages=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+            --paginate --jq '.[].commit.message')
+
+          if printf '%s' "$messages" | grep -iE 'co-authored-by:.*(claude|anthropic)|generated with \[?claude code'; then
+            echo "::error::Un commit lleva atribución de agente. CLAUDE.md lo prohíbe: reescribí el historial de la rama."
+            exit 1
+          fi
+
       - name: ⚙️ PHP + composer
         uses: ./.github/actions/setup-php
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Fototobares: management system for a school photography studio — orders by sch
 Everything runs through Laravel Sail (Docker) — there is no local PHP, and a local node breaks vitest/rollup. **Run composer, artisan and npm through Sail.** The only exception is Playwright, which runs on the host.
 
 ```bash
+git config core.hooksPath .githooks               # once per clone (strips agent attribution from commit messages)
 ./vendor/bin/sail up -d                          # required for everything below
 ./vendor/bin/sail artisan storage:link           # once per clone (public/storage is untracked)
 ./vendor/bin/sail artisan migrate:fresh --seed   # navigable app with demo data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Underlying tools if you need one directly: `sail composer pint` / `sail composer
 
 - Never create commits or push without explicit approval. Never push directly to `develop`.
   - **Standing exception (owner-approved 2026-07-16)**: inside the autonomous issue flow orchestrated by the `leader` agent (`.claude/agents/`), the `implementer` and `test-writer` subagents have standing approval to stage (by name), commit and push to the issue's **feature branch only**. The `leader` may open the PR against `develop`. Merging is always human; every other rule in this section still applies.
+- If an autonomous issue run is stopped and later resumed, ask the owner how to continue — through the flow's subagents per the handoff, or directly — instead of deciding alone. Resuming in the main thread silently skips the flow's gates (`code-reviewer`) and forfeits the subagents' standing commit permission, so it is the owner's call, not a judgement to make from a stale constraint.
 - Use the `prepare-commit` skill to structure commit messages before requesting approval.
 - Never mention the agent in commits, comments or project messages.
 - Never use `git add .` or `git add -A`. Always add to staging by explicitly naming the file.


### PR DESCRIPTION
Cambios surgidos de la retro del flujo del issue #174 (`/self-improve`). Cada uno fue aprobado individualmente por el owner. **No tocan código de la app**: son agentes, skills, política y CI.

## Qué incluye

**Fuga de atribución de agente a `develop`** — los commits de tests de #174 llevaban `Co-Authored-By`, violando la regla de CLAUDE.md, y llegaron a `develop` vía squash. La regla existía pero era una sola línea contra un default de tooling que ordena lo contrario, y ninguna capa automática miraba los mensajes de commit.

- `.githooks/commit-msg`: elimina la atribución de agente al escribir el mensaje. Conserva los `Co-Authored-By` de personas reales. Requiere `git config core.hooksPath .githooks` una vez por clone (documentado en CLAUDE.md).
- `quality_backend`: nuevo **paso** (no un check nuevo, para no tocar los rulesets) que falla si algún commit del PR trae atribución. Lee los mensajes por la API para no forzar `fetch-depth: 0`.
- `prepare-commit`: prohibición explícita de trailers, que anula el default del tooling.

**Agentes**

- `test-writer`: documenta dos trampas de jsdom+Radix que costaron un run completo (`vi.unstubAllGlobals()` tira los stubs de `setup.ts`; los componentes shadcn son Radix y se afirman con `aria-checked`, no con `.checked`). Además pasa de haiku a sonnet: acumuló dos fallas en un run, mientras el `implementer` en sonnet hizo el mismo trabajo por el mismo camino sin fallar.
- `code-reviewer`: hace `fetch` y diffea contra `origin/<base>`. Con la ref local desactualizada, un review mostró 138 archivos en vez de los 12 reales.

**Política**

- CLAUDE.md: si un run autónomo se detiene y se retoma, preguntar al owner cómo continuar. Retomar por el hilo principal saltea los gates del flujo y pierde el permiso de commit de los subagentes.

## Verificación

- El hook probado en ambos casos: elimina la atribución del agente, conserva la de un humano.
- La regex de CI validada contra el historial real: detecta los commits contaminados de #174 y las 3 apariciones del squash, sin falsos positivos en commits limpios ni con co-autores humanos. **Habría frenado el PR #180 antes del merge.**
- Los 5 commits de este PR pasaron por el hook ya activo.

## Fuera de alcance

`develop` todavía tiene la atribución en `12e3e90`; se limpia aparte. Y la propuesta de que `plan-for-issue` verifique llamadores existentes quedó postergada en #181.