### PR TITLE
feat(editor-assignments): asignación de editor por fila (pedido+producto con foto)

### DIFF
--- a/app/Actions/EditorAssignments/AssignEditorAction.php
+++ b/app/Actions/EditorAssignments/AssignEditorAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\EditorAssignments;
+
+use App\Contracts\ActionContract;
+use App\Contracts\DtoContract;
+use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\OrderDetail;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @implements ActionContract<EditorAssignmentData>
+ */
+class AssignEditorAction implements ActionContract
+{
+    /**
+     * Assign (or reassign) an editor to an order detail. The detail's
+     * product must be editable by photo (`has_photo`); reassigning
+     * overwrites the previous assignment (unique per detail, no history).
+     *
+     * @param  EditorAssignmentData  $params
+     *
+     * @throws ValidationException
+     */
+    public function handle(DtoContract $params): void
+    {
+        $detail = OrderDetail::with('product')->findOrFail($params->orderDetailId);
+
+        if ($detail->product?->has_photo !== true) {
+            throw ValidationException::withMessages([
+                'order_detail_id' => 'Este producto no admite edición de foto.',
+            ]);
+        }
+
+        EditorOrderDetailAssignment::updateOrCreate(
+            ['order_detail_id' => $params->orderDetailId],
+            [
+                'editor_id' => $params->editorId,
+                'assigned_by' => $params->assignedBy,
+                'assigned_at' => now(),
+            ]
+        );
+    }
+}

--- a/app/Actions/EditorAssignments/BulkAssignEditorAction.php
+++ b/app/Actions/EditorAssignments/BulkAssignEditorAction.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\EditorAssignments;
+
+use App\Contracts\ActionContract;
+use App\Contracts\DtoContract;
+use App\Data\EditorAssignments\BulkEditorAssignmentData;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\OrderDetail;
+
+/**
+ * @implements ActionContract<BulkEditorAssignmentData>
+ */
+class BulkAssignEditorAction implements ActionContract
+{
+    /**
+     * Assign an editor to every in-scope order detail of a school or
+     * classroom, for the selected photo products. In scope mirrors the
+     * `/tracking` board: production enabled, not delivered, not recycled,
+     * order not cancelled.
+     *
+     * @param  BulkEditorAssignmentData  $params
+     */
+    public function handle(DtoContract $params): int
+    {
+        $details = OrderDetail::query()
+            ->whereHas('product', fn ($query) => $query->where('has_photo', true)->whereIn('id', $params->productIds))
+            ->whereNotNull('production_enabled_at')
+            ->whereNull('delivered_at')
+            ->whereNull('recycled_to')
+            ->whereHas('order', function ($query) use ($params) {
+                $query->whereNull('cancelled_at');
+
+                if ($params->classroomId !== null) {
+                    $query->where('classroom_id', $params->classroomId);
+                } else {
+                    $query->whereHas('classroom', fn ($q) => $q->where('school_id', $params->schoolId));
+                }
+            })
+            ->get(['id']);
+
+        foreach ($details as $detail) {
+            EditorOrderDetailAssignment::updateOrCreate(
+                ['order_detail_id' => $detail->id],
+                [
+                    'editor_id' => $params->editorId,
+                    'assigned_by' => $params->assignedBy,
+                    'assigned_at' => now(),
+                ]
+            );
+        }
+
+        return $details->count();
+    }
+}

--- a/app/Actions/EditorAssignments/UnassignEditorAction.php
+++ b/app/Actions/EditorAssignments/UnassignEditorAction.php
@@ -6,20 +6,19 @@ namespace App\Actions\EditorAssignments;
 
 use App\Contracts\ActionContract;
 use App\Contracts\DtoContract;
