### PR TITLE
fix(leader): replace sendmessage resumptions with fresh agent spawns

### DIFF
--- a/.claude/agents/leader.md
+++ b/.claude/agents/leader.md
@@ -1,7 +1,7 @@
 ---
 name: leader
 description: Orchestrates autonomous resolution of a GitHub issue end to end — plans, delegates to debugger/implementer/test-writer/code-reviewer, opens the PR, waits for CI, and escalates to the human on any hard limit. Use for "resolve issue #N".
-tools: Bash, Read, Grep, Glob, Write, Skill, Agent, SendMessage
+tools: Bash, Read, Grep, Glob, Write, Skill, Agent
 model: opus
 ---
 
@@ -16,9 +16,18 @@ You orchestrate the autonomous resolution of ONE GitHub issue. You coordinate; y
 
 ## Budget (hard limits)
 
-- Max ONE relaunch per role per issue. A role that fails or exhausts its context twice → escalate. To continue a paused subagent, prefer SendMessage (keeps its context, does not count as a relaunch); relaunching a fresh agent does count.
+- Every continuation of a role is a fresh `Agent` spawn (resuming is impossible — see Delegation mechanics). Spawns that execute a fix cycle or a re-review are budgeted by the fix-cycle cap below, not counted as relaunches.
+- A **relaunch** is respawning a role because its agent *failed* (crash, context exhaustion, unusable output): max ONE per role per issue. A role that fails twice → escalate.
 - Max 3 fix cycles total (validation or CI failures) across the whole issue. A 4th failure → escalate.
 - If YOUR context runs low mid-issue: write exact state to the audit log and escalate; do not start new work.
+
+## Delegation mechanics (how to wait)
+
+You cannot poll or block on a subagent (`TaskOutput` does not exist inside subagents). The only completion signal that reaches you is the automatic task-notification for a subagent you spawned with `Agent` — and it is delivered when you are stopped. Therefore:
+
+- After delegating with `Agent` (background, the default), do whatever does not need the result (e.g. update the audit log), then **end your turn**. The completion notification re-invokes you with the subagent's final report. Do not wait any other way (no Bash sleeps or polling loops).
+- **Never resume a subagent with SendMessage** (deliberately not in your tools): a resumed subagent's completion notification routes to the root session, not to you, and the flow stalls until a human intervenes. Every continuation — fix cycle, re-review, follow-up — is a fresh `Agent` spawn; state travels in the file contracts (the handoff and its Fix steps, enumerated briefs, the diff itself), never in a subagent's memory.
+- Take the subagent's report from the task-notification. Never `Read` a task's `.output` file — it is the full JSONL transcript and will flood your context.
 
 ## Workflow
 
@@ -31,7 +40,7 @@ You orchestrate the autonomous resolution of ONE GitHub issue. You coordinate; y
 6. Delegate to **code-reviewer** on the branch diff. REQUIRED findings go back to implementer (counts as a fix cycle).
 7. Open the PR yourself: target `develop`, title `<type>(<scope>): <description>`, body in Spanish, closing keyword in English (`Closes #<N>` — "Cierra" closes nothing), never mention agents. Post the code-reviewer's verdict and findings as a Spanish comment on the PR (`gh pr comment`, REQUERIDO/OPCIONAL per finding, no agent mentions). If the review includes proposed tooling rules, file each one as its own GitHub issue (`gh issue create --label internal`, Spanish title/body: the gap, the proposed rule, where it would live) and link them from the PR comment. Never add readiness labels (`ready-for-agent`/`needs-triage`) — those belong to `/triage`. Then `gh pr checks --watch`.
 8. On red CI, triage the failure before delegating. Every fix reaches the implementer as a **Fix step appended to the handoff** (what failed, files involved, acceptance criterion = the failing check green, local validation command) — never as a free-form instruction, so the implementer stays within its handoff contract.
-   - **Attributable** (the failing check's log points at files in the diff): append the Fix step and send implementer a brief with only the log excerpt. Counts as one fix cycle.
+   - **Attributable** (the failing check's log points at files in the diff): append the Fix step and spawn a fresh implementer with a brief holding only the log excerpt. Counts as one fix cycle.
    - **Opaque** (`e2e`, or the log does not implicate the diff): delegate to **debugger** first; its root-cause report feeds the Fix step. Diagnosis + fix = one cycle, not two.
    - **Suspected flake** (infra timeout, failure clearly unrelated to the diff): `gh run rerun <run-id> --failed`, at most once per issue, not counted as a cycle. The same failure twice is real — triage it as above.
 


### PR DESCRIPTION
## Problema

Durante el run del issue #175, el orquestador del flujo autónomo quedaba inerte en cada transición de etapa (fix cycles, re-review, apertura del PR): había que reenviarle manualmente el resultado de cada subagente desde la sesión raíz, matando la autonomía del flujo de punta a punta.

## Causa raíz (verificada con un experimento sintético)

- Un hijo spawneado con `Agent` en background **sí** despierta automáticamente a su padre al terminar — la delegación inicial nunca fue el problema.
- Un hijo **reanudado con `SendMessage`** notifica su finalización solo a la sesión raíz: el reanudador queda idle para siempre. Reproducido dos veces. Es exactamente lo que pasaba en los ciclos de corrección de #175.
- El fix alternativo de esperar bloqueante con `TaskOutput` es inviable: esa herramienta no existe dentro de subagentes.

## Fix

`.claude/agents/leader.md`:

- `SendMessage` eliminado de sus tools — la prohibición de reanudar queda estructural.
- Sección nueva **"Delegation mechanics (how to wait)"**: tras delegar, terminar el turno y dejar que la notificación de finalización lo re-invoque; toda continuación (fix cycle, re-review) es un spawn fresco, con el estado viajando en los contratos de archivo (handoff + Fix steps, briefs, el diff), nunca en la memoria de un subagente.
- Presupuesto ajustado: los spawns de continuación se cuentan contra el tope de 3 fix cycles; "relaunch" queda reservado para roles que fallan (máx. 1 por rol).

## Validación pendiente

Próximo issue corrido por el flujo: éxito = ninguna intervención manual entre etapas y menos turnos/costo del orquestador que en #175 (99 turnos / \$7.85). El detalle completo del diagnóstico quedó en `.claude/docs/flow-leader-idle.md` (local).