### PR TITLE
feat(edition): estado de edición por fila con historial y transiciones por rol

### DIFF
--- a/app/Actions/EditingStatus/ChangeEditingStatusAction.php
+++ b/app/Actions/EditingStatus/ChangeEditingStatusAction.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\EditingStatus;
+
+use App\Contracts\ActionContract;
+use App\Contracts\DtoContract;
+use App\Data\EditingStatus\EditingStatusChangeData;
+use App\Enums\EditingStatus;
+use App\Enums\UserRole;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\OrderDetail;
+use App\Models\OrderEditingStatusChange;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @implements ActionContract<EditingStatusChangeData>
+ */
+class ChangeEditingStatusAction implements ActionContract
+{
+    /**
+     * Append a new editing status entry after validating the transition
+     * against the full matrix: role/assignment gating plus the
+     * `production_enabled_at` precondition on the first transition.
+     *
+     * @param  EditingStatusChangeData  $params
+     *
+     * @throws ValidationException
+     */
+    public function handle(DtoContract $params): void
+    {
+        $detail = OrderDetail::with('product')->findOrFail($params->orderDetailId);
+
+        if ($detail->product?->has_photo !== true) {
+            throw ValidationException::withMessages([
+                'status' => 'Este producto no admite edición de foto.',
+            ]);
+        }
+
+        $current = $detail->currentEditingStatus();
+
+        $actor = User::findOrFail($params->changedById);
+        $isManager = $actor->hasAnyRole(UserRole::Admin, UserRole::Office, UserRole::Master);
+        $isAssignedEditor = EditorOrderDetailAssignment::where('order_detail_id', $detail->id)
+            ->where('editor_id', $actor->id)
+            ->exists();
+
+        $this->assertLegalTransition($current, $params->target, $detail, $isManager, $isAssignedEditor);
+
+        OrderEditingStatusChange::create([
+            'order_detail_id' => $detail->id,
+            'status' => $params->target,
+            'changed_by' => $actor->id,
+            'changed_at' => now(),
+        ]);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function assertLegalTransition(
+        EditingStatus $current,
+        EditingStatus $target,
+        OrderDetail $detail,
+        bool $isManager,
+        bool $isAssignedEditor,
+    ): void {
+        if ($current === EditingStatus::Pendiente && $target === EditingStatus::Editada) {
+            if (! $isAssignedEditor) {
+                throw ValidationException::withMessages([
+                    'status' => 'Solo el editor asignado puede editar esta foto.',
+                ]);
+            }
+
+            if ($detail->production_enabled_at === null) {
+                throw ValidationException::withMessages([
+                    'status' => 'Esta foto todavía no tiene la producción habilitada.',
+                ]);
+            }
+
+            return;
+        }
+
+        if ($current === EditingStatus::Editada && in_array($target, [EditingStatus::Ok, EditingStatus::ACorregir], true)) {
+            if (! $isManager) {
+                throw ValidationException::withMessages([
+                    'status' => 'No tenés permiso para cambiar este estado de edición.',
+                ]);
+            }
+
+            return;
+        }
+
+        if ($current === EditingStatus::Ok && $target === EditingStatus::ACorregir) {
+            if (! $isManager) {
+                throw ValidationException::withMessages([
+                    'status' => 'No tenés permiso para cambiar este estado de edición.',
+                ]);
+            }
+
+            return;
+        }
+
+        if ($current === EditingStatus::ACorregir && $target === EditingStatus::Editada) {
+            if (! $isAssignedEditor) {
+                throw ValidationException::withMessages([
+                    'status' => 'Solo el editor asignado puede editar esta foto.',
+                ]);
+            }
+
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'status' => 'Esta transición de estado no está permitida.',
+        ]);
+    }
+}

--- a/app/Actions/EditorAssignments/AssignEditorAction.php
+++ b/app/Actions/EditorAssignments/AssignEditorAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\EditorAssignments;
 use App\Contracts\ActionContract;
 use App\Contracts\DtoContract;
 use App\Data\EditorAssignments\EditorAssignmentData;
