### PR TITLE
feat(edition): buscador y filtros por escuela, curso, editor y producto

### DIFF
--- a/app/Http/Controllers/BO/EditionController.php
+++ b/app/Http/Controllers/BO/EditionController.php
@@ -205,32 +205,34 @@ class EditionController extends Controller
             $row['editor'] = $editor !== null ? ['id' => $editor->id, 'name' => $editor->name] : null;
         }
 
-        if ($isFirstOfOrder) {
-            $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
-            $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
+        // Order-level fields are serialized on every row (not just the
+        // "first of order" one) because client-side filtering can hide the
+        // designated first row while keeping a sibling row of the same
+        // order; is_first_of_order is recomputed on the surviving rows.
+        $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
+        $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
 
-            $row['modelo_cuadro'] = $mural?->product?->name;
-            $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
-            // Not one of the "accessory columns" (carpeta/banda/medalla/taza
-            // presence flags): visible to every role, unlike $isManager below.
-            $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
-            $row['observaciones_generales'] = $order->notes->map(fn (Note $note) => [
-                'id' => $note->id,
-                'body' => $note->body,
-                'created_at' => $note->created_at->format('d/m/Y H:i'),
-            ])->values()->all();
+        $row['modelo_cuadro'] = $mural?->product?->name;
+        $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
+        // Not one of the "accessory columns" (carpeta/banda/medalla/taza
+        // presence flags): visible to every role, unlike $isManager below.
+        $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
+        $row['observaciones_generales'] = $order->notes->map(fn (Note $note) => [
+            'id' => $note->id,
+            'body' => $note->body,
+            'created_at' => $note->created_at->format('d/m/Y H:i'),
+        ])->values()->all();
 
-            if ($isManager) {
-                $row['accessories'] = [
-                    'carpeta' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'carpeta'),
-                    'banda' => $banda !== null,
-                    'medalla' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'medalla'),
-                    'taza' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'taza'),
-                    // Not in the product catalog yet (#177): rendered inert.
-                    'guantes' => false,
-                    'escarapela' => false,
-                ];
-            }
+        if ($isManager) {
+            $row['accessories'] = [
+                'carpeta' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'carpeta'),
+                'banda' => $banda !== null,
+                'medalla' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'medalla'),
+                'taza' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'taza'),
+                // Not in the product catalog yet (#177): rendered inert.
+                'guantes' => false,
+                'escarapela' => false,
+            ];
         }
 
         return $row;

--- a/app/Http/Controllers/BO/EditionController.php
+++ b/app/Http/Controllers/BO/EditionController.php
@@ -192,6 +192,8 @@ class EditionController extends Controller
             'photo_size' => $detail->product?->name,
             'diseno' => $this->variantLabel($detail->variant, 'Tipo de foto'),
             'child_name' => $order->child_name,
+            'photo_number' => $order->photo_number,
+            'variant_search' => $this->variantSearch($detail->variant),
             'editing_status' => $current->value,
             'note' => $detail->note,
             'allowed_targets' => array_map(fn (EditingStatus $status) => $status->value, $allowedTargets),
@@ -274,5 +276,19 @@ class EditionController extends Controller
         }
 
         return null;
+    }
+
+    /**
+     * Joins every non-null variant value label into a single searchable
+     * string, e.g. the "Tipo de foto" value for the photo product itself.
+     *
+     * @param  array<int, array{label: string, type?: string, value: array{label: string, color?: string}|null}>|null  $variant
+     */
+    private function variantSearch(?array $variant): string
+    {
+        return collect($variant ?? [])
+            ->map(fn (array $entry) => $entry['value']['label'] ?? null)
+            ->filter()
+            ->implode(' ');
     }
 }