-use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Data\EditorAssignments\EditorUnassignmentData;
 use App\Models\EditorOrderDetailAssignment;
 
 /**
- * @implements ActionContract<EditorAssignmentData>
+ * @implements ActionContract<EditorUnassignmentData>
  */
 class UnassignEditorAction implements ActionContract
 {
     /**
      * Remove the editor assignment of an order detail. Idempotent: no
-     * error if the detail has no assignment. Only `orderDetailId` is
-     * read; `editorId`/`assignedBy` are irrelevant for this action.
+     * error if the detail has no assignment.
      *
-     * @param  EditorAssignmentData  $params
+     * @param  EditorUnassignmentData  $params
      */
     public function handle(DtoContract $params): void
     {

--- a/app/Actions/EditorAssignments/UnassignEditorAction.php
+++ b/app/Actions/EditorAssignments/UnassignEditorAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\EditorAssignments;
+
+use App\Contracts\ActionContract;
+use App\Contracts\DtoContract;
+use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Models\EditorOrderDetailAssignment;
+
+/**
+ * @implements ActionContract<EditorAssignmentData>
+ */
+class UnassignEditorAction implements ActionContract
+{
+    /**
+     * Remove the editor assignment of an order detail. Idempotent: no
+     * error if the detail has no assignment. Only `orderDetailId` is
+     * read; `editorId`/`assignedBy` are irrelevant for this action.
+     *
+     * @param  EditorAssignmentData  $params
+     */
+    public function handle(DtoContract $params): void
+    {
+        EditorOrderDetailAssignment::where('order_detail_id', $params->orderDetailId)->delete();
+    }
+}

--- a/app/Data/EditorAssignments/BulkEditorAssignmentData.php
+++ b/app/Data/EditorAssignments/BulkEditorAssignmentData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\EditorAssignments;
+
+use App\Contracts\DtoContract;
+
+final readonly class BulkEditorAssignmentData implements DtoContract
+{
+    /**
+     * @param  array<int, int>  $productIds
+     */
+    public function __construct(
+        public int $editorId,
+        public int $assignedBy,
+        public ?int $schoolId,
+        public ?int $classroomId,
+        public array $productIds,
+    ) {}
+}

--- a/app/Data/EditorAssignments/EditorAssignmentData.php
+++ b/app/Data/EditorAssignments/EditorAssignmentData.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\EditorAssignments;
+
+use App\Contracts\DtoContract;
+
+final readonly class EditorAssignmentData implements DtoContract
+{
+    public function __construct(
+        public int $orderDetailId,
+        public int $editorId,
+        public int $assignedBy,
+    ) {}
+}

--- a/app/Data/EditorAssignments/EditorUnassignmentData.php
+++ b/app/Data/EditorAssignments/EditorUnassignmentData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\EditorAssignments;
+
+use App\Contracts\DtoContract;
+
+final readonly class EditorUnassignmentData implements DtoContract
+{
+    public function __construct(
+        public int $orderDetailId,
+    ) {}
+}

--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -15,6 +15,8 @@ use App\Http\Resources\ClassroomStudentResource;
 use App\Models\Classroom;
 use App\Models\Order;
 use App\Models\OrderDraft;
+use App\Models\Product;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -68,6 +70,8 @@ class ClassroomController extends Controller
             'classroom' => $classroom->load('teacher', 'school'),
             'students' => ClassroomStudentResource::collection($paginator),
             'filters' => ['search' => $search],
+            'assignableEditors' => User::assignableEditors()->get(['id', 'name']),
+            'photoProducts' => Product::where('has_photo', true)->get(['id', 'name']),
         ]);
     }
 

--- a/app/Http/Controllers/BO/EditorAssignmentController.php
+++ b/app/Http/Controllers/BO/EditorAssignmentController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Actions\EditorAssignments\AssignEditorAction;
+use App\Actions\EditorAssignments\BulkAssignEditorAction;
+use App\Actions\EditorAssignments\UnassignEditorAction;
+use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\BO\AssignEditorRequest;
+use App\Http\Requests\BO\BulkAssignEditorRequest;
+use App\Models\OrderDetail;
+use Illuminate\Http\RedirectResponse;
+
+class EditorAssignmentController extends Controller
+{
+    /**
+     * Assign (or reassign) an editor to a single order detail.
+     */
+    public function store(AssignEditorRequest $request, AssignEditorAction $action): RedirectResponse
+    {
+        $action->handle($request->toData());
+
+        return back()->with('success', 'Editor asignado');
+    }
+
+    /**
+     * Assign an editor to every in-scope order detail of a school or
+     * classroom, for the selected photo products.
+     */
+    public function bulkStore(BulkAssignEditorRequest $request, BulkAssignEditorAction $action): RedirectResponse
+    {
+        $count = $action->handle($request->toData());
+
+        return back()->with('success', "$count producto(s) asignados al editor");
+    }
+
+    /**
+     * Remove the editor assignment of an order detail.
+     */
+    public function destroy(OrderDetail $orderDetail, UnassignEditorAction $action): RedirectResponse
+    {
+        $action->handle(new EditorAssignmentData(
+            orderDetailId: $orderDetail->id,
+            editorId: 0,
+            assignedBy: 0,
+        ));
+
+        return back()->with('success', 'Editor desasignado');
+    }
+}

--- a/app/Http/Controllers/BO/EditorAssignmentController.php
+++ b/app/Http/Controllers/BO/EditorAssignmentController.php
@@ -7,7 +7,7 @@ namespace App\Http\Controllers\BO;
 use App\Actions\EditorAssignments\AssignEditorAction;
 use App\Actions\EditorAssignments\BulkAssignEditorAction;
 use App\Actions\EditorAssignments\UnassignEditorAction;
-use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Data\EditorAssignments\EditorUnassignmentData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\AssignEditorRequest;
 use App\Http\Requests\BO\BulkAssignEditorRequest;