+use App\Enums\EditingStatus;
 use App\Models\EditorOrderDetailAssignment;
 use App\Models\OrderDetail;
 use Illuminate\Validation\ValidationException;
@@ -32,6 +33,12 @@ class AssignEditorAction implements ActionContract
         if ($detail->product?->has_photo !== true) {
             throw ValidationException::withMessages([
                 'order_detail_id' => 'Este producto no admite edición de foto.',
+            ]);
+        }
+
+        if ($detail->currentEditingStatus() !== EditingStatus::Pendiente) {
+            throw ValidationException::withMessages([
+                'order_detail_id' => 'Esta foto ya está editada y no se puede reasignar.',
             ]);
         }
 

--- a/app/Actions/EditorAssignments/BulkAssignEditorAction.php
+++ b/app/Actions/EditorAssignments/BulkAssignEditorAction.php
@@ -9,6 +9,7 @@ use App\Contracts\DtoContract;
 use App\Data\EditorAssignments\BulkEditorAssignmentData;
 use App\Models\EditorOrderDetailAssignment;
 use App\Models\OrderDetail;
+use App\Support\EditorAssignments\BulkEditorAssignmentResult;
 
 /**
  * @implements ActionContract<BulkEditorAssignmentData>
@@ -16,16 +17,17 @@ use App\Models\OrderDetail;
 class BulkAssignEditorAction implements ActionContract
 {
     /**
-     * Assign an editor to every in-scope order detail of a school or
-     * classroom, for the selected photo products. In scope mirrors the
-     * `/tracking` board: production enabled, not delivered, not recycled,
-     * order not cancelled.
+     * Assign an editor to every in-scope, still-`pendiente` order detail of
+     * a school or classroom, for the selected photo products. In scope
+     * mirrors the `/tracking` board: production enabled, not delivered,
+     * not recycled, order not cancelled. Non-pending rows are skipped
+     * rather than failing the whole operation.
      *
      * @param  BulkEditorAssignmentData  $params
      */
-    public function handle(DtoContract $params): int
+    public function handle(DtoContract $params): BulkEditorAssignmentResult
     {
-        $details = OrderDetail::query()
+        $inScope = OrderDetail::query()
             ->whereHas('product', fn ($query) => $query->where('has_photo', true)->whereIn('id', $params->productIds))
             ->whereNotNull('production_enabled_at')
             ->whereNull('delivered_at')
@@ -38,10 +40,12 @@ class BulkAssignEditorAction implements ActionContract
                 } else {
                     $query->whereHas('classroom', fn ($q) => $q->where('school_id', $params->schoolId));
                 }
-            })
-            ->get(['id']);
+            });
 
-        foreach ($details as $detail) {
+        $inScopeCount = (clone $inScope)->count();
+        $pendingDetails = (clone $inScope)->pending()->get(['id']);
+
+        foreach ($pendingDetails as $detail) {
             EditorOrderDetailAssignment::updateOrCreate(
                 ['order_detail_id' => $detail->id],
                 [
@@ -52,6 +56,9 @@ class BulkAssignEditorAction implements ActionContract
             );
         }
 
-        return $details->count();
+        return new BulkEditorAssignmentResult(
+            assigned: $pendingDetails->count(),
+            skipped: $inScopeCount - $pendingDetails->count(),
+        );
     }
 }

--- a/app/Actions/EditorAssignments/UnassignEditorAction.php
+++ b/app/Actions/EditorAssignments/UnassignEditorAction.php
@@ -7,7 +7,10 @@ namespace App\Actions\EditorAssignments;
 use App\Contracts\ActionContract;
 use App\Contracts\DtoContract;
 use App\Data\EditorAssignments\EditorUnassignmentData;
+use App\Enums\EditingStatus;
 use App\Models\EditorOrderDetailAssignment;