--- a/resources/js/pages/edition/components/classroom-table.tsx
+++ b/resources/js/pages/edition/components/classroom-table.tsx
@@ -40,6 +40,8 @@ export interface EditionRowData {
     photo_size: string | null;
     diseno: string | null;
     child_name: string | null;
+    photo_number: number | null;
+    variant_search: string;
     editing_status: EditingStatusValue;
     note: string | null;
     allowed_targets: EditingStatusValue[];

--- a/resources/js/pages/edition/components/edition-filters.tsx
+++ b/resources/js/pages/edition/components/edition-filters.tsx
@@ -1,0 +1,144 @@
+import { Input } from '@/components/ui/input';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Search } from 'lucide-react';
+import { FilterOption } from '../hooks/use-edition-filters';
+
+const ALL = 'all';
+
+export function EditionFilters({
+    canManage,
+    search,
+    onSearchChange,
+    schoolId,
+    onSchoolChange,
+    classroomId,
+    onClassroomChange,
+    editorId,
+    onEditorChange,
+    productName,
+    onProductChange,
+    schoolOptions,
+    classroomOptions,
+    editorOptions,
+    productOptions,
+}: {
+    canManage: boolean;
+    search: string;
+    onSearchChange: (value: string) => void;
+    schoolId: number | null;
+    onSchoolChange: (value: number | null) => void;
+    classroomId: number | null;
+    onClassroomChange: (value: number | null) => void;
+    editorId: number | null;
+    onEditorChange: (value: number | null) => void;
+    productName: string | null;
+    onProductChange: (value: string | null) => void;
+    schoolOptions: FilterOption[];
+    classroomOptions: FilterOption[];
+    editorOptions: FilterOption[];
+    productOptions: string[];
+}) {
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <div className="relative min-w-0 flex-1 md:w-64 md:flex-none">
+                <Search className="absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                    placeholder="Buscar por foto, niño o diseño"
+                    value={search}
+                    onChange={(e) => onSearchChange(e.target.value)}
+                    className="pl-8"
+                />
+            </div>
+
+            <Select
+                value={schoolId !== null ? String(schoolId) : ALL}
+                onValueChange={(value) =>
+                    onSchoolChange(value === ALL ? null : Number(value))
+                }
+            >
+                <SelectTrigger className="min-w-0 md:w-48">
+                    <SelectValue placeholder="Escuela" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={ALL}>Todas las escuelas</SelectItem>
+                    {schoolOptions.map((school) => (
+                        <SelectItem value={String(school.id)} key={school.id}>
+                            {school.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <Select
+                value={classroomId !== null ? String(classroomId) : ALL}
+                onValueChange={(value) =>
+                    onClassroomChange(value === ALL ? null : Number(value))
+                }
+            >
+                <SelectTrigger className="min-w-0 md:w-48">
+                    <SelectValue placeholder="Curso" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={ALL}>Todos los cursos</SelectItem>
+                    {classroomOptions.map((classroom) => (
+                        <SelectItem
+                            value={String(classroom.id)}
+                            key={classroom.id}
+                        >
+                            {classroom.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            {canManage && (
+                <Select
+                    value={editorId !== null ? String(editorId) : ALL}
+                    onValueChange={(value) =>
+                        onEditorChange(value === ALL ? null : Number(value))
+                    }
+                >
+                    <SelectTrigger className="min-w-0 md:w-48">
+                        <SelectValue placeholder="Editor asignado" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={ALL}>Todos los editores</SelectItem>
+                        {editorOptions.map((editor) => (
+                            <SelectItem
+                                value={String(editor.id)}
+                                key={editor.id}
+                            >
+                                {editor.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+
+            <Select
+                value={productName ?? ALL}
+                onValueChange={(value) =>
+                    onProductChange(value === ALL ? null : value)
+                }
+            >
+                <SelectTrigger className="min-w-0 md:w-48">
+                    <SelectValue placeholder="Producto con foto" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={ALL}>Todos los productos</SelectItem>
+                    {productOptions.map((product) => (
+                        <SelectItem value={product} key={product}>
+                            {product}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}

--- a/resources/js/pages/edition/hooks/use-edition-filters.ts
+++ b/resources/js/pages/edition/hooks/use-edition-filters.ts
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { EditionRowData, EditionSchool } from '../components/classroom-table';
+
+export interface FilterOption {
+    id: number;
+    name: string;
+}
+
+interface EditionFilterState {
+    search: string;
+    schoolId: number | null;
+    classroomId: number | null;
+    editorId: number | null;
+    productName: string | null;
+}
+
+const DIACRITICS = /[̀-ͯ]/g;
+
+/** Lowercase and strip accents, so "jose" matches "José" like the backend search. */
+function normalize(text: string): string {
+    return text.toLowerCase().normalize('NFD').replace(DIACRITICS, '');
+}
+
+function matchesSearch(row: EditionRowData, query: string): boolean {
+    if (query === '') return true;
+
+    const haystack = [
+        row.photo_number ?? '',
+        row.child_name ?? '',
+        row.variant_search,
+        row.diseno ?? '',
+    ].join(' ');
+
+    return normalize(haystack).includes(normalize(query));
+}
+
+function matchesRow(
+    row: EditionRowData,
+    schoolId: number,
+    classroomId: number,
+    filters: EditionFilterState,
+    canManage: boolean,
+): boolean {
+    return (
+        (filters.schoolId === null || filters.schoolId === schoolId) &&
+        (filters.classroomId === null || filters.classroomId === classroomId) &&
+        (!canManage ||
+            filters.editorId === null ||
+            row.editor?.id === filters.editorId) &&
+        (filters.productName === null ||
+            row.photo_size === filters.productName) &&
+        matchesSearch(row, filters.search)
+    );
+}
+
+function filterSchools(
+    schools: EditionSchool[],
+    filters: EditionFilterState,
+    canManage: boolean,
+): EditionSchool[] {
+    return schools
+        .map((school) => ({
+            ...school,
+            classrooms: school.classrooms
+                .map((classroom) => ({
+                    ...classroom,
+                    rows: classroom.rows.filter((row) =>
+                        matchesRow(
+                            row,
+                            school.id,
+                            classroom.id,
+                            filters,
+                            canManage,
+                        ),
+                    ),
+                }))
+                .filter((classroom) => classroom.rows.length > 0),
+        }))
+        .filter((school) => school.classrooms.length > 0);
+}
+
+function dedupeById(options: FilterOption[]): FilterOption[] {
+    return Array.from(new Map(options.map((o) => [o.id, o])).values());
+}
+
+/** Client-side search + dropdown filters for the edition board (#194). */
+export function useEditionFilters(
+    schools: EditionSchool[],
+    canManage: boolean,
+) {
+    const [search, setSearch] = useState('');
+    const [schoolId, setSchoolId] = useState<number | null>(null);
+    const [classroomId, setClassroomId] = useState<number | null>(null);
+    const [editorId, setEditorId] = useState<number | null>(null);
+    const [productName, setProductName] = useState<string | null>(null);
+
+    const schoolOptions = dedupeById(
+        schools.map((school) => ({ id: school.id, name: school.name })),
+    );
+
+    const classroomOptions = dedupeById(
+        schools
+            .filter((school) => schoolId === null || school.id === schoolId)
+            .flatMap((school) =>
+                school.classrooms.map((c) => ({ id: c.id, name: c.name })),
+            ),
+    );
+
+    const allRows = schools.flatMap((s) => s.classrooms.flatMap((c) => c.rows));
+
+    const editorOptions = dedupeById(
+        allRows
+            .map((row) => row.editor)
+            .filter((editor): editor is FilterOption => editor != null),
+    );
+
+    const productOptions = Array.from(
+        new Set(
+            allRows
+                .map((row) => row.photo_size)
+                .filter((size): size is string => size != null),
+        ),
+    ).sort();
+
+    const filteredSchools = filterSchools(
+        schools,
+        { search, schoolId, classroomId, editorId, productName },
+        canManage,
+    );
+
+    return {
+        search,
+        setSearch,
+        schoolId,
+        setSchoolId,
+        classroomId,
+        setClassroomId,
+        editorId,
+        setEditorId,
+        productName,
+        setProductName,
+        schoolOptions,
+        classroomOptions,
+        editorOptions,
+        productOptions,
+        filteredSchools,
+    };
+}
+
+export { matchesRow, matchesSearch, normalize };

--- a/resources/js/pages/edition/hooks/use-edition-filters.ts
+++ b/resources/js/pages/edition/hooks/use-edition-filters.ts
@@ -53,6 +53,26 @@ function matchesRow(
     );
 }
 
+/**
+ * Recomputes is_first_of_order on the surviving rows of a classroom: the
+ * first surviving row of each order_id (in the existing sorted order) gets
+ * true, the rest false. The backend flag was computed against the full
+ * unfiltered classroom, so filtering can drop the original "first" row
+ * while keeping a sibling of the same order.
+ */
+function recomputeFirstOfOrder(rows: EditionRowData[]): EditionRowData[] {
+    const seenOrderIds = new Set<number>();
+
+    return rows.map((row) => {
+        const isFirstOfOrder = !seenOrderIds.has(row.order_id);
+        seenOrderIds.add(row.order_id);
+
+        return isFirstOfOrder === row.is_first_of_order
+            ? row
+            : { ...row, is_first_of_order: isFirstOfOrder };
+    });
+}
+
 function filterSchools(
     schools: EditionSchool[],
     filters: EditionFilterState,
@@ -64,13 +84,15 @@ function filterSchools(
             classrooms: school.classrooms
                 .map((classroom) => ({
                     ...classroom,
-                    rows: classroom.rows.filter((row) =>
-                        matchesRow(
-                            row,
-                            school.id,
-                            classroom.id,
-                            filters,
-                            canManage,
+                    rows: recomputeFirstOfOrder(
+                        classroom.rows.filter((row) =>
+                            matchesRow(
+                                row,
+                                school.id,
+                                classroom.id,
+                                filters,
+                                canManage,
+                            ),
                         ),
                     ),
                 }))
@@ -128,11 +150,25 @@ export function useEditionFilters(
         canManage,
     );
 
+    // Switching to a school that doesn't contain the currently selected
+    // classroom would otherwise silently yield "Sin resultados".
+    function handleSetSchoolId(newSchoolId: number | null) {
+        setSchoolId(newSchoolId);
+
+        if (newSchoolId === null) return;
+
+        const stillValid = schools
+            .find((school) => school.id === newSchoolId)
+            ?.classrooms.some((c) => c.id === classroomId);
+
+        if (!stillValid) setClassroomId(null);
+    }
+
     return {
         search,
         setSearch,
         schoolId,
-        setSchoolId,
+        setSchoolId: handleSetSchoolId,
         classroomId,
         setClassroomId,
         editorId,
@@ -146,5 +182,3 @@ export function useEditionFilters(
         filteredSchools,
     };
 }
-
-export { matchesRow, matchesSearch, normalize };

--- a/resources/js/pages/edition/index.tsx
+++ b/resources/js/pages/edition/index.tsx
@@ -12,6 +12,8 @@ import AppLayout from '@/layouts/app-layout';
 import { BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 import { ClassroomTable, EditionSchool } from './components/classroom-table';
+import { EditionFilters } from './components/edition-filters';
+import { useEditionFilters } from './hooks/use-edition-filters';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -35,11 +37,36 @@ export default function Edition({
         school.classrooms.some((classroom) => classroom.rows.length > 0),
     );
 
+    const filters = useEditionFilters(schools, canManage);
+    const hasFilteredRows = filters.filteredSchools.some((school) =>
+        school.classrooms.some((classroom) => classroom.rows.length > 0),
+    );
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Edición" />
 
             <section className="flex flex-col gap-8 p-4 md:p-6">
+                {hasRows && (
+                    <EditionFilters
+                        canManage={canManage}
+                        search={filters.search}
+                        onSearchChange={filters.setSearch}
+                        schoolId={filters.schoolId}
+                        onSchoolChange={filters.setSchoolId}
+                        classroomId={filters.classroomId}
+                        onClassroomChange={filters.setClassroomId}
+                        editorId={filters.editorId}
+                        onEditorChange={filters.setEditorId}
+                        productName={filters.productName}
+                        onProductChange={filters.setProductName}
+                        schoolOptions={filters.schoolOptions}
+                        classroomOptions={filters.classroomOptions}
+                        editorOptions={filters.editorOptions}
+                        productOptions={filters.productOptions}
+                    />
+                )}
+
                 {!hasRows ? (
                     <Card>
                         <CardHeader className="text-center">
@@ -50,8 +77,17 @@ export default function Edition({
                             </CardDescription>
                         </CardHeader>
                     </Card>
+                ) : !hasFilteredRows ? (
+                    <Card>
+                        <CardHeader className="text-center">
+                            <CardTitle>Sin resultados</CardTitle>
+                            <CardDescription>
+                                Ninguna fila coincide con los filtros aplicados.
+                            </CardDescription>
+                        </CardHeader>
+                    </Card>
                 ) : (
-                    schools.map((school) => (
+                    filters.filteredSchools.map((school) => (
                         <div key={school.id} className="flex flex-col gap-4">
                             <h2 className="text-xl font-semibold">
                                 {school.name}

--- a/resources/js/pages/edition/tests/classroom-table.test.tsx
+++ b/resources/js/pages/edition/tests/classroom-table.test.tsx
@@ -32,6 +32,8 @@ const classroom: EditionClassroom = {
             photo_size: 'Foto 15x21',
             diseno: 'Individual',
             child_name: 'Lola',
+            photo_number: 12,
+            variant_search: 'Individual',
             editing_status: 'pendiente',
             note: null,
             allowed_targets: [],

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -21,6 +21,8 @@ const makeRow = (overrides: Partial<EditionRowData> = {}): EditionRowData => ({
     photo_size: 'Foto 15x21',
     diseno: 'Individual',
     child_name: 'Lola',
+    photo_number: 12,
+    variant_search: 'Individual',
     editing_status: 'pendiente',
     note: 'Nota de fila',
     allowed_targets: [],

--- a/resources/js/pages/edition/tests/use-edition-filters.test.ts
+++ b/resources/js/pages/edition/tests/use-edition-filters.test.ts
@@ -1,0 +1,270 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EditionRowData, EditionSchool } from '../components/classroom-table';
+import { useEditionFilters } from '../hooks/use-edition-filters';
+
+const vale = { id: 1, name: 'Vale' };
+const bruno = { id: 2, name: 'Bruno' };
+
+function makeRow(overrides: Partial<EditionRowData>): EditionRowData {
+    return {
+        id: 0,
+        order_id: 0,
+        photo_size: null,
+        diseno: null,
+        child_name: null,
+        photo_number: null,
+        variant_search: '',
+        editing_status: 'pendiente',
+        note: null,
+        allowed_targets: [],
+        is_first_of_order: true,
+        editor: null,
+        ...overrides,
+    };
+}
+
+// School A / 1ro A: two rows, distinct editors and products
+const row1 = makeRow({
+    id: 1,
+    order_id: 100,
+    photo_size: 'Foto 15x21',
+    diseno: 'Individual',
+    child_name: 'José Pérez',
+    photo_number: 101,
+    variant_search: 'Vertical Celeste',
+    editor: vale,
+});
+const row2 = makeRow({
+    id: 2,
+    order_id: 101,
+    photo_size: 'Foto 10x15',
+    diseno: 'Grupal',
+    child_name: 'Ana López',
+    photo_number: 102,
+    variant_search: 'Horizontal Blanco',
+    editor: bruno,
+});
+
+// School A / 1ro B: one row, no editor assigned
+const row3 = makeRow({
+    id: 3,
+    order_id: 102,
+    photo_size: 'Foto 15x21',
+    diseno: 'Individual',
+    child_name: 'Niño Torres',
+    photo_number: 103,
+    variant_search: 'Vertical Blanco',
+    editor: null,
+});
+
+// School B / 2do A: one row, editor reused from row1
+const row4 = makeRow({
+    id: 4,
+    order_id: 103,
+    photo_size: 'Foto 10x15',
+    diseno: 'Individual',
+    child_name: 'Luca Gómez',
+    photo_number: 104,
+    variant_search: 'Horizontal Celeste',
+    editor: vale,
+});
+
+const schoolA: EditionSchool = {
+    id: 1,
+    name: 'Escuela A',
+    classrooms: [
+        { id: 10, name: '1ro A', rows: [row1, row2] },
+        { id: 11, name: '1ro B', rows: [row3] },
+    ],
+};
+
+const schoolB: EditionSchool = {
+    id: 2,
+    name: 'Escuela B',
+    classrooms: [{ id: 20, name: '2do A', rows: [row4] }],
+};
+
+const schools: EditionSchool[] = [schoolA, schoolB];
+
+describe('useEditionFilters', () => {
+    it('keeps every school/classroom/row when no filter is applied', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        expect(result.current.filteredSchools).toEqual(schools);
+    });
+
+    it('filters by child_name substring, case-insensitively', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setSearch('lopez'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+            },
+        ]);
+    });
+
+    it('filters by photo_number', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setSearch('103'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+            },
+        ]);
+    });
+
+    it('filters by a photo-variant value present in diseno', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setSearch('Grupal'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+            },
+        ]);
+    });
+
+    it('is accent-insensitive', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setSearch('nino'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+            },
+        ]);
+    });
+
+    it('filters by schoolId', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setSchoolId(2));
+
+        expect(result.current.filteredSchools).toEqual([schoolB]);
+    });
+
+    it('filters by classroomId', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setClassroomId(11));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+            },
+        ]);
+    });
+
+    it('filters by editorId when canManage is true', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setEditorId(1));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row1] }],
+            },
+            schoolB,
+        ]);
+    });
+
+    it('ignores editorId when canManage is false', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, false));
+
+        act(() => result.current.setEditorId(1));
+
+        expect(result.current.filteredSchools).toEqual(schools);
+    });
+
+    it('filters by productName (photo_size)', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setProductName('Foto 10x15'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+            },
+            schoolB,
+        ]);
+    });
+
+    it('applies two filters with AND semantics', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => {
+            result.current.setSearch('Blanco');
+            result.current.setProductName('Foto 10x15');
+        });
+
+        // "Blanco" alone also matches row3 (Vertical Blanco), but its
+        // photo_size is Foto 15x21, so the productName filter excludes it
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+            },
+        ]);
+    });
+
+    it('drops classrooms left empty and schools left without classrooms', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        // Only row2 was assigned to Bruno: classroom 1ro B (row3, no editor)
+        // and every classroom in School B (row4, Vale) are filtered out,
+        // so School B disappears entirely while School A keeps only 1ro A
+        act(() => result.current.setEditorId(2));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolA,
+                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+            },
+        ]);
+    });
+
+    it('exposes de-duplicated option lists, narrowing classrooms to the selected school', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        expect(result.current.schoolOptions).toEqual([
+            { id: 1, name: 'Escuela A' },
+            { id: 2, name: 'Escuela B' },
+        ]);
+        expect(result.current.classroomOptions).toEqual([
+            { id: 10, name: '1ro A' },
+            { id: 11, name: '1ro B' },
+            { id: 20, name: '2do A' },
+        ]);
+        // Vale (id 1) appears on row1 and row4: de-duplicated to one entry
+        expect(result.current.editorOptions).toEqual([
+            { id: 1, name: 'Vale' },
+            { id: 2, name: 'Bruno' },
+        ]);
+        // Foto 15x21 (row1, row3) and Foto 10x15 (row2, row4): de-duplicated
+        expect(result.current.productOptions).toEqual([
+            'Foto 10x15',
+            'Foto 15x21',
+        ]);
+
+        act(() => result.current.setSchoolId(1));
+
+        expect(result.current.classroomOptions).toEqual([
+            { id: 10, name: '1ro A' },
+            { id: 11, name: '1ro B' },
+        ]);
+    });
+});