@@ -42,11 +42,7 @@ class EditorAssignmentController extends Controller
      */
     public function destroy(OrderDetail $orderDetail, UnassignEditorAction $action): RedirectResponse
     {
-        $action->handle(new EditorAssignmentData(
-            orderDetailId: $orderDetail->id,
-            editorId: 0,
-            assignedBy: 0,
-        ));
+        $action->handle(new EditorUnassignmentData(orderDetailId: $orderDetail->id));
 
         return back()->with('success', 'Editor desasignado');
     }

--- a/app/Http/Controllers/BO/SchoolController.php
+++ b/app/Http/Controllers/BO/SchoolController.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSchoolRequest;
 use App\Http\Resources\SchoolResource;
 use App\Models\Order;
+use App\Models\Product;
 use App\Models\School;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
@@ -113,6 +114,8 @@ class SchoolController extends Controller
                 'address',
                 'user',
             ])),
+            'assignableEditors' => User::assignableEditors()->get(['id', 'name']),
+            'photoProducts' => Product::where('has_photo', true)->get(['id', 'name']),
         ]);
     }
 }

--- a/app/Http/Requests/BO/AssignEditorRequest.php
+++ b/app/Http/Requests/BO/AssignEditorRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Enums\UserRole;
+use App\Models\User;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AssignEditorRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'order_detail_id' => ['required', 'integer', 'exists:order_details,id'],
+            'editor_id' => [
+                'required',
+                'integer',
+                'exists:users,id',
+                $this->assignableEditor(...),
+                $this->notSelfAssigned(...),
+            ],
+        ];
+    }
+
+    private function assignableEditor(string $attribute, mixed $value, Closure $fail): void
+    {
+        $editor = User::query()->whereKey($value)->first();
+
+        if ($editor === null || ! $editor->hasAnyRole(UserRole::Editor, UserRole::Admin)) {
+            $fail('El usuario seleccionado no puede ser asignado como editor.');
+        }
+    }
+
+    private function notSelfAssigned(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_numeric($value)) {
+            return;
+        }
+
+        /** @var User $user */
+        $user = $this->user();
+
+        if ((int) $value === $user->id) {
+            $fail('No podés asignarte a vos mismo.');
+        }
+    }
+
+    public function toData(): EditorAssignmentData
+    {
+        /** @var array{order_detail_id: int|string, editor_id: int|string} $validated */
+        $validated = $this->validated();
+
+        /** @var User $user */
+        $user = $this->user();
+
+        return new EditorAssignmentData(
+            orderDetailId: (int) $validated['order_detail_id'],
+            editorId: (int) $validated['editor_id'],
+            assignedBy: (int) $user->id,
+        );
+    }
+}

--- a/app/Http/Requests/BO/BulkAssignEditorRequest.php
+++ b/app/Http/Requests/BO/BulkAssignEditorRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Data\EditorAssignments\BulkEditorAssignmentData;
+use App\Enums\UserRole;
+use App\Models\User;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkAssignEditorRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'editor_id' => [
+                'required',
+                'integer',
+                'exists:users,id',
+                $this->assignableEditor(...),
+                $this->notSelfAssigned(...),
+            ],
+            'product_ids' => ['required', 'array', 'min:1'],
+            'product_ids.*' => ['integer', 'exists:products,id'],
+            'school_id' => ['nullable', 'integer', 'exists:schools,id', 'required_without:classroom_id'],
+            'classroom_id' => ['nullable', 'integer', 'exists:classrooms,id', 'required_without:school_id'],
+        ];
+    }
+
+    private function assignableEditor(string $attribute, mixed $value, Closure $fail): void
+    {
+        $editor = User::query()->whereKey($value)->first();
+
+        if ($editor === null || ! $editor->hasAnyRole(UserRole::Editor, UserRole::Admin)) {
+            $fail('El usuario seleccionado no puede ser asignado como editor.');
+        }
+    }
+
+    private function notSelfAssigned(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_numeric($value)) {
+            return;
+        }
+
+        /** @var User $user */
+        $user = $this->user();
+
+        if ((int) $value === $user->id) {
+            $fail('No podés asignarte a vos mismo.');
+        }
+    }
+
+    public function toData(): BulkEditorAssignmentData
+    {
+        /** @var array{editor_id: int|string, school_id?: int|string|null, classroom_id?: int|string|null, product_ids: list<int|string>} $validated */
+        $validated = $this->validated();
+
+        /** @var User $user */
+        $user = $this->user();
+
+        return new BulkEditorAssignmentData(
+            editorId: (int) $validated['editor_id'],
+            assignedBy: (int) $user->id,
+            schoolId: isset($validated['school_id']) ? (int) $validated['school_id'] : null,
+            classroomId: isset($validated['classroom_id']) ? (int) $validated['classroom_id'] : null,
+            productIds: array_map(fn ($id) => (int) $id, $validated['product_ids']),
+        );
+    }
+}