+use App\Models\OrderDetail;
+use Illuminate\Validation\ValidationException;
 
 /**
  * @implements ActionContract<EditorUnassignmentData>
@@ -19,9 +22,19 @@ class UnassignEditorAction implements ActionContract
      * error if the detail has no assignment.
      *
      * @param  EditorUnassignmentData  $params
+     *
+     * @throws ValidationException
      */
     public function handle(DtoContract $params): void
     {
+        $detail = OrderDetail::findOrFail($params->orderDetailId);
+
+        if ($detail->currentEditingStatus() !== EditingStatus::Pendiente) {
+            throw ValidationException::withMessages([
+                'order_detail_id' => 'Esta foto ya está editada y no se puede desasignar.',
+            ]);
+        }
+
         EditorOrderDetailAssignment::where('order_detail_id', $params->orderDetailId)->delete();
     }
 }

--- a/app/Data/EditingStatus/EditingStatusChangeData.php
+++ b/app/Data/EditingStatus/EditingStatusChangeData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\EditingStatus;
+
+use App\Contracts\DtoContract;
+use App\Enums\EditingStatus;
+
+final readonly class EditingStatusChangeData implements DtoContract
+{
+    public function __construct(
+        public int $orderDetailId,
+        public EditingStatus $target,
+        public int $changedById,
+    ) {}
+}

--- a/app/Enums/EditingStatus.php
+++ b/app/Enums/EditingStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum EditingStatus: string
+{
+    case Pendiente = 'pendiente';
+    case Editada = 'editada';
+    case Ok = 'ok';
+    case ACorregir = 'a_corregir';
+}

--- a/app/Http/Controllers/BO/EditingStatusController.php
+++ b/app/Http/Controllers/BO/EditingStatusController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Actions\EditingStatus\ChangeEditingStatusAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\BO\ChangeEditingStatusRequest;
+use Illuminate\Http\RedirectResponse;
+
+class EditingStatusController extends Controller
+{
+    /**
+     * Append a new editing status entry for an order detail.
+     */
+    public function store(ChangeEditingStatusRequest $request, ChangeEditingStatusAction $action): RedirectResponse
+    {
+        $action->handle($request->toData());
+
+        return back()->with('success', 'Estado de edición actualizado');
+    }
+}

--- a/app/Http/Controllers/BO/EditingStatusController.php
+++ b/app/Http/Controllers/BO/EditingStatusController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\BO;
 use App\Actions\EditingStatus\ChangeEditingStatusAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\BO\ChangeEditingStatusRequest;
+use App\Models\OrderDetail;
 use Illuminate\Http\RedirectResponse;
 
 class EditingStatusController extends Controller
@@ -14,7 +15,7 @@ class EditingStatusController extends Controller
     /**
      * Append a new editing status entry for an order detail.
      */
