### PR TITLE
feat(edition): vista de edición por escuela/curso

### DIFF
--- a/app/Actions/EditingStatus/ChangeEditingStatusAction.php
+++ b/app/Actions/EditingStatus/ChangeEditingStatusAction.php
@@ -67,54 +67,42 @@ class ChangeEditingStatusAction implements ActionContract
         bool $isManager,
         bool $isAssignedEditor,
     ): void {
-        if ($current === EditingStatus::Pendiente && $target === EditingStatus::Editada) {
+        // Structurally reachable targets from $current, ignoring gating (all gates forced open).
+        $structurallyReachable = EditingStatus::allowedTargets($current, isManager: true, isAssignedEditor: true, productionEnabled: true);
+
+        if (! in_array($target, $structurallyReachable, true)) {
+            throw ValidationException::withMessages([
+                'status' => 'Esta transición de estado no está permitida.',
+            ]);
+        }
+
+        $productionEnabled = $detail->production_enabled_at !== null;
+        $permitted = EditingStatus::allowedTargets($current, $isManager, $isAssignedEditor, $productionEnabled);
+
+        if (in_array($target, $permitted, true)) {
+            return;
+        }
+
+        if ($current === EditingStatus::Pendiente) {
             if (! $isAssignedEditor) {
                 throw ValidationException::withMessages([
                     'status' => 'Solo el editor asignado puede editar esta foto.',
                 ]);
             }
 
-            if ($detail->production_enabled_at === null) {
-                throw ValidationException::withMessages([
-                    'status' => 'Esta foto todavía no tiene la producción habilitada.',
-                ]);
-            }
-
-            return;
+            throw ValidationException::withMessages([
+                'status' => 'Esta foto todavía no tiene la producción habilitada.',
+            ]);
         }
 
-        if ($current === EditingStatus::Editada && in_array($target, [EditingStatus::Ok, EditingStatus::ACorregir], true)) {
-            if (! $isManager) {
-                throw ValidationException::withMessages([
-                    'status' => 'No tenés permiso para cambiar este estado de edición.',
-                ]);
-            }
-
-            return;
-        }
-
-        if ($current === EditingStatus::Ok && $target === EditingStatus::ACorregir) {
-            if (! $isManager) {
-                throw ValidationException::withMessages([
-                    'status' => 'No tenés permiso para cambiar este estado de edición.',
-                ]);
-            }
-
-            return;
-        }
-
-        if ($current === EditingStatus::ACorregir && $target === EditingStatus::Editada) {
-            if (! $isAssignedEditor) {
-                throw ValidationException::withMessages([
-                    'status' => 'Solo el editor asignado puede editar esta foto.',
-                ]);
-            }
-
-            return;
+        if ($current === EditingStatus::ACorregir) {
+            throw ValidationException::withMessages([
+                'status' => 'Solo el editor asignado puede editar esta foto.',
+            ]);
         }
 
         throw ValidationException::withMessages([
-            'status' => 'Esta transición de estado no está permitida.',
+            'status' => 'No tenés permiso para cambiar este estado de edición.',
         ]);
     }
 }

--- a/app/Enums/EditingStatus.php
+++ b/app/Enums/EditingStatus.php
@@ -10,4 +10,26 @@ enum EditingStatus: string
     case Editada = 'editada';
     case Ok = 'ok';
     case ACorregir = 'a_corregir';
+
+    /**
+     * Single source of truth for the editing-status transition matrix:
+     * Pendiente -> Editada only for the assigned editor once production is
+     * enabled; Editada -> {Ok, ACorregir} and Ok -> ACorregir only for a
+     * manager; ACorregir -> Editada only for the assigned editor.
+     *
+     * @return list<self>
+     */
+    public static function allowedTargets(
+        self $current,
+        bool $isManager,
+        bool $isAssignedEditor,
+        bool $productionEnabled,
+    ): array {
+        return match ($current) {
+            self::Pendiente => $isAssignedEditor && $productionEnabled ? [self::Editada] : [],
+            self::Editada => $isManager ? [self::Ok, self::ACorregir] : [],
+            self::Ok => $isManager ? [self::ACorregir] : [],
+            self::ACorregir => $isAssignedEditor ? [self::Editada] : [],
+        };
+    }
 }