--- a/resources/js/pages/edition/tests/use-edition-filters.test.ts
+++ b/resources/js/pages/edition/tests/use-edition-filters.test.ts
@@ -267,4 +267,64 @@ describe('useEditionFilters', () => {
             { id: 11, name: '1ro B' },
         ]);
     });
+
+    it('recomputes is_first_of_order when a filter removes the original first row of an order', () => {
+        // order_id 200: originalFirst is the designated first row (backend
+        // computed against the full unfiltered classroom); sibling shares
+        // the same order but is a different product, so filtering by
+        // productName keeps only the sibling.
+        const originalFirst = makeRow({
+            id: 5,
+            order_id: 200,
+            photo_size: 'Foto 15x21',
+            child_name: 'Mica Díaz',
+            is_first_of_order: true,
+        });
+        const sibling = makeRow({
+            id: 6,
+            order_id: 200,
+            photo_size: 'Foto 10x15',
+            child_name: 'Mica Díaz',
+            is_first_of_order: false,
+        });
+        const schoolWithSplitOrder: EditionSchool = {
+            id: 3,
+            name: 'Escuela C',
+            classrooms: [
+                { id: 30, name: '3ro A', rows: [originalFirst, sibling] },
+            ],
+        };
+
+        const { result } = renderHook(() =>
+            useEditionFilters([schoolWithSplitOrder], true),
+        );
+
+        act(() => result.current.setProductName('Foto 10x15'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolWithSplitOrder,
+                classrooms: [
+                    {
+                        id: 30,
+                        name: '3ro A',
+                        rows: [{ ...sibling, is_first_of_order: true }],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('clears classroomId when switching to a school that does not contain it', () => {
+        const { result } = renderHook(() => useEditionFilters(schools, true));
+
+        act(() => result.current.setClassroomId(11)); // 1ro B, in Escuela A
+
+        expect(result.current.classroomId).toBe(11);
+
+        act(() => result.current.setSchoolId(2)); // Escuela B doesn't have classroom 11
+
+        expect(result.current.classroomId).toBeNull();
+        expect(result.current.filteredSchools).toEqual([schoolB]);
+    });
 });

--- a/tests/Feature/EditionTest.php
+++ b/tests/Feature/EditionTest.php
@@ -263,6 +263,32 @@ it('derives diseño from the "Tipo de foto" variant entry, null when absent', fu
     });
 });
 
+// photo_number and variant_search columns (search filters, #194)
+
+it('exposes photo_number and variant_search for client-side search filtering', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->create(['photo_number' => 42]);
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => [
+            ['label' => 'Tipo de foto', 'value' => ['label' => 'Grupo']],
+            ['label' => 'Color', 'value' => ['label' => 'Celeste']],
+        ],
+    ]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail) {
+        $schools = $page->toArray()['props']['schools'];
+        $row = findEditionRow($schools, $detail->id);
+
+        expect($row['photo_number'])->toBe(42)
+            ->and($row['variant_search'])->toContain('Grupo')
+            ->and($row['variant_search'])->toContain('Celeste');
+    });
+});
+
 // modelo cuadro / color / banda talle derived columns (criterion 3 backend note)
 
 it('derives modelo cuadro and color from the order mural, and banda talle for every role', function () {


### PR DESCRIPTION
## Resumen

Agrega búsqueda y filtrado sobre el listado de la página de edición.

## Cambios

- **Buscador** que filtra por número de orden del niño (`photo_number`), nombre del niño y valor de las variantes del producto con foto. Insensible a mayúsculas y acentos.
- **Filtros desplegables** por escuela, curso, editor asignado (solo visible cuando el usuario puede gestionar) y producto con foto.
- Buscador y filtros se combinan con **AND**; las escuelas y cursos que quedan sin filas tras filtrar no se muestran, con un estado vacío propio de "Sin resultados" distinto del "Nada para editar".
- El filtrado es **client-side**: el tablero ya carga el conjunto completo (sin paginación) y las opciones de los desplegables se derivan de los datos cargados.
- Las columnas a nivel de pedido (modelo de cuadro, color, talle de banda, observaciones generales y accesorios) se conservan visibles en la primera fila que sobrevive al filtro de cada pedido.

## Fuera de alcance

- Persistencia de filtros en la querystring.
- Paginación del listado.

Closes #194