-    public function store(ChangeEditingStatusRequest $request, ChangeEditingStatusAction $action): RedirectResponse
+    public function store(ChangeEditingStatusRequest $request, OrderDetail $orderDetail, ChangeEditingStatusAction $action): RedirectResponse
     {
         $action->handle($request->toData());
 

--- a/app/Http/Controllers/BO/EditorAssignmentController.php
+++ b/app/Http/Controllers/BO/EditorAssignmentController.php
@@ -32,9 +32,15 @@ class EditorAssignmentController extends Controller
      */
     public function bulkStore(BulkAssignEditorRequest $request, BulkAssignEditorAction $action): RedirectResponse
     {
-        $count = $action->handle($request->toData());
+        $result = $action->handle($request->toData());
 
-        return back()->with('success', "$count producto(s) asignados al editor");
+        $response = back()->with('success', "{$result->assigned} producto(s) asignados al editor");
+
+        if ($result->skipped > 0) {
+            $response->with('warning', "{$result->skipped} foto(s) ya están editadas y no se pueden reasignar/desasignar");
+        }
+
+        return $response;
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -41,6 +41,9 @@ class HandleInertiaRequests extends Middleware
                 'user' => $user,
                 'roles' => $user?->roleNames() ?? [],
             ],
+            'flash' => [
+                'warning' => fn () => $request->session()->get('warning'),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/BO/ChangeEditingStatusRequest.php
+++ b/app/Http/Requests/BO/ChangeEditingStatusRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\BO;
+
+use App\Data\EditingStatus\EditingStatusChangeData;
+use App\Enums\EditingStatus;
+use App\Models\OrderDetail;
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ChangeEditingStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::enum(EditingStatus::class)],
+        ];
+    }
+
+    public function toData(): EditingStatusChangeData
+    {
+        /** @var array{status: string} $validated */
+        $validated = $this->validated();
+
+        /** @var OrderDetail $orderDetail */
+        $orderDetail = $this->route('orderDetail');
+
+        /** @var User $user */
+        $user = $this->user();
+
+        return new EditingStatusChangeData(
+            orderDetailId: (int) $orderDetail->id,
+            target: EditingStatus::from($validated['status']),
+            changedById: (int) $user->id,
+        );
+    }
+}

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\EditingStatus;
 use Database\Factories\OrderDetailFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -49,6 +51,40 @@ class OrderDetail extends Pivot
     public function stockMovements()
     {
         return $this->hasMany(StockMovement::class, 'order_detail_id');
+    }
+
+    /**
+     * @return HasMany<OrderEditingStatusChange, $this>
+     */
+    public function editingStatusChanges()
+    {
+        return $this->hasMany(OrderEditingStatusChange::class, 'order_detail_id');
+    }
+
+    /**
+     * Current editing status: the latest entry in the append-only history,
+     * or `Pendiente` when the detail has none.
+     */
+    public function currentEditingStatus(): EditingStatus
+    {
+        $latest = $this->editingStatusChanges()->orderByDesc('changed_at')->orderByDesc('id')->first();
+
+        if ($latest === null) {
+            return EditingStatus::Pendiente;
+        }
+
+        return $latest->status;
+    }
+
+    /**
+     * Details still `pendiente`: no rows in the editing status history.
+     *
+     * @param  Builder<OrderDetail>  $query
+     * @return Builder<OrderDetail>
+     */
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->whereDoesntHave('editingStatusChanges');
     }
 
     protected $casts = [

--- a/app/Models/OrderEditingStatusChange.php
+++ b/app/Models/OrderEditingStatusChange.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\EditingStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OrderEditingStatusChange extends Model
+{
+    protected $casts = [
+        'status' => EditingStatus::class,
+        'changed_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<OrderDetail, $this>
+     */
+    public function orderDetail()
+    {
+        return $this->belongsTo(OrderDetail::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function changedBy()
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/app/Support/EditorAssignments/BulkEditorAssignmentResult.php
+++ b/app/Support/EditorAssignments/BulkEditorAssignmentResult.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\EditorAssignments;
+
+final readonly class BulkEditorAssignmentResult
+{
+    public function __construct(
+        public int $assigned,
+        public int $skipped,
+    ) {}
+}

--- a/database/migrations/2026_07_16_000002_create_order_editing_status_changes_table.php
+++ b/database/migrations/2026_07_16_000002_create_order_editing_status_changes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_editing_status_changes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_detail_id')->constrained('order_details')->cascadeOnDelete();
+            $table->string('status');
+            $table->foreignId('changed_by')->constrained('users');
+            $table->timestamp('changed_at');
+            $table->timestamps();
+
+            $table->index('order_detail_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_editing_status_changes');
+    }
+};

--- a/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
+++ b/resources/js/features/editor-assignment/BulkAssignEditorDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { usePage } from '@inertiajs/react';
 import { UserCog } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 import { PhotoProductsChecklist } from './PhotoProductsChecklist';
 import { useBulkAssignEditor } from './useBulkAssignEditor';
 
@@ -104,7 +105,12 @@ export function BulkAssignEditorDialog({
                 <DialogFooter>
                     <Button
                         disabled={processing}
-                        onClick={() => submit(() => setOpen(false))}
+                        onClick={() =>
+                            submit((warning) => {
+                                setOpen(false);
+                                if (warning) toast.warning(warning);
+                            })
+                        }
                     >
                         Asignar
                     </Button>

--- a/resources/js/features/editor-assignment/useBulkAssignEditor.ts
+++ b/resources/js/features/editor-assignment/useBulkAssignEditor.ts
@@ -14,12 +14,12 @@ export function useBulkAssignEditor({
         classroom_id: classroomId ?? null,
     });
 
-    const submit = (onSuccess: () => void) => {
+    const submit = (onSuccess: (warning: string | null) => void) => {
         form.post(route('editor-assignments.bulk'), {
             preserveScroll: true,
-            onSuccess: () => {
+            onSuccess: (page) => {
                 form.reset();
-                onSuccess();
+                onSuccess(page.props.flash?.warning ?? null);
             },
         });
     };

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -14,6 +14,7 @@ export type PageProps<
         user: User;
         roles: string[];
     };
+    flash?: { warning?: string | null };
 };
 
 export interface BreadcrumbItem {

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\BO\DeliveryController;
 use App\Http\Controllers\BO\DetailPriorityController;
 use App\Http\Controllers\BO\DetailProductionStatusController;
 use App\Http\Controllers\BO\DetailVariantController;
+use App\Http\Controllers\BO\EditingStatusController;
 use App\Http\Controllers\BO\EditorAssignmentController;
 use App\Http\Controllers\BO\NoteController;
 use App\Http\Controllers\BO\OrderController;
@@ -65,6 +66,7 @@ Route::middleware(['auth', 'role:master,administración,oficina,editor'])->group
     Route::get('/classrooms/{classroom}/photos', [PhotoController::class, 'index'])->name('photos.index');
     Route::post('/classrooms/{classroom}/photos', [PhotoController::class, 'store'])->name('photos.store');
     Route::delete('/photos/{photo}', [PhotoController::class, 'destroy'])->name('photos.destroy');
+    Route::post('/order-details/{orderDetail}/editing-status', [EditingStatusController::class, 'store'])->name('editing-status.store');
 });
 
 // Producción y stock: también accesibles para el rol taller

--- a/tests/Feature/EditingStatusTest.php
+++ b/tests/Feature/EditingStatusTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\EditingStatus;
+use App\Enums\UserRole;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\OrderDetail;
+use App\Models\OrderEditingStatusChange;
+use App\Models\Product;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+/**
+ * Seed a current editing status by writing a history row directly.
+ */
+function seedEditingStatus(OrderDetail $detail, EditingStatus $status, User $changedBy): OrderEditingStatusChange
+{
+    return OrderEditingStatusChange::create([
+        'order_detail_id' => $detail->id,
+        'status' => $status,
+        'changed_by' => $changedBy->id,
+        'changed_at' => now(),
+    ]);
+}
+
+// pendiente -> editada
+
+it('lets the assigned editor move a detail from pendiente to editada', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($editor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasNoErrors();
+
+    $changes = OrderEditingStatusChange::where('order_detail_id', $detail->id)->get();
+
+    expect($changes)->toHaveCount(1)
+        ->and($changes->first()->status)->toBe(EditingStatus::Editada)
+        ->and($changes->first()->changed_by)->toBe($editor->id);
+});
+
+it('rejects pendiente to editada by an editor not assigned to the detail', function () {
+    $assignedEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $otherEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $assignedEditor->id,
+        'assigned_by' => $assignedEditor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($otherEditor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects pendiente to editada when production is not enabled', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($editor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects pendiente to editada attempted by a manager', function (UserRole $role) {
+    actingAsRole($role);
+
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+// editada -> ok / a_corregir
+
+it('lets managers move a detail from editada to ok', function (UserRole $role) {
+    $actor = actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Editada, $actor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Ok->value])
+        ->assertSessionHasNoErrors();
+
+    $latest = OrderEditingStatusChange::where('order_detail_id', $detail->id)->latest('id')->first();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(2)
+        ->and($latest->status)->toBe(EditingStatus::Ok)
+        ->and($latest->changed_by)->toBe($actor->id);
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+it('lets managers move a detail from editada to a_corregir', function (UserRole $role) {
+    $actor = actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Editada, $actor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::ACorregir->value])
+        ->assertSessionHasNoErrors();
+
+    $latest = OrderEditingStatusChange::where('order_detail_id', $detail->id)->latest('id')->first();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(2)
+        ->and($latest->status)->toBe(EditingStatus::ACorregir)
+        ->and($latest->changed_by)->toBe($actor->id);
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+it('rejects editada to ok attempted by the assigned editor', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Editada, $editor);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($editor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Ok->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(1);
+});
+
+// a_corregir -> editada
+
+it('lets the assigned editor move a detail from a_corregir to editada', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::ACorregir, $editor);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($editor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasNoErrors();
+
+    $latest = OrderEditingStatusChange::where('order_detail_id', $detail->id)->latest('id')->first();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(2)
+        ->and($latest->status)->toBe(EditingStatus::Editada)
+        ->and($latest->changed_by)->toBe($editor->id);
+});
+
+it('rejects a_corregir to editada by an editor not assigned to the detail', function () {
+    $assignedEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $otherEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::ACorregir, $assignedEditor);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $assignedEditor->id,
+        'assigned_by' => $assignedEditor->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($otherEditor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(1);
+});
+
+// ok -> a_corregir
+
+it('lets managers move a detail from ok to a_corregir', function (UserRole $role) {
+    $actor = actingAsRole($role);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Ok, $actor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::ACorregir->value])
+        ->assertSessionHasNoErrors();
+
+    $latest = OrderEditingStatusChange::where('order_detail_id', $detail->id)->latest('id')->first();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(2)
+        ->and($latest->status)->toBe(EditingStatus::ACorregir)
+        ->and($latest->changed_by)->toBe($actor->id);
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+]);
+
+it('rejects ok to editada, the only legal move from ok is to a_corregir', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Ok, $actor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(1);
+});
+
+// Illegal transitions, representative set
+
+it('rejects illegal transitions', function (EditingStatus $from, EditingStatus $target) {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    if ($from !== EditingStatus::Pendiente) {
+        seedEditingStatus($detail, $from, $actor);
+    }
+
+    post(route('editing-status.store', $detail), ['status' => $target->value])
+        ->assertSessionHasErrors();
+
+    $expectedCount = $from === EditingStatus::Pendiente ? 0 : 1;
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe($expectedCount);
+})->with([
+    'pendiente -> ok' => [EditingStatus::Pendiente, EditingStatus::Ok],
+    'pendiente -> a_corregir' => [EditingStatus::Pendiente, EditingStatus::ACorregir],
+    'editada -> editada' => [EditingStatus::Editada, EditingStatus::Editada],
+    'a_corregir -> ok' => [EditingStatus::ACorregir, EditingStatus::Ok],
+    'ok -> ok' => [EditingStatus::Ok, EditingStatus::Ok],
+]);
+
+// Product not editable by photo
+
+it('rejects any transition on a product that does not admit photo editing', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => false]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+    seedEditingStatus($detail, EditingStatus::Editada, $actor);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Ok->value])
+        ->assertSessionHasErrors();
+
+    expect(OrderEditingStatusChange::where('order_detail_id', $detail->id)->count())->toBe(1);
+});
+
+// Route-level role gate
+
+it('forbids taller from changing editing status', function () {
+    actingAsRole(UserRole::Worker);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertForbidden();
+});
+
+// Append-only history, full cycle
+
+it('appends a full history through the editing status cycle', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    actingAs($editor);
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasNoErrors();
+
+    actingAs($manager);
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::ACorregir->value])
+        ->assertSessionHasNoErrors();
+
+    actingAs($editor);
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Editada->value])
+        ->assertSessionHasNoErrors();
+
+    actingAs($manager);
+    post(route('editing-status.store', $detail), ['status' => EditingStatus::Ok->value])
+        ->assertSessionHasNoErrors();
+
+    $changes = OrderEditingStatusChange::where('order_detail_id', $detail->id)->orderBy('id')->get();
+
+    expect($changes)->toHaveCount(4)
+        ->and($changes->pluck('status')->all())->toBe([
+            EditingStatus::Editada,
+            EditingStatus::ACorregir,
+            EditingStatus::Editada,
+            EditingStatus::Ok,
+        ])
+        ->and($detail->refresh()->currentEditingStatus())->toBe(EditingStatus::Ok);
+});