--- a/app/Http/Controllers/BO/EditionController.php
+++ b/app/Http/Controllers/BO/EditionController.php
@@ -205,9 +205,13 @@ class EditionController extends Controller
 
         if ($isFirstOfOrder) {
             $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
+            $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
 
             $row['modelo_cuadro'] = $mural?->product?->name;
             $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
+            // Not one of the "accessory columns" (carpeta/banda/medalla/taza
+            // presence flags): visible to every role, unlike $isManager below.
+            $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
             $row['observaciones_generales'] = $order->notes->map(fn (Note $note) => [
                 'id' => $note->id,
                 'body' => $note->body,
@@ -215,9 +219,6 @@ class EditionController extends Controller
             ])->values()->all();
 
             if ($isManager) {
-                $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
-
-                $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
                 $row['accessories'] = [
                     'carpeta' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'carpeta'),
                     'banda' => $banda !== null,

--- a/app/Http/Controllers/BO/EditionController.php
+++ b/app/Http/Controllers/BO/EditionController.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\BO;
+
+use App\Enums\EditingStatus;
+use App\Enums\UserRole;
+use App\Http\Controllers\Controller;
+use App\Models\Classroom;
+use App\Models\Note;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\School;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class EditionController extends Controller
+{
+    /**
+     * Read-only edition board: one row per photo-editable order detail,
+     * grouped by school -> classroom. Editors only see their own assigned
+     * rows and a reduced column set; managers (master/administración/
+     * oficina) see everything plus per-classroom accessory totals.
+     */
+    public function index(Request $request): Response
+    {
+        /** @var User $actor */
+        $actor = $request->user();
+
+        $isManager = $actor->hasAnyRole(UserRole::Master, UserRole::Admin, UserRole::Office);
+
+        $details = OrderDetail::query()
+            ->whereHas('product', fn ($query) => $query->where('has_photo', true))
+            ->whereNull('delivered_at')
+            ->whereNull('recycled_to')
+            ->whereHas('order', fn ($query) => $query->whereNull('cancelled_at'))
+            ->when(! $isManager, function ($query) use ($actor) {
+                $query->whereHas('editorAssignment', fn ($assignment) => $assignment->where('editor_id', $actor->id));
+            })
+            ->with([
+                'product.type',
+                'order.classroom.school',
+                'order.notes',
+                'editorAssignment.editor',
+                'editingStatusChanges',
+            ])
+            ->get();
+
+        $orderIds = $details->pluck('order_id')->unique();
+
+        /** @var Collection<int|string, Collection<int, OrderDetail>> $activeDetailsByOrder */
+        $activeDetailsByOrder = OrderDetail::query()
+            ->whereIn('order_id', $orderIds)
+            ->whereNull('delivered_at')
+            ->whereNull('recycled_to')
+            ->with('product.type')
+            ->get()
+            ->groupBy('order_id');
+
+        $schools = $this->groupBySchool($details, $activeDetailsByOrder, $isManager, $actor);
+
+        return Inertia::render('edition/index', [
+            'schools' => $schools,
+            'canManage' => $isManager,
+            'editors' => $isManager ? User::assignableEditors()->get(['id', 'name']) : [],
+            'photoProducts' => $isManager ? Product::where('has_photo', true)->get(['id', 'name']) : [],
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, OrderDetail>  $details
+     * @param  Collection<int|string, Collection<int, OrderDetail>>  $activeDetailsByOrder
+     * @return array<int, array<string, mixed>>
+     */
+    private function groupBySchool(Collection $details, Collection $activeDetailsByOrder, bool $isManager, User $actor): array
+    {
+        return $details
+            ->groupBy(function (OrderDetail $detail) {
+                /** @var Order $order */
+                $order = $detail->order;
+
+                /** @var Classroom $classroom */
+                $classroom = $order->classroom;
+
+                return $classroom->school_id;
+            })
+            ->map(function (Collection $schoolDetails) use ($activeDetailsByOrder, $isManager, $actor) {
+                /** @var OrderDetail $firstDetail */
+                $firstDetail = $schoolDetails->first();
+
+                /** @var Order $order */
+                $order = $firstDetail->order;
+
+                /** @var Classroom $classroom */
+                $classroom = $order->classroom;
+
+                /** @var School $school */
+                $school = $classroom->school;
+
+                return [
+                    'id' => $school->id,
+                    'name' => $school->name,
+                    'classrooms' => $this->groupByClassroom($schoolDetails, $activeDetailsByOrder, $isManager, $actor),
+                ];
+            })
+            ->sortBy('name')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, OrderDetail>  $schoolDetails
+     * @param  Collection<int|string, Collection<int, OrderDetail>>  $activeDetailsByOrder
+     * @return array<int, array<string, mixed>>
+     */
+    private function groupByClassroom(Collection $schoolDetails, Collection $activeDetailsByOrder, bool $isManager, User $actor): array
+    {
+        return $schoolDetails
+            ->groupBy(function (OrderDetail $detail) {
+                /** @var Order $order */
+                $order = $detail->order;
+
+                return $order->classroom_id;
+            })
+            ->map(function (Collection $classroomDetails) use ($activeDetailsByOrder, $isManager, $actor) {
+                /** @var OrderDetail $firstDetail */
+                $firstDetail = $classroomDetails->first();
+
+                /** @var Order $firstOrder */
+                $firstOrder = $firstDetail->order;
+
+                /** @var Classroom $classroom */
+                $classroom = $firstOrder->classroom;
+
+                $sortedRows = $classroomDetails->sortBy([['order_id', 'asc'], ['id', 'asc']])->values();
+                $firstRowIds = $sortedRows->unique('order_id')->pluck('id')->all();
+
+                $rows = $sortedRows
+                    ->map(fn (OrderDetail $detail) => $this->mapRow(
+                        $detail,
+                        in_array($detail->id, $firstRowIds, true),
+                        $activeDetailsByOrder->get($detail->order_id) ?? collect(),
+                        $isManager,
+                        $actor,
+                    ))
+                    ->values()
+                    ->all();
+
+                $classroomGroup = [
+                    'id' => $classroom->id,
+                    'name' => $classroom->name,
+                    'rows' => $rows,
+                ];
+
+                if ($isManager) {
+                    /** @var Collection<int, int> $orderIds */
+                    $orderIds = $sortedRows->pluck('order_id')->unique()->values();
+
+                    $classroomGroup['totals'] = $this->accessoryTotals($orderIds, $activeDetailsByOrder);
+                }
+
+                return $classroomGroup;
+            })
+            ->sortBy('name')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, OrderDetail>  $orderActiveDetails
+     * @return array<string, mixed>
+     */
+    private function mapRow(OrderDetail $detail, bool $isFirstOfOrder, Collection $orderActiveDetails, bool $isManager, User $actor): array
+    {
+        /** @var Order $order */
+        $order = $detail->order;
+
+        $current = $detail->currentEditingStatus();
+        $isAssignedEditor = $detail->editorAssignment?->editor_id === $actor->id;
+        $productionEnabled = $detail->production_enabled_at !== null;
+
+        $allowedTargets = EditingStatus::allowedTargets($current, $isManager, $isAssignedEditor, $productionEnabled);
+
+        $row = [
+            'id' => $detail->id,
+            'order_id' => $detail->order_id,
+            'photo_size' => $detail->product?->name,
+            'diseno' => $this->variantLabel($detail->variant, 'Tipo de foto'),
+            'child_name' => $order->child_name,
+            'editing_status' => $current->value,
+            'note' => $detail->note,
+            'allowed_targets' => array_map(fn (EditingStatus $status) => $status->value, $allowedTargets),
+            'is_first_of_order' => $isFirstOfOrder,
+        ];
+
+        if ($isManager) {
+            $editor = $detail->editorAssignment?->editor;
+            $row['editor'] = $editor !== null ? ['id' => $editor->id, 'name' => $editor->name] : null;
+        }
+
+        if ($isFirstOfOrder) {
+            $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
+
+            $row['modelo_cuadro'] = $mural?->product?->name;
+            $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
+            $row['observaciones_generales'] = $order->notes->map(fn (Note $note) => [
+                'id' => $note->id,
+                'body' => $note->body,
+                'created_at' => $note->created_at->format('d/m/Y H:i'),
+            ])->values()->all();
+
+            if ($isManager) {
+                $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
+
+                $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
+                $row['accessories'] = [
+                    'carpeta' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'carpeta'),
+                    'banda' => $banda !== null,
+                    'medalla' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'medalla'),
+                    'taza' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'taza'),
+                    // Not in the product catalog yet (#177): rendered inert.
+                    'guantes' => false,
+                    'escarapela' => false,
+                ];
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * Accessory presence counted once per order (not per row), per the
+     * classroom totals footer.
+     *
+     * @param  Collection<int, int>  $orderIds
+     * @param  Collection<int|string, Collection<int, OrderDetail>>  $activeDetailsByOrder
+     * @return array<string, int>
+     */
+    private function accessoryTotals(Collection $orderIds, Collection $activeDetailsByOrder): array
+    {
+        $totals = ['carpeta' => 0, 'banda' => 0, 'medalla' => 0, 'taza' => 0, 'guantes' => 0, 'escarapela' => 0];
+
+        foreach ($orderIds as $orderId) {
+            $orderDetails = $activeDetailsByOrder->get($orderId) ?? collect();
+
+            foreach (['carpeta', 'banda', 'medalla', 'taza'] as $type) {
+                if ($orderDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === $type)) {
+                    $totals[$type]++;
+                }
+            }
+        }
+
+        return $totals;
+    }
+
+    /**
+     * Looks up a variant snapshot entry by its label, e.g. "Tipo de foto",
+     * "Color" or "Talle".
+     *
+     * @param  array<int, array{label: string, type?: string, value: array{label: string, color?: string}|null}>|null  $variant
+     */
+    private function variantLabel(?array $variant, string $label): ?string
+    {
+        foreach ($variant ?? [] as $entry) {
+            if ($entry['label'] === $label) {
+                return $entry['value']['label'] ?? null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class OrderDetail extends Pivot
@@ -59,6 +60,14 @@ class OrderDetail extends Pivot
     public function editingStatusChanges()
     {
         return $this->hasMany(OrderEditingStatusChange::class, 'order_detail_id');
+    }
+
+    /**
+     * @return HasOne<EditorOrderDetailAssignment, $this>
+     */
+    public function editorAssignment()
+    {
+        return $this->hasOne(EditorOrderDetailAssignment::class, 'order_detail_id');
     }
 
     /**

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -72,11 +72,19 @@ class OrderDetail extends Pivot
 
     /**
      * Current editing status: the latest entry in the append-only history,
-     * or `Pendiente` when the detail has none.
+     * or `Pendiente` when the detail has none. Reads the `editingStatusChanges`
+     * relation from memory when it has been eager-loaded (avoids an N+1 query
+     * per row), falling back to a fresh query otherwise.
      */
     public function currentEditingStatus(): EditingStatus
     {
-        $latest = $this->editingStatusChanges()->orderByDesc('changed_at')->orderByDesc('id')->first();
+        if ($this->relationLoaded('editingStatusChanges')) {
+            $latest = $this->editingStatusChanges
+                ->sortBy([['changed_at', 'desc'], ['id', 'desc']])
+                ->first();
+        } else {
+            $latest = $this->editingStatusChanges()->orderByDesc('changed_at')->orderByDesc('id')->first();
+        }
 
         if ($latest === null) {
             return EditingStatus::Pendiente;

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import { Link, usePage } from '@inertiajs/react';
 import {
     Group,
     Home,
+    Images,
     ListOrdered,
     Package,
     PackageOpen,
@@ -29,6 +30,7 @@ import { NavUser } from './nav-user';
 const SALES = ['master', 'administración', 'oficina'];
 const PRODUCTION = ['master', 'administración', 'oficina', 'taller'];
 const MANAGEMENT = ['master', 'administración'];
+const EDITION = ['master', 'administración', 'oficina', 'editor'];
 
 const routeables = [
     { name: 'Dashboard', route: 'dashboard', icon: Home, roles: null },
@@ -46,6 +48,12 @@ const routeables = [
         route: 'tracking.index',
         icon: Rss,
         roles: PRODUCTION,
+    },
+    {
+        name: 'Edición',
+        route: 'edition.index',
+        icon: Images,
+        roles: EDITION,
     },
     {
         name: 'Stockeables',

--- a/resources/js/pages/edition/components/assignment-control.tsx
+++ b/resources/js/pages/edition/components/assignment-control.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { AssignableEditor } from '@/features/editor-assignment/BulkAssignEditorDialog';
+import { X } from 'lucide-react';
+import { useEditorAssignment } from '../hooks/use-editor-assignment';
+
+/**
+ * Individual assign/unassign control for a single row: a select of
+ * assignable editors plus an unassign button, shown only once one is set.
+ */
+export function AssignmentControl({
+    orderDetailId,
+    editors,
+    current,
+}: {
+    orderDetailId: number;
+    editors: AssignableEditor[];
+    current: { id: number; name: string } | null;
+}) {
+    const { assign, unassign } = useEditorAssignment();
+
+    return (
+        <div className="flex items-center gap-1">
+            <Select
+                value={current ? String(current.id) : undefined}
+                onValueChange={(value) => assign(orderDetailId, Number(value))}
+            >
+                <SelectTrigger className="w-40">
+                    <SelectValue placeholder="Sin asignar" />
+                </SelectTrigger>
+                <SelectContent>
+                    {editors.map((editor) => (
+                        <SelectItem key={editor.id} value={String(editor.id)}>
+                            {editor.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {current && (
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    title="Desasignar editor"
+                    onClick={() => unassign(orderDetailId)}
+                >
+                    <X className="h-4 w-4" />
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/edition/components/classroom-table.tsx
+++ b/resources/js/pages/edition/components/classroom-table.tsx
@@ -1,0 +1,137 @@
+import { Badge } from '@/components/ui/badge';
+import {
+    Table,
+    TableBody,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import {
+    AssignableEditor,
+    BulkAssignEditorDialog,
+    PhotoProduct,
+} from '@/features/editor-assignment/BulkAssignEditorDialog';
+import { EditionRow } from './edition-row';
+import { TotalsFooter } from './totals-footer';
+
+export type EditingStatusValue = 'pendiente' | 'editada' | 'ok' | 'a_corregir';
+
+export interface EditionAccessoryTotals {
+    carpeta: number;
+    banda: number;
+    medalla: number;
+    taza: number;
+    guantes: number;
+    escarapela: number;
+}
+
+export interface EditionAccessoryFlags {
+    carpeta: boolean;
+    banda: boolean;
+    medalla: boolean;
+    taza: boolean;
+    guantes: boolean;
+    escarapela: boolean;
+}
+
+export interface EditionRowData {
+    id: number;
+    order_id: number;
+    photo_size: string | null;
+    diseno: string | null;
+    child_name: string | null;
+    editing_status: EditingStatusValue;
+    note: string | null;
+    allowed_targets: EditingStatusValue[];
+    is_first_of_order: boolean;
+    editor?: { id: number; name: string } | null;
+    modelo_cuadro?: string | null;
+    color?: string | null;
+    banda_talle?: string | null;
+    observaciones_generales?: Note[];
+    accessories?: EditionAccessoryFlags;
+}
+
+export interface EditionClassroom {
+    id: number;
+    name: string;
+    rows: EditionRowData[];
+    totals?: EditionAccessoryTotals;
+}
+
+export interface EditionSchool {
+    id: number;
+    name: string;
+    classrooms: EditionClassroom[];
+}
+
+export function ClassroomTable({
+    classroom,
+    canManage,
+    editors,
+    photoProducts,
+}: {
+    classroom: EditionClassroom;
+    canManage: boolean;
+    editors: AssignableEditor[];
+    photoProducts: PhotoProduct[];
+}) {
+    return (
+        <div className="rounded-xl border border-input">
+            <header className="flex flex-wrap items-center justify-between gap-2 border-b border-input p-4">
+                <div className="flex items-center gap-2">
+                    <h3 className="font-medium">{classroom.name}</h3>
+                    <Badge variant="secondary">{classroom.rows.length}</Badge>
+                </div>
+                {canManage && (
+                    <BulkAssignEditorDialog
+                        assignableEditors={editors}
+                        photoProducts={photoProducts}
+                        classroomId={classroom.id}
+                    />
+                )}
+            </header>
+
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Pedido</TableHead>
+                        <TableHead>Niño</TableHead>
+                        <TableHead>Tamaño de foto</TableHead>
+                        <TableHead>Diseño</TableHead>
+                        <TableHead>Modelo cuadro</TableHead>
+                        <TableHead>Color</TableHead>
+                        <TableHead>Talle banda</TableHead>
+                        {canManage && (
+                            <>
+                                <TableHead>Carpeta</TableHead>
+                                <TableHead>Banda</TableHead>
+                                <TableHead>Medalla</TableHead>
+                                <TableHead>Taza</TableHead>
+                                <TableHead>Guantes</TableHead>
+                                <TableHead>Escarapela</TableHead>
+                            </>
+                        )}
+                        <TableHead>Notas</TableHead>
+                        <TableHead>Observaciones generales</TableHead>
+                        <TableHead>Estado</TableHead>
+                        {canManage && <TableHead>Editor asignado</TableHead>}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {classroom.rows.map((row) => (
+                        <EditionRow
+                            key={row.id}
+                            row={row}
+                            canManage={canManage}
+                            editors={editors}
+                        />
+                    ))}
+                </TableBody>
+                {canManage && classroom.totals && (
+                    <TotalsFooter totals={classroom.totals} />
+                )}
+            </Table>
+        </div>
+    );
+}

--- a/resources/js/pages/edition/components/edition-row.tsx
+++ b/resources/js/pages/edition/components/edition-row.tsx
@@ -1,0 +1,137 @@
+import { Badge } from '@/components/ui/badge';
+import { TableCell, TableRow } from '@/components/ui/table';
+import { AssignableEditor } from '@/features/editor-assignment/BulkAssignEditorDialog';
+import { AssignmentControl } from './assignment-control';
+import { EditingStatusValue, EditionRowData } from './classroom-table';
+import { TransitionControl } from './transition-control';
+
+const STATUS_LABELS: Record<EditingStatusValue, string> = {
+    pendiente: 'Pendiente',
+    editada: 'Editada',
+    ok: 'Ok',
+    a_corregir: 'A corregir',
+};
+
+const STATUS_VARIANTS: Record<
+    EditingStatusValue,
+    'outline' | 'default' | 'warning'
+> = {
+    pendiente: 'outline',
+    editada: 'default',
+    ok: 'default',
+    a_corregir: 'warning',
+};
+
+const yesNo = (value: boolean | undefined) => (value ? 'Sí' : 'No');
+
+/**
+ * One row per photo-editable order detail. Order-level columns (modelo
+ * cuadro, color, talle banda, accesorios, observaciones generales) only
+ * render on the first row of each order — blank on the rest — to avoid
+ * repeating order data across its rows.
+ */
+export function EditionRow({
+    row,
+    canManage,
+    editors,
+}: {
+    row: EditionRowData;
+    canManage: boolean;
+    editors: AssignableEditor[];
+}) {
+    const first = row.is_first_of_order;
+
+    return (
+        <TableRow>
+            <TableCell>
+                <a
+                    href={route('orders.show', { order: row.order_id })}
+                    className="underline-offset-2 hover:underline"
+                >
+                    #{row.order_id}
+                </a>
+            </TableCell>
+            <TableCell>{row.child_name ?? '—'}</TableCell>
+            <TableCell>{row.photo_size ?? '—'}</TableCell>
+            <TableCell>{row.diseno ?? '—'}</TableCell>
+            <TableCell>{first ? (row.modelo_cuadro ?? '—') : ''}</TableCell>
+            <TableCell>{first ? (row.color ?? '—') : ''}</TableCell>
+            <TableCell>{first ? (row.banda_talle ?? '—') : ''}</TableCell>
+            {canManage && (
+                <>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.carpeta)
+                            : ''}
+                    </TableCell>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.banda)
+                            : ''}
+                    </TableCell>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.medalla)
+                            : ''}
+                    </TableCell>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.taza)
+                            : ''}
+                    </TableCell>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.guantes)
+                            : ''}
+                    </TableCell>
+                    <TableCell>
+                        {first && row.accessories
+                            ? yesNo(row.accessories.escarapela)
+                            : ''}
+                    </TableCell>
+                </>
+            )}
+            <TableCell className="max-w-50 truncate">{row.note}</TableCell>
+            <TableCell className="max-w-50">
+                {!first ? (
+                    ''
+                ) : row.observaciones_generales &&
+                  row.observaciones_generales.length > 0 ? (
+                    <ul className="flex flex-col gap-0.5 text-xs text-gray-500">
+                        {row.observaciones_generales.map((note) => (
+                            <li
+                                key={note.id}
+                                className="truncate"
+                                title={note.body}
+                            >
+                                {note.body}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    '—'
+                )}
+            </TableCell>
+            <TableCell>
+                <div className="flex flex-col items-start gap-1">
+                    <Badge variant={STATUS_VARIANTS[row.editing_status]}>
+                        {STATUS_LABELS[row.editing_status]}
+                    </Badge>
+                    <TransitionControl
+                        orderDetailId={row.id}
+                        allowedTargets={row.allowed_targets}
+                    />
+                </div>
+            </TableCell>
+            {canManage && (
+                <TableCell>
+                    <AssignmentControl
+                        orderDetailId={row.id}
+                        editors={editors}
+                        current={row.editor ?? null}
+                    />
+                </TableCell>
+            )}
+        </TableRow>
+    );
+}

--- a/resources/js/pages/edition/components/totals-footer.tsx
+++ b/resources/js/pages/edition/components/totals-footer.tsx
@@ -1,0 +1,25 @@
+import { TableCell, TableFooter, TableRow } from '@/components/ui/table';
+import { EditionAccessoryTotals } from './classroom-table';
+
+/**
+ * Per-classroom accessory totals (carpeta/banda/medalla/taza + the inert
+ * guantes/escarapela columns), counted once per order by the backend.
+ * Manager-only view: aligned under the accessory columns, which only render
+ * for `canManage`.
+ */
+export function TotalsFooter({ totals }: { totals: EditionAccessoryTotals }) {
+    return (
+        <TableFooter>
+            <TableRow>
+                <TableCell colSpan={7}>Totales</TableCell>
+                <TableCell>{totals.carpeta}</TableCell>
+                <TableCell>{totals.banda}</TableCell>
+                <TableCell>{totals.medalla}</TableCell>
+                <TableCell>{totals.taza}</TableCell>
+                <TableCell>{totals.guantes}</TableCell>
+                <TableCell>{totals.escarapela}</TableCell>
+                <TableCell colSpan={4} />
+            </TableRow>
+        </TableFooter>
+    );
+}

--- a/resources/js/pages/edition/components/transition-control.tsx
+++ b/resources/js/pages/edition/components/transition-control.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import { useEditingStatusTransition } from '../hooks/use-editing-status-transition';
+import { EditingStatusValue } from './classroom-table';
+
+const TARGET_LABELS: Record<EditingStatusValue, string> = {
+    pendiente: 'Pendiente',
+    editada: 'Editada',
+    ok: 'Ok',
+    a_corregir: 'A corregir',
+};
+
+/**
+ * Renders one button per legal target status for the current row and
+ * actor — `allowed_targets` already reflects role/assignment gating, so an
+ * empty list (nothing reachable) simply renders nothing.
+ */
+export function TransitionControl({
+    orderDetailId,
+    allowedTargets,
+}: {
+    orderDetailId: number;
+    allowedTargets: EditingStatusValue[];
+}) {
+    const { transition } = useEditingStatusTransition();
+
+    if (allowedTargets.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap gap-1">
+            {allowedTargets.map((target) => (
+                <Button
+                    key={target}
+                    size="sm"
+                    variant="outline"
+                    title={`Pasar a "${TARGET_LABELS[target]}"`}
+                    onClick={() => transition(orderDetailId, target)}
+                >
+                    {TARGET_LABELS[target]}
+                    <ArrowRight className="ml-1 h-3 w-3" />
+                </Button>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/pages/edition/hooks/use-editing-status-transition.ts
+++ b/resources/js/pages/edition/hooks/use-editing-status-transition.ts
@@ -1,0 +1,28 @@
+import { router } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+/**
+ * Per-row editing status transition, reusing the existing
+ * `/order-details/{orderDetail}/editing-status` endpoint (#176). The set of
+ * legal targets is computed server-side per row (`allowed_targets`).
+ */
+export function useEditingStatusTransition() {
+    const transition = (orderDetailId: number, status: string) => {
+        router.post(
+            route('editing-status.store', { orderDetail: orderDetailId }),
+            { status },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onSuccess: () => toast.success('Estado de edición actualizado'),
+                onError: (errors) =>
+                    toast.error(
+                        Object.values(errors)[0] ??
+                            'No se pudo actualizar el estado',
+                    ),
+            },
+        );
+    };
+
+    return { transition };
+}

--- a/resources/js/pages/edition/hooks/use-editor-assignment.ts
+++ b/resources/js/pages/edition/hooks/use-editor-assignment.ts
@@ -1,0 +1,43 @@
+import { router } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+/**
+ * Individual editor assignment for a single order detail row, reusing the
+ * existing `/editor-assignments` write endpoints (#175).
+ */
+export function useEditorAssignment() {
+    const assign = (orderDetailId: number, editorId: number) => {
+        router.post(
+            route('editor-assignments.store'),
+            { order_detail_id: orderDetailId, editor_id: editorId },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onSuccess: () => toast.success('Editor asignado'),
+                onError: (errors) =>
+                    toast.error(
+                        Object.values(errors)[0] ??
+                            'No se pudo asignar el editor',
+                    ),
+            },
+        );
+    };
+
+    const unassign = (orderDetailId: number) => {
+        router.delete(
+            route('editor-assignments.destroy', { orderDetail: orderDetailId }),
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onSuccess: () => toast.success('Editor desasignado'),
+                onError: (errors) =>
+                    toast.error(
+                        Object.values(errors)[0] ??
+                            'No se pudo desasignar el editor',
+                    ),
+            },
+        );
+    };
+
+    return { assign, unassign };
+}

--- a/resources/js/pages/edition/index.tsx
+++ b/resources/js/pages/edition/index.tsx
@@ -1,0 +1,74 @@
+import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    AssignableEditor,
+    PhotoProduct,
+} from '@/features/editor-assignment/BulkAssignEditorDialog';
+import AppLayout from '@/layouts/app-layout';
+import { BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/react';
+import { ClassroomTable, EditionSchool } from './components/classroom-table';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Edición',
+        href: route('edition.index'),
+    },
+];
+
+export default function Edition({
+    schools,
+    canManage,
+    editors,
+    photoProducts,
+}: PageProps<{
+    schools: EditionSchool[];
+    canManage: boolean;
+    editors: AssignableEditor[];
+    photoProducts: PhotoProduct[];
+}>) {
+    const hasRows = schools.some((school) =>
+        school.classrooms.some((classroom) => classroom.rows.length > 0),
+    );
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Edición" />
+
+            <section className="flex flex-col gap-8 p-4 md:p-6">
+                {!hasRows ? (
+                    <Card>
+                        <CardHeader className="text-center">
+                            <CardTitle>Nada para editar</CardTitle>
+                            <CardDescription>
+                                No hay fotos pendientes de edición por el
+                                momento.
+                            </CardDescription>
+                        </CardHeader>
+                    </Card>
+                ) : (
+                    schools.map((school) => (
+                        <div key={school.id} className="flex flex-col gap-4">
+                            <h2 className="text-xl font-semibold">
+                                {school.name}
+                            </h2>
+                            {school.classrooms.map((classroom) => (
+                                <ClassroomTable
+                                    key={classroom.id}
+                                    classroom={classroom}
+                                    canManage={canManage}
+                                    editors={editors}
+                                    photoProducts={photoProducts}
+                                />
+                            ))}
+                        </div>
+                    ))
+                )}
+            </section>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/edition/tests/classroom-table.test.tsx
+++ b/resources/js/pages/edition/tests/classroom-table.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ClassroomTable,
+    EditionClassroom,
+} from '../components/classroom-table';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/features/editor-assignment/BulkAssignEditorDialog', () => ({
+    BulkAssignEditorDialog: () => <div data-testid="bulk-assign-dialog" />,
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.order ?? ''}`,
+);
+
+const editors = [{ id: 1, name: 'Vale' }];
+const photoProducts = [{ id: 1, name: 'Foto 15x21' }];
+
+const classroom: EditionClassroom = {
+    id: 1,
+    name: '5 A',
+    rows: [
+        {
+            id: 1,
+            order_id: 10,
+            photo_size: 'Foto 15x21',
+            diseno: 'Individual',
+            child_name: 'Lola',
+            editing_status: 'pendiente',
+            note: null,
+            allowed_targets: [],
+            is_first_of_order: true,
+            editor: null,
+            modelo_cuadro: 'Moldura fina',
+            color: 'Negro',
+            banda_talle: 'M',
+            observaciones_generales: [],
+            accessories: {
+                carpeta: true,
+                banda: false,
+                medalla: false,
+                taza: false,
+                guantes: false,
+                escarapela: false,
+            },
+        },
+    ],
+    totals: {
+        carpeta: 1,
+        banda: 0,
+        medalla: 0,
+        taza: 0,
+        guantes: 0,
+        escarapela: 0,
+    },
+};
+
+const MANAGER_ONLY_HEADERS = [
+    'Carpeta',
+    'Banda',
+    'Medalla',
+    'Taza',
+    'Guantes',
+    'Escarapela',
+    'Editor asignado',
+];
+
+describe('ClassroomTable', () => {
+    it('renders the full column set, including totals, for a manager (canManage) view', () => {
+        render(
+            <ClassroomTable
+                classroom={classroom}
+                canManage={true}
+                editors={editors}
+                photoProducts={photoProducts}
+            />,
+        );
+
+        for (const header of MANAGER_ONLY_HEADERS) {
+            expect(screen.getByText(header)).toBeTruthy();
+        }
+        expect(screen.getByText('Totales')).toBeTruthy();
+    });
+
+    it('renders the reduced column set, without totals, for the editor view', () => {
+        render(
+            <ClassroomTable
+                classroom={classroom}
+                canManage={false}
+                editors={editors}
+                photoProducts={photoProducts}
+            />,
+        );
+
+        for (const header of MANAGER_ONLY_HEADERS) {
+            expect(screen.queryByText(header)).toBeNull();
+        }
+        expect(screen.queryByText('Totales')).toBeNull();
+        // Columns common to every role still render
+        expect(screen.getByText('Pedido')).toBeTruthy();
+        expect(screen.getByText('Talle banda')).toBeTruthy();
+    });
+});

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EditionRowData } from '../components/classroom-table';
+import { EditionRow } from '../components/edition-row';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.order ?? ''}`,
+);
+
+const editors = [{ id: 1, name: 'Vale' }];
+
+const makeRow = (overrides: Partial<EditionRowData> = {}): EditionRowData => ({
+    id: 1,
+    order_id: 10,
+    photo_size: 'Foto 15x21',
+    diseno: 'Individual',
+    child_name: 'Lola',
+    editing_status: 'pendiente',
+    note: 'Nota de fila',
+    allowed_targets: [],
+    is_first_of_order: true,
+    editor: null,
+    modelo_cuadro: 'Moldura fina',
+    color: 'Negro',
+    banda_talle: 'M',
+    observaciones_generales: [],
+    accessories: {
+        carpeta: true,
+        banda: false,
+        medalla: true,
+        taza: false,
+        guantes: false,
+        escarapela: false,
+    },
+    ...overrides,
+});
+
+function renderRow(row: EditionRowData, canManage: boolean) {
+    return render(
+        <table>
+            <tbody>
+                <EditionRow row={row} canManage={canManage} editors={editors} />
+            </tbody>
+        </table>,
+    );
+}
+
+describe('EditionRow', () => {
+    it('renders the reduced column set for the editor role: no assigned-editor and no accessory columns', () => {
+        renderRow(makeRow(), false);
+
+        // banda_talle is present for every role
+        expect(screen.getByText('M')).toBeTruthy();
+        // Accessory Sí/No cells never render outside canManage
+        expect(screen.queryByText('Sí')).toBeNull();
+        expect(screen.queryByText('No')).toBeNull();
+        // No editor assignment control (Radix combobox trigger)
+        expect(screen.queryByRole('combobox')).toBeNull();
+    });
+
+    it('renders the full column set for a manager role: accessory flags and assignment control', () => {
+        renderRow(makeRow(), true);
+
+        expect(screen.getByText('M')).toBeTruthy();
+        expect(screen.getAllByText('Sí')).toHaveLength(2); // carpeta, medalla
+        expect(screen.getAllByText('No')).toHaveLength(4); // banda, taza, guantes, escarapela
+        expect(screen.getByRole('combobox')).toBeTruthy();
+    });
+
+    it('renders order-level cells (modelo cuadro, color, accessories) only on the first row of the order', () => {
+        const { container } = renderRow(
+            makeRow({ is_first_of_order: false }),
+            true,
+        );
+
+        const row = within(container).getByRole('row');
+        const cells = within(row).getAllByRole('cell');
+
+        // modelo cuadro / color / banda talle cells are blank, not the values
+        expect(within(row).queryByText('Moldura fina')).toBeNull();
+        expect(within(row).queryByText('Negro')).toBeNull();
+        expect(within(row).queryByText('M')).toBeNull();
+        // Accessory flags are blank too, not "Sí"/"No"
+        expect(within(row).queryByText('Sí')).toBeNull();
+        expect(within(row).queryByText('No')).toBeNull();
+
+        expect(cells[4].textContent).toBe(''); // modelo cuadro
+        expect(cells[5].textContent).toBe(''); // color
+        expect(cells[6].textContent).toBe(''); // banda talle
+    });
+
+    it('renders order-level cells on the first row of the order', () => {
+        renderRow(makeRow({ is_first_of_order: true }), true);
+
+        expect(screen.getByText('Moldura fina')).toBeTruthy();
+        expect(screen.getByText('Negro')).toBeTruthy();
+        expect(screen.getByText('M')).toBeTruthy();
+    });
+});

--- a/resources/js/pages/edition/tests/transition-control.test.tsx
+++ b/resources/js/pages/edition/tests/transition-control.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TransitionControl } from '../components/transition-control';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: vi.fn() },
+}));
+
+vi.stubGlobal('route', (name: string) => `http://localhost/${name}`);
+
+describe('TransitionControl', () => {
+    it('renders exactly the allowed target statuses and nothing else', () => {
+        render(
+            <TransitionControl
+                orderDetailId={1}
+                allowedTargets={['ok', 'a_corregir']}
+            />,
+        );
+
+        const buttons = screen.getAllByRole('button');
+
+        expect(buttons).toHaveLength(2);
+        expect(screen.getByRole('button', { name: /Ok/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /A corregir/ })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: /Editada/ })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Pendiente/ })).toBeNull();
+    });
+
+    it('renders a single button for a single allowed target', () => {
+        render(
+            <TransitionControl
+                orderDetailId={2}
+                allowedTargets={['editada']}
+            />,
+        );
+
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+        expect(screen.getByRole('button', { name: /Editada/ })).toBeTruthy();
+    });
+
+    it('renders nothing when there are no allowed targets', () => {
+        const { container } = render(
+            <TransitionControl orderDetailId={3} allowedTargets={[]} />,
+        );
+
+        expect(container.firstChild).toBeNull();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\BO\DetailPriorityController;
 use App\Http\Controllers\BO\DetailProductionStatusController;
 use App\Http\Controllers\BO\DetailVariantController;
 use App\Http\Controllers\BO\EditingStatusController;
+use App\Http\Controllers\BO\EditionController;
 use App\Http\Controllers\BO\EditorAssignmentController;
 use App\Http\Controllers\BO\NoteController;
 use App\Http\Controllers\BO\OrderController;
@@ -67,6 +68,7 @@ Route::middleware(['auth', 'role:master,administración,oficina,editor'])->group
     Route::post('/classrooms/{classroom}/photos', [PhotoController::class, 'store'])->name('photos.store');
     Route::delete('/photos/{photo}', [PhotoController::class, 'destroy'])->name('photos.destroy');
     Route::post('/order-details/{orderDetail}/editing-status', [EditingStatusController::class, 'store'])->name('editing-status.store');
+    Route::get('/edition', [EditionController::class, 'index'])->name('edition.index');
 });
 
 // Producción y stock: también accesibles para el rol taller

--- a/tests/Feature/EditingStatusTest.php
+++ b/tests/Feature/EditingStatusTest.php
@@ -361,3 +361,65 @@ it('appends a full history through the editing status cycle', function () {
         ])
         ->and($detail->refresh()->currentEditingStatus())->toBe(EditingStatus::Ok);
 });
+
+// EditingStatus::allowedTargets() — single source of truth for the
+// transition matrix (refactored for #177's board), unit-tested directly
+// against every branch, not just through the HTTP endpoint above.
+
+it('computes the allowed targets for every branch of the transition matrix', function (
+    EditingStatus $current,
+    bool $isManager,
+    bool $isAssignedEditor,
+    bool $productionEnabled,
+    array $expected,
+) {
+    expect(EditingStatus::allowedTargets($current, $isManager, $isAssignedEditor, $productionEnabled))
+        ->toBe($expected);
+})->with([
+    // Pendiente -> Editada only for the assigned editor once production is enabled
+    'pendiente, assigned editor, production enabled' => [
+        EditingStatus::Pendiente, false, true, true, [EditingStatus::Editada],
+    ],
+    'pendiente, assigned editor, production not enabled' => [
+        EditingStatus::Pendiente, false, true, false, [],
+    ],
+    'pendiente, not the assigned editor, production enabled' => [
+        EditingStatus::Pendiente, false, false, true, [],
+    ],
+    'pendiente, manager (never assigned)' => [
+        EditingStatus::Pendiente, true, false, true, [],
+    ],
+
+    // Editada -> {Ok, ACorregir} only for a manager
+    'editada, manager' => [
+        EditingStatus::Editada, true, false, true, [EditingStatus::Ok, EditingStatus::ACorregir],
+    ],
+    'editada, assigned editor (not a manager)' => [
+        EditingStatus::Editada, false, true, true, [],
+    ],
+    'editada, neither manager nor assigned editor' => [
+        EditingStatus::Editada, false, false, true, [],
+    ],
+
+    // Ok -> ACorregir only for a manager
+    'ok, manager' => [
+        EditingStatus::Ok, true, false, true, [EditingStatus::ACorregir],
+    ],
+    'ok, assigned editor (not a manager)' => [
+        EditingStatus::Ok, false, true, true, [],
+    ],
+    'ok, neither manager nor assigned editor' => [
+        EditingStatus::Ok, false, false, true, [],
+    ],
+
+    // ACorregir -> Editada only for the assigned editor
+    'a_corregir, assigned editor' => [
+        EditingStatus::ACorregir, false, true, true, [EditingStatus::Editada],
+    ],
+    'a_corregir, manager (not the assigned editor)' => [
+        EditingStatus::ACorregir, true, false, true, [],
+    ],
+    'a_corregir, neither manager nor assigned editor' => [
+        EditingStatus::ACorregir, false, false, true, [],
+    ],
+]);

--- a/tests/Feature/EditionTest.php
+++ b/tests/Feature/EditionTest.php
@@ -12,6 +12,7 @@ use App\Models\OrderEditingStatusChange;
 use App\Models\Product;
 use App\Models\School;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
 
 use function Pest\Laravel\get;
@@ -358,4 +359,122 @@ it('groups rows by school and then by classroom', function () {
         expect($classroomGroup)->not->toBeNull()
             ->and(collect($classroomGroup['rows'])->pluck('id')->all())->toBe([$detail->id]);
     });
+});
+
+// allowed_targets per row wiring (code-review F1, REQUIRED 2)
+
+it('reports no allowed targets for a manager viewing a pendiente row', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $detail->id);
+
+        expect($row['allowed_targets'])->toBe([]);
+    });
+});
+
+it('allows the assigned editor to move a pendiente row to editada once production is enabled', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    test()->actingAs($editor);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $detail->id);
+
+        expect($row['allowed_targets'])->toBe(['editada']);
+    });
+});
+
+it('reports no allowed targets for the assigned editor on a pendiente row without production enabled', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    test()->actingAs($editor);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $detail->id);
+
+        expect($row['allowed_targets'])->toBe([]);
+    });
+});
+
+it('allows the assigned editor to move an a_corregir row back to editada', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+    OrderEditingStatusChange::create([
+        'order_detail_id' => $detail->id,
+        'status' => EditingStatus::ACorregir,
+        'changed_by' => $manager->id,
+        'changed_at' => now(),
+    ]);
+
+    test()->actingAs($editor);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $detail->id);
+
+        expect($row['editing_status'])->toBe('a_corregir')
+            ->and($row['allowed_targets'])->toBe(['editada']);
+    });
+});
+
+// N+1 guard (code-review F1, REQUIRED 1): eager-loading `editingStatusChanges`
+// must yield a single query for the whole board, not one per row.
+
+it('does not issue a per-row editing status query when building the board', function () {
+    $manager = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $details = OrderDetail::factory()->count(3)->create(['product_id' => $product->id]);
+
+    foreach ($details as $detail) {
+        OrderEditingStatusChange::create([
+            'order_detail_id' => $detail->id,
+            'status' => EditingStatus::Editada,
+            'changed_by' => $manager->id,
+            'changed_at' => now(),
+        ]);
+    }
+
+    $statusQueries = 0;
+    DB::listen(function ($query) use (&$statusQueries) {
+        if (str_contains($query->sql, 'order_editing_status_changes')) {
+            $statusQueries++;
+        }
+    });
+
+    get(route('edition.index'))->assertOk();
+
+    expect($statusQueries)->toBe(1);
 });