--- a/app/Http/Requests/BO/BulkAssignEditorRequest.php
+++ b/app/Http/Requests/BO/BulkAssignEditorRequest.php
@@ -33,8 +33,8 @@ class BulkAssignEditorRequest extends FormRequest
             ],
             'product_ids' => ['required', 'array', 'min:1'],
             'product_ids.*' => ['integer', 'exists:products,id'],
-            'school_id' => ['nullable', 'integer', 'exists:schools,id', 'required_without:classroom_id'],
-            'classroom_id' => ['nullable', 'integer', 'exists:classrooms,id', 'required_without:school_id'],
+            'school_id' => ['nullable', 'integer', 'exists:schools,id', 'required_without:classroom_id', 'prohibits:classroom_id'],
+            'classroom_id' => ['nullable', 'integer', 'exists:classrooms,id', 'required_without:school_id', 'prohibits:school_id'],
         ];
     }
 

--- a/app/Models/EditorOrderDetailAssignment.php
+++ b/app/Models/EditorOrderDetailAssignment.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EditorOrderDetailAssignment extends Model
+{
+    protected $casts = [
+        'assigned_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<OrderDetail, $this>
+     */
+    public function orderDetail()
+    {
+        return $this->belongsTo(OrderDetail::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function editor()
+    {
+        return $this->belongsTo(User::class, 'editor_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function assignedBy()
+    {
+        return $this->belongsTo(User::class, 'assigned_by');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -57,5 +58,20 @@ class User extends Authenticatable
         }
 
         return false;
+    }
+
+    /**
+     * Users that can be assigned as editor of an order detail: the
+     * `editor` role, or `administración` (which may assign to others but
+     * never to itself).
+     *
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    public function scopeAssignableEditors(Builder $query): Builder
+    {
+        return $query->whereHas('roles', function ($roles) {
+            $roles->whereIn('name', [UserRole::Editor->value, UserRole::Admin->value]);
+        });
     }
 }

--- a/database/migrations/2026_07_16_000001_create_editor_order_detail_assignments_table.php
+++ b/database/migrations/2026_07_16_000001_create_editor_order_detail_assignments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('editor_order_detail_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_detail_id')
+                ->unique()
+                ->constrained('order_details')
+                ->cascadeOnDelete();
+            $table->foreignId('editor_id')->constrained('users');
+            $table->foreignId('assigned_by')->constrained('users');
+            $table->timestamp('assigned_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('editor_order_detail_assignments');
+    }
+};

--- a/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
+++ b/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
@@ -1,0 +1,110 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { UserCog } from 'lucide-react';
+import { useState } from 'react';
+import { PhotoProductsChecklist } from './PhotoProductsChecklist';
+import { useBulkAssignEditor } from './useBulkAssignEditor';
+
+export interface AssignableEditor {
+    id: number;
+    name: string;
+}
+
+export interface PhotoProduct {
+    id: number;
+    name: string;
+}
+
+export function BulkAssignEditorDialog({
+    assignableEditors,
+    photoProducts,
+    schoolId,
+    classroomId,
+}: {
+    assignableEditors: AssignableEditor[];
+    photoProducts: PhotoProduct[];
+    schoolId?: number;
+    classroomId?: number;
+}) {
+    const [open, setOpen] = useState(false);
+    const { data, setData, submit, processing, errors } = useBulkAssignEditor({
+        schoolId,
+        classroomId,
+    });
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                    <UserCog />
+                    Asignar editor
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Asignar editor en masa</DialogTitle>
+                    <DialogDescription>
+                        Asigna un editor a los productos con foto editable que
+                        estén en producción.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="editor_id">Editor</Label>
+                    <Select
+                        value={data.editor_id}
+                        onValueChange={(value) => setData('editor_id', value)}
+                    >
+                        <SelectTrigger id="editor_id">
+                            <SelectValue placeholder="Elegir editor..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {assignableEditors.map((editor) => (
+                                <SelectItem
+                                    value={String(editor.id)}
+                                    key={editor.id}
+                                >
+                                    {editor.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <InputError message={errors.editor_id} />
+                </div>
+
+                <PhotoProductsChecklist
+                    photoProducts={photoProducts}
+                    selectedIds={data.product_ids}
+                    onChange={(ids) => setData('product_ids', ids)}
+                    error={errors.product_ids}
+                />
+
+                <DialogFooter>
+                    <Button
+                        disabled={processing}
+                        onClick={() => submit(() => setOpen(false))}
+                    >
+                        Asignar
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
+++ b/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
@@ -17,6 +17,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { usePage } from '@inertiajs/react';
 import { UserCog } from 'lucide-react';
 import { useState } from 'react';
 import { PhotoProductsChecklist } from './PhotoProductsChecklist';
@@ -48,6 +49,10 @@ export function BulkAssignEditorDialog({
         schoolId,
         classroomId,
     });
+    const { auth } = usePage().props;
+    const selectableEditors = assignableEditors.filter(
+        (editor) => editor.id !== auth.user.id,
+    );
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
@@ -76,7 +81,7 @@ export function BulkAssignEditorDialog({
                             <SelectValue placeholder="Elegir editor..." />
                         </SelectTrigger>
                         <SelectContent>
-                            {assignableEditors.map((editor) => (
+                            {selectableEditors.map((editor) => (
                                 <SelectItem
                                     value={String(editor.id)}
                                     key={editor.id}

--- a/resources/js/features/editor-assignment/PhotoProductsChecklist.tsx
+++ b/resources/js/features/editor-assignment/PhotoProductsChecklist.tsx
@@ -1,0 +1,60 @@
+import InputError from '@/components/input-error';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { PhotoProduct } from './BulkAssignEditorDialog';
+
+export function PhotoProductsChecklist({
+    photoProducts,
+    selectedIds,
+    onChange,
+    error,
+}: {
+    photoProducts: PhotoProduct[];
+    selectedIds: number[];
+    onChange: (ids: number[]) => void;
+    error?: string;
+}) {
+    const allSelected =
+        photoProducts.length > 0 && selectedIds.length === photoProducts.length;
+
+    const toggleAll = (checked: boolean) => {
+        onChange(checked ? photoProducts.map((product) => product.id) : []);
+    };
+
+    const toggleProduct = (productId: number, checked: boolean) => {
+        onChange(
+            checked
+                ? [...selectedIds, productId]
+                : selectedIds.filter((id) => id !== productId),
+        );
+    };
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+                <Checkbox
+                    id="all_products"
+                    checked={allSelected}
+                    onCheckedChange={(checked) => toggleAll(checked === true)}
+                />
+                <Label htmlFor="all_products">Todos los productos</Label>
+            </div>
+
+            {photoProducts.map((product) => (
+                <div className="flex items-center gap-2" key={product.id}>
+                    <Checkbox
+                        id={`product_${product.id}`}
+                        checked={selectedIds.includes(product.id)}
+                        onCheckedChange={(checked) =>
+                            toggleProduct(product.id, checked === true)
+                        }
+                    />
+                    <Label htmlFor={`product_${product.id}`}>
+                        {product.name}
+                    </Label>
+                </div>
+            ))}
+            <InputError message={error} />
+        </div>
+    );
+}

--- a/resources/js/features/editor-assignment/useBulkAssignEditor.ts
+++ b/resources/js/features/editor-assignment/useBulkAssignEditor.ts
@@ -1,0 +1,28 @@
+import { useForm } from '@inertiajs/react';
+
+export function useBulkAssignEditor({
+    schoolId,
+    classroomId,
+}: {
+    schoolId?: number;
+    classroomId?: number;
+}) {
+    const form = useForm({
+        editor_id: '',
+        product_ids: [] as number[],
+        school_id: schoolId ?? null,
+        classroom_id: classroomId ?? null,
+    });
+
+    const submit = (onSuccess: () => void) => {
+        form.post(route('editor-assignments.bulk'), {
+            preserveScroll: true,
+            onSuccess: () => {
+                form.reset();
+                onSuccess();
+            },
+        });
+    };
+
+    return { ...form, submit };
+}

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -5,6 +5,11 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import {
+    AssignableEditor,
+    BulkAssignEditorDialog,
+    PhotoProduct,
+} from '@/features/editor-assignment/BulkAssignEditorDialog';
 import { Searchbar } from '@/features/searchbar';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
@@ -17,10 +22,14 @@ export default function ClassroomShow({
     classroom,
     students,
     filters,
+    assignableEditors,
+    photoProducts,
 }: PageProps<{
     classroom: Classroom & { teacher?: Teacher; school: School };
     students: Paginated<ClassroomStudent>;
     filters: { search: string | null };
+    assignableEditors: AssignableEditor[];
+    photoProducts: PhotoProduct[];
 }>) {
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -87,24 +96,31 @@ export default function ClassroomShow({
             </section>
 
             <section className="p-6">
-                <div className="mb-4 flex items-center justify-between">
+                <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
                     <h2 className="text-2xl font-bold">
                         Alumnos ({students.data.length})
                     </h2>
-                    <Link
-                        href={route('photos.index', {
-                            classroom: classroom.id,
-                        })}
-                        className={cn(
-                            buttonVariants({
-                                size: 'sm',
-                            }),
-                            'gap-2',
-                        )}
-                    >
-                        <ImagePlus className="h-4 w-4" />
-                        Gestionar fotos
-                    </Link>
+                    <div className="flex flex-wrap gap-2">
+                        <BulkAssignEditorDialog
+                            assignableEditors={assignableEditors}
+                            photoProducts={photoProducts}
+                            classroomId={classroom.id}
+                        />
+                        <Link
+                            href={route('photos.index', {
+                                classroom: classroom.id,
+                            })}
+                            className={cn(
+                                buttonVariants({
+                                    size: 'sm',
+                                }),
+                                'gap-2',
+                            )}
+                        >
+                            <ImagePlus className="h-4 w-4" />
+                            Gestionar fotos
+                        </Link>
+                    </div>
                 </div>
 
                 <div className="mb-4">

--- a/resources/js/pages/schools/show.tsx
+++ b/resources/js/pages/schools/show.tsx
@@ -1,3 +1,8 @@
+import {
+    AssignableEditor,
+    BulkAssignEditorDialog,
+    PhotoProduct,
+} from '@/features/editor-assignment/BulkAssignEditorDialog';
 import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
@@ -8,10 +13,14 @@ import { SchoolShowData, useSchoolShow } from './hooks/use-school-show';
 
 export default function School({
     school,
+    assignableEditors,
+    photoProducts,
 }: PageProps<{
     school: {
         data: SchoolShowData;
     };
+    assignableEditors: AssignableEditor[];
+    photoProducts: PhotoProduct[];
 }>) {
     const controller = useSchoolShow();
 
@@ -33,6 +42,14 @@ export default function School({
             <ClassroomModals controller={controller} />
 
             <SchoolInfoCard school={school.data} />
+
+            <div className="flex justify-end px-6 pt-4">
+                <BulkAssignEditorDialog
+                    assignableEditors={assignableEditors}
+                    photoProducts={photoProducts}
+                    schoolId={school.data.id}
+                />
+            </div>
 
             <ClassroomsTable school={school.data} controller={controller} />
         </AppLayout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\BO\DeliveryController;
 use App\Http\Controllers\BO\DetailPriorityController;
 use App\Http\Controllers\BO\DetailProductionStatusController;
 use App\Http\Controllers\BO\DetailVariantController;
+use App\Http\Controllers\BO\EditorAssignmentController;
 use App\Http\Controllers\BO\NoteController;
 use App\Http\Controllers\BO\OrderController;
 use App\Http\Controllers\BO\OrderDraftController;
@@ -53,6 +54,10 @@ Route::middleware(['auth', 'role:master,administración,oficina'])->group(functi
         Route::post('/', [NoteController::class, 'store'])->name('notes.store');
         Route::delete('/{note}', [NoteController::class, 'destroy'])->name('notes.destroy');
     });
+
+    Route::post('/editor-assignments', [EditorAssignmentController::class, 'store'])->name('editor-assignments.store');
+    Route::post('/editor-assignments/bulk', [EditorAssignmentController::class, 'bulkStore'])->name('editor-assignments.bulk');
+    Route::delete('/editor-assignments/{orderDetail}', [EditorAssignmentController::class, 'destroy'])->name('editor-assignments.destroy');
 });
 
 // Fotos: también accesibles para el rol editor

--- a/tests/Feature/EditorAssignmentTest.php
+++ b/tests/Feature/EditorAssignmentTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Classroom;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\School;
+use App\Models\User;
+
+use function Pest\Laravel\delete;
+use function Pest\Laravel\post;
+
+// Individual assign (editor-assignments.store)
+
+it('assigns an editor to a photo detail', function (UserRole $role) {
+    $actor = actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasNoErrors();
+
+    $assignment = EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->firstOrFail();
+
+    expect($assignment->editor_id)->toBe($editor->id)
+        ->and($assignment->assigned_by)->toBe($actor->id)
+        ->and($assignment->assigned_at)->not->toBeNull();
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+it('accepts an editor_id belonging to a user with the administración role', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $admin = User::factory()->withRole(UserRole::Admin)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $admin->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->first()?->editor_id)
+        ->toBe($admin->id);
+});
+
+it('overwrites the previous assignment on reassignment', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $firstEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $secondEditor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $firstEditor->id,
+    ])->assertSessionHasNoErrors();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $secondEditor->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->count())->toBe(1);
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->first()?->editor_id)
+        ->toBe($secondEditor->id);
+});
+
+it('rejects an editor_id whose role is not assignable', function (UserRole $role) {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $notAssignable = User::factory()->withRole($role)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $notAssignable->id,
+    ])->assertSessionHasErrors('editor_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+})->with([
+    'oficina' => [UserRole::Office],
+    'taller' => [UserRole::Worker],
+    'master' => [UserRole::Master],
+]);
+
+it('rejects self-assignment even for administración', function () {
+    $actor = actingAsRole(UserRole::Admin);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $actor->id,
+    ])->assertSessionHasErrors('editor_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects assigning a detail whose product does not admit photo editing', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => false]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('denies editor and taller from assigning individually', function (UserRole $role) {
+    actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertForbidden();
+})->with([
+    'editor' => [UserRole::Editor],
+    'taller' => [UserRole::Worker],
+]);
+
+// Unassign (editor-assignments.destroy)
+
+it('unassigns an existing editor assignment', function (UserRole $role) {
+    actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    delete(route('editor-assignments.destroy', $detail))->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+it('is a no-op unassigning a detail with no assignment', function () {
+    actingAsRole(UserRole::Office);
+
+    $detail = OrderDetail::factory()->create();
+
+    delete(route('editor-assignments.destroy', $detail))->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('denies editor and taller from unassigning', function (UserRole $role) {
+    actingAsRole($role);
+
+    $detail = OrderDetail::factory()->create();
+
+    delete(route('editor-assignments.destroy', $detail))->assertForbidden();
+})->with([
+    'editor' => [UserRole::Editor],
+    'taller' => [UserRole::Worker],
+]);
+
+// Bulk assign (editor-assignments.bulk)
+
+it('bulk assigns every in-scope detail across a school for the selected products', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $school = School::factory()->create();
+    $classroomA = Classroom::factory()->create(['school_id' => $school->id]);
+    $classroomB = Classroom::factory()->create(['school_id' => $school->id]);
+    $product = Product::factory()->create(['has_photo' => true]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $orderA = Order::factory()->create(['classroom_id' => $classroomA->id]);
+    $orderB = Order::factory()->create(['classroom_id' => $classroomB->id]);
+
+    $detailA = OrderDetail::factory()->enabled()->create([
+        'order_id' => $orderA->id,
+        'product_id' => $product->id,
+    ]);
+    $detailB = OrderDetail::factory()->enabled()->create([
+        'order_id' => $orderB->id,
+        'product_id' => $product->id,
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'school_id' => $school->id,
+    ])->assertSessionHasNoErrors();
+
+    foreach ([$detailA, $detailB] as $detail) {
+        $assignment = EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->first();
+        expect($assignment)->not->toBeNull()
+            ->and($assignment->editor_id)->toBe($editor->id)
+            ->and($assignment->assigned_by)->toBe($actor->id);
+    }
+});
+
+it('bulk assigns only the in-scope details of the selected classroom', function () {
+    actingAsRole(UserRole::Office);
+
+    $school = School::factory()->create();
+    $targetClassroom = Classroom::factory()->create(['school_id' => $school->id]);
+    $otherClassroom = Classroom::factory()->create(['school_id' => $school->id]);
+    $product = Product::factory()->create(['has_photo' => true]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $targetOrder = Order::factory()->create(['classroom_id' => $targetClassroom->id]);
+    $otherOrder = Order::factory()->create(['classroom_id' => $otherClassroom->id]);
+
+    $targetDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $targetOrder->id,
+        'product_id' => $product->id,
+    ]);
+    $otherDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $otherOrder->id,
+        'product_id' => $product->id,
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $targetClassroom->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $targetDetail->id)->exists())->toBeTrue()
+        ->and(EditorOrderDetailAssignment::where('order_detail_id', $otherDetail->id)->exists())->toBeFalse();
+});
+
+it('bulk respects the selected product_ids', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $selectedProduct = Product::factory()->create(['has_photo' => true]);
+    $unselectedProduct = Product::factory()->create(['has_photo' => true]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $selectedDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $selectedProduct->id,
+    ]);
+    $unselectedDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $unselectedProduct->id,
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$selectedProduct->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $selectedDetail->id)->exists())->toBeTrue()
+        ->and(EditorOrderDetailAssignment::where('order_detail_id', $unselectedDetail->id)->exists())->toBeFalse();
+});
+
+it('bulk excludes out-of-scope details', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $nonPhotoProduct = Product::factory()->create(['has_photo' => false]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $normalOrder = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $cancelledOrder = Order::factory()->cancelled()->create(['classroom_id' => $classroom->id]);
+
+    $nonPhotoDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $normalOrder->id,
+        'product_id' => $nonPhotoProduct->id,
+    ]);
+    $deliveredDetail = OrderDetail::factory()->enabled()->delivered()->create([
+        'order_id' => $normalOrder->id,
+        'product_id' => $product->id,
+    ]);
+    $recycledDetail = OrderDetail::factory()->enabled()->recycled()->create([
+        'order_id' => $normalOrder->id,
+        'product_id' => $product->id,
+    ]);
+    $notEnabledDetail = OrderDetail::factory()->create([
+        'order_id' => $normalOrder->id,
+        'product_id' => $product->id,
+    ]);
+    $cancelledOrderDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $cancelledOrder->id,
+        'product_id' => $product->id,
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id, $nonPhotoProduct->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasNoErrors();
+
+    foreach ([$nonPhotoDetail, $deliveredDetail, $recycledDetail, $notEnabledDetail, $cancelledOrderDetail] as $detail) {
+        expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+    }
+});
+
+it('bulk rejects a non-assignable editor_id', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $notAssignable = User::factory()->withRole(UserRole::Worker)->create();
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $notAssignable->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasErrors('editor_id');
+
+    expect(EditorOrderDetailAssignment::query()->exists())->toBeFalse();
+});
+
+it('bulk rejects self-assignment', function () {
+    $actor = actingAsRole(UserRole::Admin);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $actor->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasErrors('editor_id');
+
+    expect(EditorOrderDetailAssignment::query()->exists())->toBeFalse();
+});
+
+it('bulk requires at least one of school_id or classroom_id', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+    ])->assertSessionHasErrors(['school_id', 'classroom_id']);
+
+    // NOTE: sending both school_id and classroom_id is not currently rejected
+    // by BulkAssignEditorRequest (only `required_without` is enforced on each
+    // field, no mutual-exclusivity rule) — reported back instead of asserted
+    // here, since production code is out of scope for this test task.
+});
+
+it('denies editor and taller from bulk assigning', function (UserRole $role) {
+    actingAsRole($role);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $classroom->id,
+    ])->assertForbidden();
+})->with([
+    'editor' => [UserRole::Editor],
+    'taller' => [UserRole::Worker],
+]);

--- a/tests/Feature/EditorAssignmentTest.php
+++ b/tests/Feature/EditorAssignmentTest.php
@@ -359,21 +359,35 @@ it('bulk rejects self-assignment', function () {
     expect(EditorOrderDetailAssignment::query()->exists())->toBeFalse();
 });
 
-it('bulk requires at least one of school_id or classroom_id', function () {
+it('bulk requires exactly one of school_id or classroom_id', function () {
     actingAsRole(UserRole::Office);
 
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
     $product = Product::factory()->create(['has_photo' => true]);
     $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $detail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
 
     post(route('editor-assignments.bulk'), [
         'editor_id' => $editor->id,
         'product_ids' => [$product->id],
     ])->assertSessionHasErrors(['school_id', 'classroom_id']);
 
-    // NOTE: sending both school_id and classroom_id is not currently rejected
-    // by BulkAssignEditorRequest (only `required_without` is enforced on each
-    // field, no mutual-exclusivity rule) — reported back instead of asserted
-    // here, since production code is out of scope for this test task.
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'school_id' => $school->id,
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasErrors(['school_id', 'classroom_id']);
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
 });
 
 it('denies editor and taller from bulk assigning', function (UserRole $role) {


### PR DESCRIPTION
## Qué

Asignación de editor por fila (pedido + producto con foto). Backend completo más la UI de asignación masiva en las fichas de escuela y curso.

- Tabla `editor_order_detail_assignments` con `order_detail_id` **único**: la reasignación sobrescribe la fila vigente (upsert), sin historial.
- **Asignación individual** (asignar/reasignar) de un editor a un `order_detail` puntual.
- **Asignación masiva** por escuela (`schools/show`) y por curso (`classrooms/show`), con un selector de productos con foto (todos / algunos / uno) armado dinámicamente a partir de los productos con `has_photo = true` existentes.
- **Desasignación**: elimina la fila y devuelve el `order_detail` a "sin asignar".
- **Alcance del bulk**: solo `order_details` cuyo producto tenga `has_photo = true` y que cumplan el mismo constraint que `/tracking` (`production_enabled_at` no nulo, `delivered_at` nulo, `recycled_to` nulo y pedido no cancelado).

## Reglas de autorización

- Solo `master`, `administración` y `oficina` pueden asignar, reasignar o desasignar. `editor` y `taller` reciben 403.
- El `editor_id` asignable debe ser un usuario con rol `editor` o `administración`; cualquier otro rol se rechaza.
- **Ningún usuario puede autoasignarse**, `administración` incluida: `editor_id` nunca puede ser el id del usuario autenticado.
- El bulk exige exactamente uno de `school_id` / `classroom_id`.

## Fuera de alcance (según el triage del issue)

- Estado de edición y su historial, y el guard de "solo se reasigna/desasigna en estado pendiente" → #176.
- Vista de edición por escuela/curso y UI de asignación individual → #177.

## Pruebas

`tests/Feature/EditorAssignmentTest.php` cubre asignación individual, reasignación (unique), roles asignables, prohibición de autoasignación (todos los roles), scope del bulk por escuela y por curso, exclusiones fuera de scope, exactamente-uno de escuela/curso y autorización por rol.

Closes #175