--- a/tests/Feature/EditorAssignmentTest.php
+++ b/tests/Feature/EditorAssignmentTest.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use App\Enums\EditingStatus;
 use App\Enums\UserRole;
 use App\Models\Classroom;
 use App\Models\EditorOrderDetailAssignment;
 use App\Models\Order;
 use App\Models\OrderDetail;
+use App\Models\OrderEditingStatusChange;
 use App\Models\Product;
 use App\Models\School;
 use App\Models\User;
@@ -406,3 +408,119 @@ it('denies editor and taller from bulk assigning', function (UserRole $role) {
     'editor' => [UserRole::Editor],
     'taller' => [UserRole::Worker],
 ]);
+
+// Non-pendiente guard (criterion 9)
+
+it('rejects individual assign on a detail that is not pendiente anymore', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    OrderEditingStatusChange::create([
+        'order_detail_id' => $detail->id,
+        'status' => EditingStatus::Editada,
+        'changed_by' => $actor->id,
+        'changed_at' => now(),
+    ]);
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects individual unassign on a detail that is not pendiente anymore', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $actor->id,
+        'assigned_at' => now(),
+    ]);
+
+    OrderEditingStatusChange::create([
+        'order_detail_id' => $detail->id,
+        'status' => EditingStatus::Editada,
+        'changed_by' => $actor->id,
+        'changed_at' => now(),
+    ]);
+
+    delete(route('editor-assignments.destroy', $detail))->assertSessionHasErrors();
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeTrue();
+});
+
+it('bulk skips non-pendiente rows and flashes a warning', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $otherEditor = User::factory()->withRole(UserRole::Editor)->create();
+
+    $pendingDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+    $editedDetail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $editedDetail->id,
+        'editor_id' => $otherEditor->id,
+        'assigned_by' => $actor->id,
+        'assigned_at' => now(),
+    ]);
+
+    OrderEditingStatusChange::create([
+        'order_detail_id' => $editedDetail->id,
+        'status' => EditingStatus::Editada,
+        'changed_by' => $actor->id,
+        'changed_at' => now(),
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasNoErrors()
+        ->assertSessionHas('warning');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $pendingDetail->id)->first()?->editor_id)
+        ->toBe($editor->id)
+        ->and(EditorOrderDetailAssignment::where('order_detail_id', $editedDetail->id)->first()?->editor_id)
+        ->toBe($otherEditor->id);
+});
+
+it('bulk flashes no warning when every in-scope detail is still pendiente', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    post(route('editor-assignments.bulk'), [
+        'editor_id' => $editor->id,
+        'product_ids' => [$product->id],
+        'classroom_id' => $classroom->id,
+    ])->assertSessionHasNoErrors()
+        ->assertSessionMissing('warning');
+});