--- a/tests/Feature/EditionTest.php
+++ b/tests/Feature/EditionTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\EditingStatus;
+use App\Enums\UserRole;
+use App\Models\Classroom;
+use App\Models\EditorOrderDetailAssignment;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\OrderEditingStatusChange;
+use App\Models\Product;
+use App\Models\School;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+
+/**
+ * Locates a mapped row by order_detail id inside the schools -> classrooms
+ * -> rows Inertia payload.
+ *
+ * @param  array<int, array<string, mixed>>  $schools
+ * @return array<string, mixed>
+ */
+function findEditionRow(array $schools, int $detailId): ?array
+{
+    foreach ($schools as $school) {
+        foreach ($school['classrooms'] as $classroom) {
+            foreach ($classroom['rows'] as $row) {
+                if ($row['id'] === $detailId) {
+                    return $row;
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+// Route access (criterion 4 of #177, behavior beyond RoleAccessTest's matrix)
+
+it('allows master, administración, oficina and editor into the edition board', function (UserRole $role) {
+    actingAsRole($role);
+
+    get(route('edition.index'))->assertOk();
+})->with([
+    'master' => [UserRole::Master],
+    'administración' => [UserRole::Admin],
+    'oficina' => [UserRole::Office],
+    'editor' => [UserRole::Editor],
+]);
+
+it('forbids taller from the edition board', function () {
+    actingAsRole(UserRole::Worker);
+
+    get(route('edition.index'))->assertForbidden();
+});
+
+// Row scope: one per photo-editable order detail (criterion 1)
+
+it('lists one row per photo-editable order detail and excludes non-photo products', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->create();
+    $photoProduct1 = Product::factory()->create(['has_photo' => true]);
+    $photoProduct2 = Product::factory()->create(['has_photo' => true]);
+    $nonPhotoProduct = Product::factory()->create(['has_photo' => false]);
+
+    $detail1 = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $photoProduct1->id]);
+    $detail2 = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $photoProduct2->id]);
+    OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $nonPhotoProduct->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail1, $detail2) {
+        $schools = $page->toArray()['props']['schools'];
+        $rowIds = collect($schools)
+            ->pluck('classrooms')->flatten(1)
+            ->pluck('rows')->flatten(1)
+            ->pluck('id');
+
+        expect($rowIds->all())->toEqualCanonicalizing([$detail1->id, $detail2->id]);
+    });
+});
+
+// Visibility: only non-delivered, non-cancelled orders (criterion 2)
+
+it('excludes delivered details, recycled details and details of cancelled orders', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+
+    $visible = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $delivered = OrderDetail::factory()->delivered()->create(['product_id' => $product->id]);
+    $recycled = OrderDetail::factory()->recycled()->create(['product_id' => $product->id]);
+    $cancelledOrder = Order::factory()->cancelled()->create();
+    $cancelled = OrderDetail::factory()->create(['order_id' => $cancelledOrder->id, 'product_id' => $product->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($visible, $delivered, $recycled, $cancelled) {
+        $schools = $page->toArray()['props']['schools'];
+        $rowIds = collect($schools)
+            ->pluck('classrooms')->flatten(1)
+            ->pluck('rows')->flatten(1)
+            ->pluck('id');
+
+        expect($rowIds->all())->toBe([$visible->id])
+            ->and($rowIds->all())->not->toContain($delivered->id, $recycled->id, $cancelled->id);
+    });
+});
+
+// Editor scope (criterion 4)
+
+it('scopes the editor role to only their own assigned rows', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $otherEditor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+
+    $ownDetail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $otherEditorDetail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $unassignedDetail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $ownDetail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $otherEditorDetail->id,
+        'editor_id' => $otherEditor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    test()->actingAs($editor);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($ownDetail, $otherEditorDetail, $unassignedDetail) {
+        $schools = $page->toArray()['props']['schools'];
+        $rowIds = collect($schools)
+            ->pluck('classrooms')->flatten(1)
+            ->pluck('rows')->flatten(1)
+            ->pluck('id');
+
+        expect($rowIds->all())->toBe([$ownDetail->id])
+            ->and($rowIds->all())->not->toContain($otherEditorDetail->id, $unassignedDetail->id);
+    });
+});
+
+// Role-conditional payload (criterion 5)
+
+it('omits the assigned-editor field, accessory flags and classroom totals from the editor payload', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    test()->actingAs($editor);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $props = $page->toArray()['props'];
+        $row = findEditionRow($props['schools'], $detail->id);
+
+        expect($props['canManage'])->toBeFalse()
+            ->and($row)->not->toBeNull()
+            ->and($row)->not->toHaveKey('editor')
+            ->and($row)->not->toHaveKey('accessories');
+
+        foreach ($props['schools'] as $school) {
+            foreach ($school['classrooms'] as $classroom) {
+                expect($classroom)->not->toHaveKey('totals');
+            }
+        }
+    });
+});
+
+it('includes the assigned-editor field, accessory flags and classroom totals for a manager view', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $editor->id,
+        'assigned_at' => now(),
+    ]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail, $editor) {
+        $props = $page->toArray()['props'];
+        $row = findEditionRow($props['schools'], $detail->id);
+
+        expect($props['canManage'])->toBeTrue()
+            ->and($row)->toHaveKey('editor')
+            ->and($row['editor']['id'])->toBe($editor->id)
+            ->and($row)->toHaveKey('accessories');
+
+        foreach ($props['schools'] as $school) {
+            foreach ($school['classrooms'] as $classroom) {
+                expect($classroom)->toHaveKey('totals');
+            }
+        }
+    });
+});
+
+// Accessory totals counted per order, not per row (criterion 6)
+
+it('counts accessory totals once per order, not once per photo row', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $photoProduct = Product::factory()->create(['has_photo' => true]);
+    $carpeta = Product::factory()->ofType('carpeta')->create();
+
+    // Two photo rows on the same order...
+    OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $photoProduct->id]);
+    OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $photoProduct->id]);
+    // ...plus one carpeta on that same order
+    OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $carpeta->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($classroom) {
+        $props = $page->toArray()['props'];
+        $classroomGroup = collect($props['schools'])->pluck('classrooms')->flatten(1)
+            ->firstWhere('id', $classroom->id);
+
+        expect($classroomGroup['totals']['carpeta'])->toBe(1);
+    });
+});
+
+// diseño derived column (criterion 3 backend note)
+
+it('derives diseño from the "Tipo de foto" variant entry, null when absent', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $withDiseno = OrderDetail::factory()->create([
+        'product_id' => $product->id,
+        'variant' => [
+            ['label' => 'Tipo de foto', 'value' => ['label' => 'Grupo']],
+        ],
+    ]);
+    $withoutDiseno = OrderDetail::factory()->create([
+        'product_id' => $product->id,
+        'variant' => [],
+    ]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($withDiseno, $withoutDiseno) {
+        $schools = $page->toArray()['props']['schools'];
+
+        expect(findEditionRow($schools, $withDiseno->id)['diseno'])->toBe('Grupo')
+            ->and(findEditionRow($schools, $withoutDiseno->id)['diseno'])->toBeNull();
+    });
+});
+
+// modelo cuadro / color / banda talle derived columns (criterion 3 backend note)
+
+it('derives modelo cuadro and color from the order mural, and banda talle for every role', function () {
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+    $manager = User::factory()->withRole(UserRole::Office)->create();
+
+    $order = Order::factory()->create();
+    $photoProduct = Product::factory()->create(['has_photo' => true]);
+    $photoDetail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $photoProduct->id]);
+
+    EditorOrderDetailAssignment::create([
+        'order_detail_id' => $photoDetail->id,
+        'editor_id' => $editor->id,
+        'assigned_by' => $manager->id,
+        'assigned_at' => now(),
+    ]);
+
+    $mural = Product::factory()->mural()->create(['name' => 'Moldura fina']);
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $mural->id,
+        'variant' => [['label' => 'Color', 'value' => ['label' => 'Negro']]],
+    ]);
+
+    $banda = Product::factory()->banda()->create();
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $banda->id,
+        'variant' => [['label' => 'Talle', 'value' => ['label' => 'M']]],
+    ]);
+
+    // Manager view
+    test()->actingAs($manager);
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($photoDetail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $photoDetail->id);
+
+        expect($row['modelo_cuadro'])->toBe('Moldura fina')
+            ->and($row['color'])->toBe('Negro')
+            ->and($row['banda_talle'])->toBe('M');
+    });
+
+    // Editor view: banda talle still present, unlike accessories/editor
+    test()->actingAs($editor);
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($photoDetail) {
+        $row = findEditionRow($page->toArray()['props']['schools'], $photoDetail->id);
+
+        expect($row['banda_talle'])->toBe('M');
+    });
+});
+
+// Current editing status per row (criterion 6 of #176, exposed on #177's board)
+
+it('reflects the current editing status per row, defaulting to pendiente', function () {
+    $actor = actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $pending = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $edited = OrderDetail::factory()->create(['product_id' => $product->id]);
+
+    OrderEditingStatusChange::create([
+        'order_detail_id' => $edited->id,
+        'status' => EditingStatus::Editada,
+        'changed_by' => $actor->id,
+        'changed_at' => now(),
+    ]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($pending, $edited) {
+        $schools = $page->toArray()['props']['schools'];
+
+        expect(findEditionRow($schools, $pending->id)['editing_status'])->toBe('pendiente')
+            ->and(findEditionRow($schools, $edited->id)['editing_status'])->toBe('editada');
+    });
+});
+
+// Grouping by school -> classroom (structural sanity, ties #177's core shape)
+
+it('groups rows by school and then by classroom', function () {
+    actingAsRole(UserRole::Office);
+
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
+    $product = Product::factory()->create(['has_photo' => true]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($school, $classroom, $detail) {
+        $schools = $page->toArray()['props']['schools'];
+        $schoolGroup = collect($schools)->firstWhere('id', $school->id);
+
+        expect($schoolGroup)->not->toBeNull();
+
+        $classroomGroup = collect($schoolGroup['classrooms'])->firstWhere('id', $classroom->id);
+
+        expect($classroomGroup)->not->toBeNull()
+            ->and(collect($classroomGroup['rows'])->pluck('id')->all())->toBe([$detail->id]);
+    });
+});


