### PR TITLE
feat(edition): show notes and observaciones via hover tooltip

### DIFF
--- a/resources/js/pages/edition/components/edition-row.tsx
+++ b/resources/js/pages/edition/components/edition-row.tsx
@@ -1,5 +1,11 @@
 import { Badge } from '@/components/ui/badge';
 import { TableCell, TableRow } from '@/components/ui/table';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { AssignableEditor } from '@/features/editor-assignment/BulkAssignEditorDialog';
 import { AssignmentControl } from './assignment-control';
 import { EditingStatusValue, EditionRowData } from './classroom-table';
@@ -91,23 +97,45 @@ export function EditionRow({
                     </TableCell>
                 </>
             )}
-            <TableCell className="max-w-50 truncate">{row.note}</TableCell>
+            <TableCell className="max-w-50 truncate">
+                {row.note ? (
+                    <TooltipProvider delayDuration={0}>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span>{row.note}</span>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-70 wrap-break-word whitespace-pre-wrap">
+                                <p>{row.note}</p>
+                            </TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
+                ) : (
+                    row.note
+                )}
+            </TableCell>
             <TableCell className="max-w-50">
                 {!first ? (
                     ''
                 ) : row.observaciones_generales &&
                   row.observaciones_generales.length > 0 ? (
-                    <ul className="flex flex-col gap-0.5 text-xs text-gray-500">
-                        {row.observaciones_generales.map((note) => (
-                            <li
-                                key={note.id}
-                                className="truncate"
-                                title={note.body}
-                            >
-                                {note.body}
-                            </li>
-                        ))}
-                    </ul>
+                    <TooltipProvider delayDuration={0}>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <ul className="flex flex-col gap-0.5 text-xs text-gray-500">
+                                    {row.observaciones_generales.map((note) => (
+                                        <li key={note.id} className="truncate">
+                                            {note.body}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-70 wrap-break-word whitespace-pre-wrap">
+                                {row.observaciones_generales.map((note) => (
+                                    <p key={note.id}>{note.body}</p>
+                                ))}
+                            </TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
                 ) : (
                     '—'
                 )}

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -102,4 +102,62 @@ describe('EditionRow', () => {
         expect(screen.getByText('Negro')).toBeTruthy();
         expect(screen.getByText('M')).toBeTruthy();
     });
+
+    it('Notas cell exposes the full note through a tooltip trigger, not a native title', () => {
+        const { container } = renderRow(
+            makeRow({ note: 'Nota muy larga de producto' }),
+            false,
+        );
+
+        expect(screen.getByText('Nota muy larga de producto')).toBeTruthy();
+        expect(container.querySelector('[title]')).toBeNull();
+    });
+
+    it('Notas cell renders blank with no tooltip when the note is empty', () => {
+        const { container } = renderRow(makeRow({ note: null }), false);
+
+        const row = within(container).getByRole('row');
+        const cells = within(row).getAllByRole('cell');
+
+        // Notas is the cell right before Observaciones generales (last two
+        // cells outside canManage: Notas, Observaciones, Estado)
+        const notasCell = cells[cells.length - 3];
+        expect(notasCell.textContent).toBe('');
+        expect(container.querySelector('[title]')).toBeNull();
+    });
+
+    it('Observaciones generales shows every note body and drops the native title', () => {
+        const { container } = renderRow(
+            makeRow({
+                is_first_of_order: true,
+                observaciones_generales: [
+                    {
+                        id: 1,
+                        body: 'Primera observación',
+                        created_at: '2026-07-17T10:00:00Z',
+                    },
+                    {
+                        id: 2,
+                        body: 'Segunda observación',
+                        created_at: '2026-07-17T11:00:00Z',
+                    },
+                ],
+            }),
+            false,
+        );
+
+        expect(screen.getByText('Primera observación')).toBeTruthy();
+        expect(screen.getByText('Segunda observación')).toBeTruthy();
+        expect(container.querySelector('[title]')).toBeNull();
+    });
+
+    it('Observaciones generales renders — with no tooltip when the order has no notes', () => {
+        const { container } = renderRow(
+            makeRow({ is_first_of_order: true, observaciones_generales: [] }),
+            false,
+        );
+
+        expect(screen.getByText('—')).toBeTruthy();
+        expect(container.querySelector('[title]')).toBeNull();
+    });
 });

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { EditionRowData } from '../components/classroom-table';
 import { EditionRow } from '../components/edition-row';
@@ -103,13 +103,23 @@ describe('EditionRow', () => {
         expect(screen.getByText('M')).toBeTruthy();
     });
 
-    it('Notas cell exposes the full note through a tooltip trigger, not a native title', () => {
+    it('Notas cell shows the full note in the tooltip content when opened, not a native title', () => {
         const { container } = renderRow(
             makeRow({ note: 'Nota muy larga de producto' }),
             false,
         );
 
-        expect(screen.getByText('Nota muy larga de producto')).toBeTruthy();
+        // TooltipContent is not mounted until the tooltip opens.
+        expect(screen.queryByRole('tooltip')).toBeNull();
+        expect(container.querySelector('[title]')).toBeNull();
+
+        fireEvent.focus(screen.getByText('Nota muy larga de producto'));
+
+        // The opened TooltipContent carries the full note text.
+        const tooltip = screen.getByRole('tooltip');
+        expect(
+            within(tooltip).getByText('Nota muy larga de producto'),
+        ).toBeTruthy();
         expect(container.querySelector('[title]')).toBeNull();
     });
 
@@ -126,7 +136,7 @@ describe('EditionRow', () => {
         expect(container.querySelector('[title]')).toBeNull();
     });
 
-    it('Observaciones generales shows every note body and drops the native title', () => {
+    it('Observaciones generales shows every note body in the tooltip content when opened, and drops the native title', () => {
         const { container } = renderRow(
             makeRow({
                 is_first_of_order: true,
@@ -146,8 +156,16 @@ describe('EditionRow', () => {
             false,
         );
 
-        expect(screen.getByText('Primera observación')).toBeTruthy();
-        expect(screen.getByText('Segunda observación')).toBeTruthy();
+        // TooltipContent is not mounted until the tooltip opens.
+        expect(screen.queryByRole('tooltip')).toBeNull();
+        expect(container.querySelector('[title]')).toBeNull();
+
+        fireEvent.focus(screen.getByRole('list'));
+
+        // The opened TooltipContent carries every note body.
+        const tooltip = screen.getByRole('tooltip');
+        expect(within(tooltip).getByText('Primera observación')).toBeTruthy();
+        expect(within(tooltip).getByText('Segunda observación')).toBeTruthy();
         expect(container.querySelector('[title]')).toBeNull();
     });
 


### PR DESCRIPTION
## Resumen

En el tablero de Edición, la celda "Notas" (nota de producto) no tenía ninguna ayuda al pasar el cursor, y "Observaciones generales" solo usaba el atributo `title` nativo del navegador por cada línea. Se reemplazan ambos por un componente `Tooltip` de shadcn/ui que se muestra al hacer hover.

## Cambios

- Celda "Notas": muestra el texto completo de la nota en un `Tooltip` cuando hay contenido; si está vacía, no se muestra tooltip.
- Celda "Observaciones generales": un único `Tooltip` que lista todas las notas del pedido (no solo la línea truncada); se elimina el `title` nativo. Sin notas, sigue mostrando `—` sin tooltip.
- Solo cambia la presentación (hover → tooltip): no cambia qué datos se muestran ni de dónde vienen.

## Fuera de alcance

- No se permite editar ni crear notas desde el tooltip.
- No se tocan agrupamiento, columnas ni buscador (issues separados: #189).

## Pruebas

- Vitest: nuevos casos en `edition-row.test.tsx` que abren el tooltip y verifican el texto completo de la nota y todas las observaciones, más los casos de celda vacía (sin tooltip, sin `title`).

Closes #192