### PR DESCRIPTION
## Qué

Agrega el estado de edición por fila (`order_detail` con foto), derivado de un historial append-only, con transiciones controladas por rol y por la asignación vigente de editor (#175). Es el slice de backend completo, endpoint incluido; la vista queda para #177.

## Cambios

- Nueva tabla append-only `order_editing_status_changes` (`order_detail_id`, `status`, `changed_by`, `changed_at`). Sin columna de estado en `order_details`.
- Enum `App\Enums\EditingStatus` (`pendiente`, `editada`, `ok`, `a_corregir`). El estado actual de una fila es la última entrada; sin entradas, `pendiente`.
- Endpoint propio de transición (ruta + controller delgado + `FormRequest` + `Action`) que aplica la matriz de transiciones:
  - `pendiente → editada`: solo el editor asignado a la fila, y con `production_enabled_at` no nulo.
  - `editada → ok` / `editada → a_corregir`: solo administración, oficina o master.
  - `a_corregir → editada`: solo el editor asignado.
  - `ok → a_corregir`: solo administración, oficina o master (única salida desde `ok`).
  - Se rechaza toda transición no listada, todo editor no asignado a la fila y toda fila cuyo producto no tenga `has_photo`.
- Guard diferido de #175: las tres acciones de asignación operan solo sobre filas en estado `pendiente`. La asignación y desasignación individuales rechazan filas ya editadas; el bulk las omite y reporta cuántas se saltaron mediante un aviso en el `BulkAssignEditorDialog`.
- Cobertura Pest de la matriz rol × transición y del guard de asignación.

## Fuera de alcance

- La vista de edición y la UI de transiciones (#177).
- Acciones en bulk sobre el estado de edición.

Closes #176