### PR DESCRIPTION
## Qué

Vista de BO agrupada por **escuela → curso**, con una fila por `order_detail` cuyo producto tiene foto. Expone la asignación de editor (#175) y el estado de edición (#176) desde una sola pantalla, siguiendo el patrón de `TrackingController` / `resources/js/pages/tracking/`. Visible para administración, oficina, editor y master (no taller); solo pedidos no entregados.

## Cambios

- **Backend**
  - `EditionController` de solo lectura + ruta `GET /edition` (grupo `master,administración,oficina,editor`) y entrada en el sidebar.
  - `OrderDetail::editorAssignment()` para poder eager-loadear el editor asignado sin violar `shouldBeStrict`.
  - Refactor: la matriz de transiciones de estado de edición pasa a `EditingStatus::allowedTargets()` (única fuente de verdad); la Action delega en ella, sin cambiar comportamiento ni mensajes.
- **Frontend**
  - `resources/js/pages/edition/**`: tablero agrupado por escuela/curso, columnas según rol, acciones de asignación (individual y masiva) y de transición de estado por fila. Reusa `BulkAssignEditorDialog` existente.

## Criterios de aceptación cubiertos

- Una fila por `order_detail` con foto; solo pedidos no entregados ni cancelados.
- El editor ve únicamente sus filas asignadas, con el set de columnas reducido (sin editor asignado, sin accesorios, sin pie de totales).
- Columnas derivadas desde `order_details`/`variant` sin duplicar datos: **diseño** = variante `Tipo de foto` (Individual/Grupo), **modelo cuadro** = nombre del producto mural, **color** = variante `Color`, **talle banda** = variante `Talle` (visible para todos los roles).
- Accesorios y totales por **tipo de producto**, contados **por pedido** (no por fila). `guantes`/`escarapela` no existen aún en el catálogo, por lo que sus columnas quedan inertes.
- Acciones de asignación (individual + masiva por escuela/curso) y de transición de estado según el rol, conectadas a los endpoints existentes.

## Notas

- La columna "diseño" no estaba definida en el issue; se resolvió por decisión del dueño como la variante `Tipo de foto`.
- El tope de resultados de la query (paginación/límite) queda pendiente como mejora futura, no incluido en este PR.

Closes #177