### PR TITLE
feat(edition): subagrupar por producto con foto con encabezados dinámicos y contador por pedido

### DIFF
--- a/app/Http/Controllers/BO/EditionController.php
+++ b/app/Http/Controllers/BO/EditionController.php
@@ -138,29 +138,29 @@ class EditionController extends Controller
                 $classroom = $firstOrder->classroom;
 
                 $sortedRows = $classroomDetails->sortBy([['order_id', 'asc'], ['id', 'asc']])->values();
-                $firstRowIds = $sortedRows->unique('order_id')->pluck('id')->all();
 
-                $rows = $sortedRows
-                    ->map(fn (OrderDetail $detail) => $this->mapRow(
-                        $detail,
-                        in_array($detail->id, $firstRowIds, true),
-                        $activeDetailsByOrder->get($detail->order_id) ?? collect(),
-                        $isManager,
-                        $actor,
-                    ))
-                    ->values()
-                    ->all();
+                /** @var Collection<int, int> $orderIds */
+                $orderIds = $sortedRows->pluck('order_id')->unique()->values();
+
+                /** @var Collection<int, int> $orderSeqByOrderId */
+                $orderSeqByOrderId = $orderIds->flip();
+
+                $photoProductGroups = $this->groupByPhotoProduct(
+                    $sortedRows,
+                    $orderSeqByOrderId,
+                    $activeDetailsByOrder,
+                    $isManager,
+                    $actor,
+                );
 
                 $classroomGroup = [
                     'id' => $classroom->id,
                     'name' => $classroom->name,
-                    'rows' => $rows,
+                    'order_count' => $orderIds->count(),
+                    'photoProductGroups' => $photoProductGroups,
                 ];
 
                 if ($isManager) {
-                    /** @var Collection<int, int> $orderIds */
-                    $orderIds = $sortedRows->pluck('order_id')->unique()->values();
-
                     $classroomGroup['totals'] = $this->accessoryTotals($orderIds, $activeDetailsByOrder);
                 }
 
@@ -172,10 +172,61 @@ class EditionController extends Controller
     }
 
     /**
+     * Sub-groups a classroom's sorted rows by photo product ("Producto con
+     * foto"), each carrying the sorted union of its rows' variant labels as
+     * dynamic columns.
+     *
+     * @param  Collection<int, OrderDetail>  $sortedRows
+     * @param  Collection<int, int>  $orderSeqByOrderId
+     * @param  Collection<int|string, Collection<int, OrderDetail>>  $activeDetailsByOrder
+     * @return array<int, array<string, mixed>>
+     */
+    private function groupByPhotoProduct(Collection $sortedRows, Collection $orderSeqByOrderId, Collection $activeDetailsByOrder, bool $isManager, User $actor): array
+    {
+        return $sortedRows
+            ->groupBy(fn (OrderDetail $detail) => $detail->product_id)
+            ->map(function (Collection $groupRows) use ($orderSeqByOrderId, $activeDetailsByOrder, $isManager, $actor) {
+                $groupRows = $groupRows->values();
+                $firstRowIds = $groupRows->unique('order_id')->pluck('id')->all();
+
+                $rows = $groupRows
+                    ->map(fn (OrderDetail $detail) => $this->mapRow(
+                        $detail,
+                        in_array($detail->id, $firstRowIds, true),
+                        $orderSeqByOrderId->get($detail->order_id, 0),
+                        $activeDetailsByOrder->get($detail->order_id) ?? collect(),
+                        $isManager,
+                        $actor,
+                    ))
+                    ->values();
+
+                $variantColumns = $groupRows
+                    ->flatMap(fn (OrderDetail $detail) => array_keys($this->variantsMap($detail->variant)))
+                    ->unique()
+                    ->sort()
+                    ->values()
+                    ->all();
+
+                /** @var OrderDetail $firstGroupDetail */
+                $firstGroupDetail = $groupRows->first();
+
+                return [
+                    'product_id' => $firstGroupDetail->product_id,
+                    'product_name' => $firstGroupDetail->product?->name,
+                    'variant_columns' => $variantColumns,
+                    'rows' => $rows->all(),
+                ];
+            })
+            ->sortBy('product_name')
+            ->values()
+            ->all();
+    }
+
+    /**
      * @param  Collection<int, OrderDetail>  $orderActiveDetails
      * @return array<string, mixed>
      */
-    private function mapRow(OrderDetail $detail, bool $isFirstOfOrder, Collection $orderActiveDetails, bool $isManager, User $actor): array
+    private function mapRow(OrderDetail $detail, bool $isFirstOfOrder, int $orderSeq, Collection $orderActiveDetails, bool $isManager, User $actor): array
     {
         /** @var Order $order */
         $order = $detail->order;
@@ -189,8 +240,9 @@ class EditionController extends Controller
         $row = [
             'id' => $detail->id,
             'order_id' => $detail->order_id,
+            'order_seq' => $orderSeq,
             'photo_size' => $detail->product?->name,
-            'diseno' => $this->variantLabel($detail->variant, 'Tipo de foto'),
+            'variants' => $this->variantsMap($detail->variant),
             'child_name' => $order->child_name,
             'photo_number' => $order->photo_number,
             'variant_search' => $this->variantSearch($detail->variant),
@@ -200,23 +252,6 @@ class EditionController extends Controller
             'is_first_of_order' => $isFirstOfOrder,
         ];
 
-        if ($isManager) {
-            $editor = $detail->editorAssignment?->editor;
-            $row['editor'] = $editor !== null ? ['id' => $editor->id, 'name' => $editor->name] : null;
-        }
-
-        // Order-level fields are serialized on every row (not just the
-        // "first of order" one) because client-side filtering can hide the
-        // designated first row while keeping a sibling row of the same
-        // order; is_first_of_order is recomputed on the surviving rows.
-        $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
-        $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
-
-        $row['modelo_cuadro'] = $mural?->product?->name;
-        $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
-        // Not one of the "accessory columns" (carpeta/banda/medalla/taza
-        // presence flags): visible to every role, unlike $isManager below.
-        $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
         $row['observaciones_generales'] = $order->notes->map(fn (Note $note) => [
             'id' => $note->id,
             'body' => $note->body,
@@ -224,6 +259,21 @@ class EditionController extends Controller
         ])->values()->all();
 
         if ($isManager) {
+            $editor = $detail->editorAssignment?->editor;
+            $row['editor'] = $editor !== null ? ['id' => $editor->id, 'name' => $editor->name] : null;
+
+            // Order-level fields are serialized on every row (not just the
+            // "first of order" one) because client-side filtering can hide
+            // the designated first row while keeping a sibling row of the
+            // same order; is_first_of_order is recomputed on the surviving
+            // rows.
+            $mural = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'mural');
+            $banda = $orderActiveDetails->first(fn (OrderDetail $d) => $d->product?->type?->name === 'banda');
+
+            $row['modelo_cuadro'] = $mural?->product?->name;
+            $row['color'] = $mural !== null ? $this->variantLabel($mural->variant, 'Color') : null;
+            $row['banda_talle'] = $banda !== null ? $this->variantLabel($banda->variant, 'Talle') : null;
+
             $row['accessories'] = [
                 'carpeta' => $orderActiveDetails->contains(fn (OrderDetail $d) => $d->product?->type?->name === 'carpeta'),
                 'banda' => $banda !== null,
@@ -236,6 +286,25 @@ class EditionController extends Controller
         }
 
         return $row;
+    }
+
+    /**
+     * Builds a `{label: {label, color}|null}` map from a variant snapshot,
+     * keyed by each entry's label (e.g. "Tipo de foto", "Color"), used to
+     * render one dynamic column per photo-product group.
+     *
+     * @param  array<int, array{label: string, type?: string, value: array{label: string, color?: string}|null}>|null  $variant
+     * @return array<string, array{label: string, color?: string}|null>
+     */
+    private function variantsMap(?array $variant): array
+    {
+        $map = [];
+
+        foreach ($variant ?? [] as $entry) {
+            $map[$entry['label']] = $entry['value'];
+        }
+
+        return $map;
     }
 
     /**

--- a/resources/js/pages/edition/components/classroom-table.tsx
+++ b/resources/js/pages/edition/components/classroom-table.tsx
@@ -34,11 +34,17 @@ export interface EditionAccessoryFlags {
     escarapela: boolean;
 }
 
+export interface EditionVariantValue {
+    label: string;
+    color?: string;
+}
+
 export interface EditionRowData {
     id: number;
     order_id: number;
+    order_seq: number;
     photo_size: string | null;
-    diseno: string | null;
+    variants: Record<string, EditionVariantValue | null>;
     child_name: string | null;
     photo_number: number | null;
     variant_search: string;
@@ -54,10 +60,18 @@ export interface EditionRowData {
     accessories?: EditionAccessoryFlags;
 }
 
+export interface EditionPhotoProductGroup {
+    product_id: number;
+    product_name: string | null;
+    variant_columns: string[];
+    rows: EditionRowData[];
+}
+
 export interface EditionClassroom {
     id: number;
     name: string;
-    rows: EditionRowData[];
+    order_count: number;
+    photoProductGroups: EditionPhotoProductGroup[];
     totals?: EditionAccessoryTotals;
 }
 
@@ -83,7 +97,7 @@ export function ClassroomTable({
             <header className="flex flex-wrap items-center justify-between gap-2 border-b border-input p-4">
                 <div className="flex items-center gap-2">
                     <h3 className="font-medium">{classroom.name}</h3>
-                    <Badge variant="secondary">{classroom.rows.length}</Badge>
+                    <Badge variant="secondary">{classroom.order_count}</Badge>
                 </div>
                 {canManage && (
                     <BulkAssignEditorDialog
@@ -94,46 +108,66 @@ export function ClassroomTable({
                 )}
             </header>
 
-            <Table>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead>Pedido</TableHead>
-                        <TableHead>Niño</TableHead>
-                        <TableHead>Tamaño de foto</TableHead>
-                        <TableHead>Diseño</TableHead>
-                        <TableHead>Modelo cuadro</TableHead>
-                        <TableHead>Color</TableHead>
-                        <TableHead>Talle banda</TableHead>
-                        {canManage && (
-                            <>
-                                <TableHead>Carpeta</TableHead>
-                                <TableHead>Banda</TableHead>
-                                <TableHead>Medalla</TableHead>
-                                <TableHead>Taza</TableHead>
-                                <TableHead>Guantes</TableHead>
-                                <TableHead>Escarapela</TableHead>
-                            </>
-                        )}
-                        <TableHead>Notas</TableHead>
-                        <TableHead>Observaciones generales</TableHead>
-                        <TableHead>Estado</TableHead>
-                        {canManage && <TableHead>Editor asignado</TableHead>}
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {classroom.rows.map((row) => (
-                        <EditionRow
-                            key={row.id}
-                            row={row}
-                            canManage={canManage}
-                            editors={editors}
-                        />
-                    ))}
-                </TableBody>
-                {canManage && classroom.totals && (
+            <div className="flex flex-col gap-6 p-4">
+                {classroom.photoProductGroups.map((group) => (
+                    <div key={group.product_id} className="flex flex-col gap-2">
+                        <h4 className="font-medium text-muted-foreground">
+                            {group.product_name}
+                        </h4>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Pedido</TableHead>
+                                    <TableHead>Niño</TableHead>
+                                    {group.variant_columns.map((label) => (
+                                        <TableHead key={label}>
+                                            {label}
+                                        </TableHead>
+                                    ))}
+                                    {canManage && (
+                                        <>
+                                            <TableHead>Modelo cuadro</TableHead>
+                                            <TableHead>Color</TableHead>
+                                            <TableHead>Talle banda</TableHead>
+                                            <TableHead>Carpeta</TableHead>
+                                            <TableHead>Banda</TableHead>
+                                            <TableHead>Medalla</TableHead>
+                                            <TableHead>Taza</TableHead>
+                                            <TableHead>Guantes</TableHead>
+                                            <TableHead>Escarapela</TableHead>
+                                        </>
+                                    )}
+                                    <TableHead>Notas</TableHead>
+                                    <TableHead>
+                                        Observaciones generales
+                                    </TableHead>
+                                    <TableHead>Estado</TableHead>
+                                    {canManage && (
+                                        <TableHead>Editor asignado</TableHead>
+                                    )}
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {group.rows.map((row) => (
+                                    <EditionRow
+                                        key={row.id}
+                                        row={row}
+                                        variantColumns={group.variant_columns}
+                                        canManage={canManage}
+                                        editors={editors}
+                                    />
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </div>
+                ))}
+            </div>
+
+            {canManage && classroom.totals && (
+                <Table>
                     <TotalsFooter totals={classroom.totals} />
-                )}
-            </Table>
+                </Table>
+            )}
         </div>
     );
 }

--- a/resources/js/pages/edition/components/classroom-table.tsx
+++ b/resources/js/pages/edition/components/classroom-table.tsx
@@ -109,65 +109,87 @@ export function ClassroomTable({
             </header>
 
             <div className="flex flex-col gap-6 p-4">
-                {classroom.photoProductGroups.map((group) => (
-                    <div key={group.product_id} className="flex flex-col gap-2">
-                        <h4 className="font-medium text-muted-foreground">
-                            {group.product_name}
-                        </h4>
-                        <Table>
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead>Pedido</TableHead>
-                                    <TableHead>Niño</TableHead>
-                                    {group.variant_columns.map((label) => (
-                                        <TableHead key={label}>
-                                            {label}
-                                        </TableHead>
-                                    ))}
-                                    {canManage && (
-                                        <>
-                                            <TableHead>Modelo cuadro</TableHead>
-                                            <TableHead>Color</TableHead>
-                                            <TableHead>Talle banda</TableHead>
-                                            <TableHead>Carpeta</TableHead>
-                                            <TableHead>Banda</TableHead>
-                                            <TableHead>Medalla</TableHead>
-                                            <TableHead>Taza</TableHead>
-                                            <TableHead>Guantes</TableHead>
-                                            <TableHead>Escarapela</TableHead>
-                                        </>
-                                    )}
-                                    <TableHead>Notas</TableHead>
-                                    <TableHead>
-                                        Observaciones generales
-                                    </TableHead>
-                                    <TableHead>Estado</TableHead>
-                                    {canManage && (
-                                        <TableHead>Editor asignado</TableHead>
-                                    )}
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {group.rows.map((row) => (
-                                    <EditionRow
-                                        key={row.id}
-                                        row={row}
-                                        variantColumns={group.variant_columns}
-                                        canManage={canManage}
-                                        editors={editors}
-                                    />
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </div>
-                ))}
-            </div>
+                {classroom.photoProductGroups.map((group, index) => {
+                    const isLastGroup =
+                        index === classroom.photoProductGroups.length - 1;
+                    const showTotals =
+                        isLastGroup && canManage && classroom.totals;
 
-            {canManage && classroom.totals && (
-                <Table>
-                    <TotalsFooter totals={classroom.totals} />
-                </Table>
-            )}
+                    return (
+                        <div
+                            key={group.product_id}
+                            className="flex flex-col gap-2"
+                        >
+                            <h4 className="font-medium text-muted-foreground">
+                                {group.product_name}
+                            </h4>
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Pedido</TableHead>
+                                        <TableHead>Niño</TableHead>
+                                        {group.variant_columns.map((label) => (
+                                            <TableHead key={label}>
+                                                {label}
+                                            </TableHead>
+                                        ))}
+                                        {canManage && (
+                                            <>
+                                                <TableHead>
+                                                    Modelo cuadro
+                                                </TableHead>
+                                                <TableHead>Color</TableHead>
+                                                <TableHead>
+                                                    Talle banda
+                                                </TableHead>
+                                                <TableHead>Carpeta</TableHead>
+                                                <TableHead>Banda</TableHead>
+                                                <TableHead>Medalla</TableHead>
+                                                <TableHead>Taza</TableHead>
+                                                <TableHead>Guantes</TableHead>
+                                                <TableHead>
+                                                    Escarapela
+                                                </TableHead>
+                                            </>
+                                        )}
+                                        <TableHead>Notas</TableHead>
+                                        <TableHead>
+                                            Observaciones generales
+                                        </TableHead>
+                                        <TableHead>Estado</TableHead>
+                                        {canManage && (
+                                            <TableHead>
+                                                Editor asignado
+                                            </TableHead>
+                                        )}
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {group.rows.map((row) => (
+                                        <EditionRow
+                                            key={row.id}
+                                            row={row}
+                                            variantColumns={
+                                                group.variant_columns
+                                            }
+                                            canManage={canManage}
+                                            editors={editors}
+                                        />
+                                    ))}
+                                </TableBody>
+                                {showTotals && classroom.totals && (
+                                    <TotalsFooter
+                                        totals={classroom.totals}
+                                        leadingColSpan={
+                                            2 + group.variant_columns.length + 3
+                                        }
+                                    />
+                                )}
+                            </Table>
+                        </div>
+                    );
+                })}
+            </div>
         </div>
     );
 }

--- a/resources/js/pages/edition/components/edition-row.tsx
+++ b/resources/js/pages/edition/components/edition-row.tsx
@@ -7,8 +7,13 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { AssignableEditor } from '@/features/editor-assignment/BulkAssignEditorDialog';
+import { cn } from '@/lib/utils';
 import { AssignmentControl } from './assignment-control';
-import { EditingStatusValue, EditionRowData } from './classroom-table';
+import {
+    EditingStatusValue,
+    EditionRowData,
+    EditionVariantValue,
+} from './classroom-table';
 import { TransitionControl } from './transition-control';
 
 const STATUS_LABELS: Record<EditingStatusValue, string> = {
@@ -30,41 +35,87 @@ const STATUS_VARIANTS: Record<
 
 const yesNo = (value: boolean | undefined) => (value ? 'Sí' : 'No');
 
+// Repeating palette applied by order_seq so every row of the same order
+// shares a left-border + subtle background, including across sub-tables.
+const ORDER_LINK_CLASSES = [
+    'border-l-blue-400 bg-blue-50/70 dark:bg-blue-950/20',
+    'border-l-emerald-400 bg-emerald-50/70 dark:bg-emerald-950/20',
+    'border-l-amber-400 bg-amber-50/70 dark:bg-amber-950/20',
+    'border-l-purple-400 bg-purple-50/70 dark:bg-purple-950/20',
+    'border-l-rose-400 bg-rose-50/70 dark:bg-rose-950/20',
+    'border-l-cyan-400 bg-cyan-50/70 dark:bg-cyan-950/20',
+];
+
+function orderLinkClassName(orderSeq: number): string {
+    return ORDER_LINK_CLASSES[orderSeq % ORDER_LINK_CLASSES.length];
+}
+
+function VariantCell({ value }: { value: EditionVariantValue | null }) {
+    if (!value) return <>—</>;
+
+    return (
+        <span className="inline-flex items-center gap-1">
+            {value.color && (
+                <span
+                    className="h-3 w-3 rounded-full border border-black/10"
+                    style={{ backgroundColor: value.color }}
+                />
+            )}
+            {value.label}
+        </span>
+    );
+}
+
 /**
  * One row per photo-editable order detail. Order-level columns (modelo
  * cuadro, color, talle banda, accesorios, observaciones generales) only
- * render on the first row of each order — blank on the rest — to avoid
- * repeating order data across its rows.
+ * render on the first row of each order within its photo-product group —
+ * blank on the rest — to avoid repeating order data across its rows.
  */
 export function EditionRow({
     row,
+    variantColumns,
     canManage,
     editors,
 }: {
     row: EditionRowData;
+    variantColumns: string[];
     canManage: boolean;
     editors: AssignableEditor[];
 }) {
     const first = row.is_first_of_order;
 
     return (
-        <TableRow>
+        <TableRow
+            className={cn('border-l-4', orderLinkClassName(row.order_seq))}
+        >
             <TableCell>
-                <a
-                    href={route('orders.show', { order: row.order_id })}
-                    className="underline-offset-2 hover:underline"
-                >
-                    #{row.order_id}
-                </a>
+                {row.photo_number !== null ? (
+                    <a
+                        href={route('orders.show', { order: row.order_id })}
+                        className="underline-offset-2 hover:underline"
+                    >
+                        {row.photo_number}
+                    </a>
+                ) : (
+                    '—'
+                )}
             </TableCell>
             <TableCell>{row.child_name ?? '—'}</TableCell>
-            <TableCell>{row.photo_size ?? '—'}</TableCell>
-            <TableCell>{row.diseno ?? '—'}</TableCell>
-            <TableCell>{first ? (row.modelo_cuadro ?? '—') : ''}</TableCell>
-            <TableCell>{first ? (row.color ?? '—') : ''}</TableCell>
-            <TableCell>{first ? (row.banda_talle ?? '—') : ''}</TableCell>
+            {variantColumns.map((label) => (
+                <TableCell key={label}>
+                    <VariantCell value={row.variants[label] ?? null} />
+                </TableCell>
+            ))}
             {canManage && (
                 <>
+                    <TableCell>
+                        {first ? (row.modelo_cuadro ?? '—') : ''}
+                    </TableCell>
+                    <TableCell>{first ? (row.color ?? '—') : ''}</TableCell>
+                    <TableCell>
+                        {first ? (row.banda_talle ?? '—') : ''}
+                    </TableCell>
                     <TableCell>
                         {first && row.accessories
                             ? yesNo(row.accessories.carpeta)

--- a/resources/js/pages/edition/components/totals-footer.tsx
+++ b/resources/js/pages/edition/components/totals-footer.tsx
@@ -7,11 +7,17 @@ import { EditionAccessoryTotals } from './classroom-table';
  * Manager-only view: aligned under the accessory columns, which only render
  * for `canManage`.
  */
-export function TotalsFooter({ totals }: { totals: EditionAccessoryTotals }) {
+export function TotalsFooter({
+    totals,
+    leadingColSpan,
+}: {
+    totals: EditionAccessoryTotals;
+    leadingColSpan: number;
+}) {
     return (
         <TableFooter>
             <TableRow>
-                <TableCell colSpan={7}>Totales</TableCell>
+                <TableCell colSpan={leadingColSpan}>Totales</TableCell>
                 <TableCell>{totals.carpeta}</TableCell>
                 <TableCell>{totals.banda}</TableCell>
                 <TableCell>{totals.medalla}</TableCell>

--- a/resources/js/pages/edition/hooks/use-edition-filters.ts
+++ b/resources/js/pages/edition/hooks/use-edition-filters.ts
@@ -72,6 +72,13 @@ function recomputeFirstOfOrder(rows: EditionRowData[]): EditionRowData[] {
     });
 }
 
+/** Counts distinct order_ids across a set of surviving photo-product groups. */
+function countDistinctOrders(groups: { rows: EditionRowData[] }[]): number {
+    return new Set(
+        groups.flatMap((group) => group.rows.map((row) => row.order_id)),
+    ).size;
+}
+
 function filterSchools(
     schools: EditionSchool[],
     filters: EditionFilterState,
@@ -81,9 +88,8 @@ function filterSchools(
         .map((school) => ({
             ...school,
             classrooms: school.classrooms
-                .map((classroom) => ({
-                    ...classroom,
-                    photoProductGroups: classroom.photoProductGroups
+                .map((classroom) => {
+                    const photoProductGroups = classroom.photoProductGroups
                         .map((group) => ({
                             ...group,
                             rows: recomputeFirstOfOrder(
@@ -98,8 +104,14 @@ function filterSchools(
                                 ),
                             ),
                         }))
-                        .filter((group) => group.rows.length > 0),
-                }))
+                        .filter((group) => group.rows.length > 0);
+
+                    return {
+                        ...classroom,
+                        photoProductGroups,
+                        order_count: countDistinctOrders(photoProductGroups),
+                    };
+                })
                 .filter((classroom) => classroom.photoProductGroups.length > 0),
         }))
         .filter((school) => school.classrooms.length > 0);

--- a/resources/js/pages/edition/hooks/use-edition-filters.ts
+++ b/resources/js/pages/edition/hooks/use-edition-filters.ts
@@ -28,7 +28,6 @@ function matchesSearch(row: EditionRowData, query: string): boolean {
         row.photo_number ?? '',
         row.child_name ?? '',
         row.variant_search,
-        row.diseno ?? '',
     ].join(' ');
 
     return normalize(haystack).includes(normalize(query));
@@ -84,19 +83,24 @@ function filterSchools(
             classrooms: school.classrooms
                 .map((classroom) => ({
                     ...classroom,
-                    rows: recomputeFirstOfOrder(
-                        classroom.rows.filter((row) =>
-                            matchesRow(
-                                row,
-                                school.id,
-                                classroom.id,
-                                filters,
-                                canManage,
+                    photoProductGroups: classroom.photoProductGroups
+                        .map((group) => ({
+                            ...group,
+                            rows: recomputeFirstOfOrder(
+                                group.rows.filter((row) =>
+                                    matchesRow(
+                                        row,
+                                        school.id,
+                                        classroom.id,
+                                        filters,
+                                        canManage,
+                                    ),
+                                ),
                             ),
-                        ),
-                    ),
+                        }))
+                        .filter((group) => group.rows.length > 0),
                 }))
-                .filter((classroom) => classroom.rows.length > 0),
+                .filter((classroom) => classroom.photoProductGroups.length > 0),
         }))
         .filter((school) => school.classrooms.length > 0);
 }
@@ -128,7 +132,11 @@ export function useEditionFilters(
             ),
     );
 
-    const allRows = schools.flatMap((s) => s.classrooms.flatMap((c) => c.rows));
+    const allRows = schools.flatMap((s) =>
+        s.classrooms.flatMap((c) =>
+            c.photoProductGroups.flatMap((g) => g.rows),
+        ),
+    );
 
     const editorOptions = dedupeById(
         allRows

--- a/resources/js/pages/edition/index.tsx
+++ b/resources/js/pages/edition/index.tsx
@@ -34,12 +34,16 @@ export default function Edition({
     photoProducts: PhotoProduct[];
 }>) {
     const hasRows = schools.some((school) =>
-        school.classrooms.some((classroom) => classroom.rows.length > 0),
+        school.classrooms.some((classroom) =>
+            classroom.photoProductGroups.some((group) => group.rows.length > 0),
+        ),
     );
 
     const filters = useEditionFilters(schools, canManage);
     const hasFilteredRows = filters.filteredSchools.some((school) =>
-        school.classrooms.some((classroom) => classroom.rows.length > 0),
+        school.classrooms.some((classroom) =>
+            classroom.photoProductGroups.some((group) => group.rows.length > 0),
+        ),
     );
 
     return (

--- a/resources/js/pages/edition/tests/classroom-table.test.tsx
+++ b/resources/js/pages/edition/tests/classroom-table.test.tsx
@@ -134,4 +134,61 @@ describe('ClassroomTable', () => {
         expect(screen.getByText('3')).toBeTruthy();
         expect(screen.getByText('Foto 15x21')).toBeTruthy();
     });
+
+    it('renders one sub-table heading per photo-product group', () => {
+        const multiGroupClassroom: EditionClassroom = {
+            ...classroom,
+            photoProductGroups: [
+                ...classroom.photoProductGroups,
+                {
+                    product_id: 2,
+                    product_name: 'Foto 10x15',
+                    variant_columns: ['Tipo de foto'],
+                    rows: [
+                        {
+                            id: 2,
+                            order_id: 11,
+                            order_seq: 1,
+                            photo_size: 'Foto 10x15',
+                            variants: {
+                                'Tipo de foto': { label: 'Grupal' },
+                            },
+                            child_name: 'Nico',
+                            photo_number: 13,
+                            variant_search: 'Grupal',
+                            editing_status: 'pendiente',
+                            note: null,
+                            allowed_targets: [],
+                            is_first_of_order: true,
+                            editor: null,
+                            modelo_cuadro: null,
+                            color: null,
+                            banda_talle: null,
+                            observaciones_generales: [],
+                            accessories: {
+                                carpeta: false,
+                                banda: false,
+                                medalla: false,
+                                taza: false,
+                                guantes: false,
+                                escarapela: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        render(
+            <ClassroomTable
+                classroom={multiGroupClassroom}
+                canManage={true}
+                editors={editors}
+                photoProducts={photoProducts}
+            />,
+        );
+
+        expect(screen.getByText('Foto 15x21')).toBeTruthy();
+        expect(screen.getByText('Foto 10x15')).toBeTruthy();
+    });
 });

--- a/resources/js/pages/edition/tests/classroom-table.test.tsx
+++ b/resources/js/pages/edition/tests/classroom-table.test.tsx
@@ -25,32 +25,41 @@ const photoProducts = [{ id: 1, name: 'Foto 15x21' }];
 const classroom: EditionClassroom = {
     id: 1,
     name: '5 A',
-    rows: [
+    order_count: 3,
+    photoProductGroups: [
         {
-            id: 1,
-            order_id: 10,
-            photo_size: 'Foto 15x21',
-            diseno: 'Individual',
-            child_name: 'Lola',
-            photo_number: 12,
-            variant_search: 'Individual',
-            editing_status: 'pendiente',
-            note: null,
-            allowed_targets: [],
-            is_first_of_order: true,
-            editor: null,
-            modelo_cuadro: 'Moldura fina',
-            color: 'Negro',
-            banda_talle: 'M',
-            observaciones_generales: [],
-            accessories: {
-                carpeta: true,
-                banda: false,
-                medalla: false,
-                taza: false,
-                guantes: false,
-                escarapela: false,
-            },
+            product_id: 1,
+            product_name: 'Foto 15x21',
+            variant_columns: ['Tipo de foto'],
+            rows: [
+                {
+                    id: 1,
+                    order_id: 10,
+                    order_seq: 0,
+                    photo_size: 'Foto 15x21',
+                    variants: { 'Tipo de foto': { label: 'Individual' } },
+                    child_name: 'Lola',
+                    photo_number: 12,
+                    variant_search: 'Individual',
+                    editing_status: 'pendiente',
+                    note: null,
+                    allowed_targets: [],
+                    is_first_of_order: true,
+                    editor: null,
+                    modelo_cuadro: 'Moldura fina',
+                    color: 'Negro',
+                    banda_talle: 'M',
+                    observaciones_generales: [],
+                    accessories: {
+                        carpeta: true,
+                        banda: false,
+                        medalla: false,
+                        taza: false,
+                        guantes: false,
+                        escarapela: false,
+                    },
+                },
+            ],
         },
     ],
     totals: {
@@ -64,6 +73,9 @@ const classroom: EditionClassroom = {
 };
 
 const MANAGER_ONLY_HEADERS = [
+    'Modelo cuadro',
+    'Color',
+    'Talle banda',
     'Carpeta',
     'Banda',
     'Medalla',
@@ -106,6 +118,20 @@ describe('ClassroomTable', () => {
         expect(screen.queryByText('Totales')).toBeNull();
         // Columns common to every role still render
         expect(screen.getByText('Pedido')).toBeTruthy();
-        expect(screen.getByText('Talle banda')).toBeTruthy();
+        expect(screen.getByText('Tipo de foto')).toBeTruthy();
+    });
+
+    it('renders the classroom badge from order_count and the product name as the group heading', () => {
+        render(
+            <ClassroomTable
+                classroom={classroom}
+                canManage={true}
+                editors={editors}
+                photoProducts={photoProducts}
+            />,
+        );
+
+        expect(screen.getByText('3')).toBeTruthy();
+        expect(screen.getByText('Foto 15x21')).toBeTruthy();
     });
 });

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -229,4 +229,29 @@ describe('EditionRow', () => {
         expect(screen.getByText('—')).toBeTruthy();
         expect(container.querySelector('[title]')).toBeNull();
     });
+
+    it('applies the same order-link classes to rows sharing an order_seq', () => {
+        const { container: containerZero } = renderRow(
+            makeRow({ order_seq: 0 }),
+            false,
+        );
+        const { container: containerSix } = renderRow(
+            makeRow({ order_seq: 6 }),
+            false,
+        );
+        const { container: containerOne } = renderRow(
+            makeRow({ order_seq: 1 }),
+            false,
+        );
+
+        const rowZero = within(containerZero).getByRole('row');
+        const rowSix = within(containerSix).getByRole('row');
+        const rowOne = within(containerOne).getByRole('row');
+
+        // order_seq 0 and 6 are equal mod 6, so they share the same palette entry.
+        expect(rowZero.className).toContain('border-l-blue-400');
+        expect(rowSix.className).toContain('border-l-blue-400');
+        // order_seq 1 maps to a different palette entry.
+        expect(rowOne.className).not.toContain('border-l-blue-400');
+    });
 });

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -14,12 +14,14 @@ vi.stubGlobal(
 );
 
 const editors = [{ id: 1, name: 'Vale' }];
+const variantColumns = ['Tipo de foto'];
 
 const makeRow = (overrides: Partial<EditionRowData> = {}): EditionRowData => ({
     id: 1,
     order_id: 10,
+    order_seq: 0,
     photo_size: 'Foto 15x21',
-    diseno: 'Individual',
+    variants: { 'Tipo de foto': { label: 'Individual' } },
     child_name: 'Lola',
     photo_number: 12,
     variant_search: 'Individual',
@@ -47,18 +49,31 @@ function renderRow(row: EditionRowData, canManage: boolean) {
     return render(
         <table>
             <tbody>
-                <EditionRow row={row} canManage={canManage} editors={editors} />
+                <EditionRow
+                    row={row}
+                    variantColumns={variantColumns}
+                    canManage={canManage}
+                    editors={editors}
+                />
             </tbody>
         </table>,
     );
 }
 
 describe('EditionRow', () => {
-    it('renders the reduced column set for the editor role: no assigned-editor and no accessory columns', () => {
+    it('renders one cell per variant_columns label, from the variants map', () => {
         renderRow(makeRow(), false);
 
-        // banda_talle is present for every role
-        expect(screen.getByText('M')).toBeTruthy();
+        expect(screen.getByText('Individual')).toBeTruthy();
+    });
+
+    it('renders the reduced column set for the editor role: no non-photo columns and no assigned-editor', () => {
+        renderRow(makeRow(), false);
+
+        // modelo cuadro / color / banda talle are manager-only now
+        expect(screen.queryByText('Moldura fina')).toBeNull();
+        expect(screen.queryByText('Negro')).toBeNull();
+        expect(screen.queryByText('M')).toBeNull();
         // Accessory Sí/No cells never render outside canManage
         expect(screen.queryByText('Sí')).toBeNull();
         expect(screen.queryByText('No')).toBeNull();
@@ -66,9 +81,11 @@ describe('EditionRow', () => {
         expect(screen.queryByRole('combobox')).toBeNull();
     });
 
-    it('renders the full column set for a manager role: accessory flags and assignment control', () => {
+    it('renders the full column set for a manager role: non-photo columns, accessory flags and assignment control', () => {
         renderRow(makeRow(), true);
 
+        expect(screen.getByText('Moldura fina')).toBeTruthy();
+        expect(screen.getByText('Negro')).toBeTruthy();
         expect(screen.getByText('M')).toBeTruthy();
         expect(screen.getAllByText('Sí')).toHaveLength(2); // carpeta, medalla
         expect(screen.getAllByText('No')).toHaveLength(4); // banda, taza, guantes, escarapela
@@ -92,9 +109,12 @@ describe('EditionRow', () => {
         expect(within(row).queryByText('Sí')).toBeNull();
         expect(within(row).queryByText('No')).toBeNull();
 
-        expect(cells[4].textContent).toBe(''); // modelo cuadro
-        expect(cells[5].textContent).toBe(''); // color
-        expect(cells[6].textContent).toBe(''); // banda talle
+        // Cells: 0 Pedido, 1 Niño, 2 Tipo de foto (variant), 3 modelo cuadro,
+        // 4 color, 5 banda talle, 6-11 accessories, 12 Notas, 13
+        // Observaciones, 14 Estado, 15 Editor asignado
+        expect(cells[3].textContent).toBe(''); // modelo cuadro
+        expect(cells[4].textContent).toBe(''); // color
+        expect(cells[5].textContent).toBe(''); // banda talle
     });
 
     it('renders order-level cells on the first row of the order', () => {
@@ -103,6 +123,35 @@ describe('EditionRow', () => {
         expect(screen.getByText('Moldura fina')).toBeTruthy();
         expect(screen.getByText('Negro')).toBeTruthy();
         expect(screen.getByText('M')).toBeTruthy();
+    });
+
+    it('renders the Pedido cell from photo_number, linking to the order', () => {
+        render(
+            <table>
+                <tbody>
+                    <EditionRow
+                        row={makeRow({ photo_number: 99, order_id: 55 })}
+                        variantColumns={variantColumns}
+                        canManage={false}
+                        editors={editors}
+                    />
+                </tbody>
+            </table>,
+        );
+
+        const link = screen.getByText('99');
+        expect(link.closest('a')?.getAttribute('href')).toBe(
+            'http://localhost/orders.show/55',
+        );
+    });
+
+    it('renders — in the Pedido cell when photo_number is null', () => {
+        const { container } = renderRow(makeRow({ photo_number: null }), false);
+
+        const row = within(container).getByRole('row');
+        const cells = within(row).getAllByRole('cell');
+
+        expect(cells[0].textContent).toBe('—');
     });
 
     it('Notas cell shows the full note in the tooltip content when opened, not a native title', () => {

--- a/resources/js/pages/edition/tests/use-edition-filters.test.ts
+++ b/resources/js/pages/edition/tests/use-edition-filters.test.ts
@@ -171,6 +171,7 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto10x15InA, rows: [row2] },
                         ],
@@ -211,6 +212,7 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto10x15InA, rows: [row2] },
                         ],
@@ -279,6 +281,7 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto15x21InA, rows: [row1] },
                         ],
@@ -308,6 +311,7 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto10x15InA, rows: [row2] },
                         ],
@@ -335,6 +339,7 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto10x15InA, rows: [row2] },
                         ],
@@ -358,9 +363,76 @@ describe('useEditionFilters', () => {
                 classrooms: [
                     {
                         ...classroom10,
+                        order_count: 1,
                         photoProductGroups: [
                             { ...groupFoto10x15InA, rows: [row2] },
                         ],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('recomputes order_count to the surviving distinct orders after filtering', () => {
+        // classroom40 has 3 distinct orders (400, 401, 402) spread across two
+        // groups: groupKeep holds two orders (400, 401), groupDrop holds one
+        // (402, a different product). Filtering by productName drops
+        // groupDrop entirely, so order_count must fall from 3 to 2 — NOT the
+        // original fixture's order_count.
+        const orderA = makeRow({
+            id: 7,
+            order_id: 400,
+            photo_size: 'Foto 15x21',
+            child_name: 'Uno',
+        });
+        const orderB = makeRow({
+            id: 8,
+            order_id: 401,
+            photo_size: 'Foto 15x21',
+            child_name: 'Dos',
+        });
+        const orderC = makeRow({
+            id: 9,
+            order_id: 402,
+            photo_size: 'Foto 10x15',
+            child_name: 'Tres',
+        });
+        const groupKeep = makeGroup({
+            product_id: 1,
+            product_name: 'Foto 15x21',
+            rows: [orderA, orderB],
+        });
+        const groupDrop = makeGroup({
+            product_id: 2,
+            product_name: 'Foto 10x15',
+            rows: [orderC],
+        });
+        const classroom40 = makeClassroom({
+            id: 40,
+            name: '4to A',
+            order_count: 3,
+            photoProductGroups: [groupKeep, groupDrop],
+        });
+        const schoolWithThreeOrders: EditionSchool = {
+            id: 4,
+            name: 'Escuela D',
+            classrooms: [classroom40],
+        };
+
+        const { result } = renderHook(() =>
+            useEditionFilters([schoolWithThreeOrders], true),
+        );
+
+        act(() => result.current.setProductName('Foto 15x21'));
+
+        expect(result.current.filteredSchools).toEqual([
+            {
+                ...schoolWithThreeOrders,
+                classrooms: [
+                    {
+                        ...classroom40,
+                        order_count: 2,
+                        photoProductGroups: [groupKeep],
                     },
                 ],
             },

--- a/resources/js/pages/edition/tests/use-edition-filters.test.ts
+++ b/resources/js/pages/edition/tests/use-edition-filters.test.ts
@@ -1,6 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { EditionRowData, EditionSchool } from '../components/classroom-table';
+import {
+    EditionClassroom,
+    EditionPhotoProductGroup,
+    EditionRowData,
+    EditionSchool,
+} from '../components/classroom-table';
 import { useEditionFilters } from '../hooks/use-edition-filters';
 
 const vale = { id: 1, name: 'Vale' };
@@ -10,8 +15,9 @@ function makeRow(overrides: Partial<EditionRowData>): EditionRowData {
     return {
         id: 0,
         order_id: 0,
+        order_seq: 0,
         photo_size: null,
-        diseno: null,
+        variants: {},
         child_name: null,
         photo_number: null,
         variant_search: '',
@@ -24,12 +30,38 @@ function makeRow(overrides: Partial<EditionRowData>): EditionRowData {
     };
 }
 
-// School A / 1ro A: two rows, distinct editors and products
+function makeGroup(
+    overrides: Partial<EditionPhotoProductGroup> & {
+        rows: EditionRowData[];
+    },
+): EditionPhotoProductGroup {
+    return {
+        product_id: 0,
+        product_name: null,
+        variant_columns: [],
+        ...overrides,
+    };
+}
+
+function makeClassroom(
+    overrides: Partial<EditionClassroom> & {
+        photoProductGroups: EditionPhotoProductGroup[];
+    },
+): EditionClassroom {
+    return {
+        id: 0,
+        name: '',
+        order_count: 0,
+        ...overrides,
+    };
+}
+
+// School A / 1ro A: two rows in distinct photo-product groups, distinct
+// editors and products
 const row1 = makeRow({
     id: 1,
     order_id: 100,
     photo_size: 'Foto 15x21',
-    diseno: 'Individual',
     child_name: 'José Pérez',
     photo_number: 101,
     variant_search: 'Vertical Celeste',
@@ -39,7 +71,6 @@ const row2 = makeRow({
     id: 2,
     order_id: 101,
     photo_size: 'Foto 10x15',
-    diseno: 'Grupal',
     child_name: 'Ana López',
     photo_number: 102,
     variant_search: 'Horizontal Blanco',
@@ -51,7 +82,6 @@ const row3 = makeRow({
     id: 3,
     order_id: 102,
     photo_size: 'Foto 15x21',
-    diseno: 'Individual',
     child_name: 'Niño Torres',
     photo_number: 103,
     variant_search: 'Vertical Blanco',
@@ -63,26 +93,62 @@ const row4 = makeRow({
     id: 4,
     order_id: 103,
     photo_size: 'Foto 10x15',
-    diseno: 'Individual',
     child_name: 'Luca Gómez',
     photo_number: 104,
     variant_search: 'Horizontal Celeste',
     editor: vale,
 });
 
+const groupFoto15x21InA = makeGroup({
+    product_id: 1,
+    product_name: 'Foto 15x21',
+    rows: [row1],
+});
+const groupFoto10x15InA = makeGroup({
+    product_id: 2,
+    product_name: 'Foto 10x15',
+    rows: [row2],
+});
+const groupFoto15x21InB = makeGroup({
+    product_id: 1,
+    product_name: 'Foto 15x21',
+    rows: [row3],
+});
+const groupFoto10x15InC = makeGroup({
+    product_id: 2,
+    product_name: 'Foto 10x15',
+    rows: [row4],
+});
+
+const classroom10 = makeClassroom({
+    id: 10,
+    name: '1ro A',
+    order_count: 2,
+    photoProductGroups: [groupFoto15x21InA, groupFoto10x15InA],
+});
+const classroom11 = makeClassroom({
+    id: 11,
+    name: '1ro B',
+    order_count: 1,
+    photoProductGroups: [groupFoto15x21InB],
+});
+const classroom20 = makeClassroom({
+    id: 20,
+    name: '2do A',
+    order_count: 1,
+    photoProductGroups: [groupFoto10x15InC],
+});
+
 const schoolA: EditionSchool = {
     id: 1,
     name: 'Escuela A',
-    classrooms: [
-        { id: 10, name: '1ro A', rows: [row1, row2] },
-        { id: 11, name: '1ro B', rows: [row3] },
-    ],
+    classrooms: [classroom10, classroom11],
 };
 
 const schoolB: EditionSchool = {
     id: 2,
     name: 'Escuela B',
-    classrooms: [{ id: 20, name: '2do A', rows: [row4] }],
+    classrooms: [classroom20],
 };
 
 const schools: EditionSchool[] = [schoolA, schoolB];
@@ -102,7 +168,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto10x15InA, rows: [row2] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -115,20 +188,34 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+                classrooms: [
+                    {
+                        ...classroom11,
+                        photoProductGroups: [
+                            { ...groupFoto15x21InB, rows: [row3] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
 
-    it('filters by a photo-variant value present in diseno', () => {
+    it('filters by a photo-variant value present in variant_search', () => {
         const { result } = renderHook(() => useEditionFilters(schools, true));
 
-        act(() => result.current.setSearch('Grupal'));
+        act(() => result.current.setSearch('Horizontal Blanco'));
 
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto10x15InA, rows: [row2] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -141,7 +228,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+                classrooms: [
+                    {
+                        ...classroom11,
+                        photoProductGroups: [
+                            { ...groupFoto15x21InB, rows: [row3] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -162,7 +256,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 11, name: '1ro B', rows: [row3] }],
+                classrooms: [
+                    {
+                        ...classroom11,
+                        photoProductGroups: [
+                            { ...groupFoto15x21InB, rows: [row3] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -175,7 +276,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row1] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto15x21InA, rows: [row1] },
+                        ],
+                    },
+                ],
             },
             schoolB,
         ]);
@@ -197,7 +305,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto10x15InA, rows: [row2] },
+                        ],
+                    },
+                ],
             },
             schoolB,
         ]);
@@ -212,11 +327,19 @@ describe('useEditionFilters', () => {
         });
 
         // "Blanco" alone also matches row3 (Vertical Blanco), but its
-        // photo_size is Foto 15x21, so the productName filter excludes it
+        // photo_size is Foto 15x21, so the productName filter excludes it.
+        // School B's row4 fails the "Blanco" search, so it drops entirely.
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto10x15InA, rows: [row2] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -232,7 +355,14 @@ describe('useEditionFilters', () => {
         expect(result.current.filteredSchools).toEqual([
             {
                 ...schoolA,
-                classrooms: [{ id: 10, name: '1ro A', rows: [row2] }],
+                classrooms: [
+                    {
+                        ...classroom10,
+                        photoProductGroups: [
+                            { ...groupFoto10x15InA, rows: [row2] },
+                        ],
+                    },
+                ],
             },
         ]);
     });
@@ -271,8 +401,8 @@ describe('useEditionFilters', () => {
     it('recomputes is_first_of_order when a filter removes the original first row of an order', () => {
         // order_id 200: originalFirst is the designated first row (backend
         // computed against the full unfiltered classroom); sibling shares
-        // the same order but is a different product, so filtering by
-        // productName keeps only the sibling.
+        // the same order but is a different product (different group), so
+        // filtering by productName keeps only the sibling's group.
         const originalFirst = makeRow({
             id: 5,
             order_id: 200,
@@ -287,12 +417,26 @@ describe('useEditionFilters', () => {
             child_name: 'Mica Díaz',
             is_first_of_order: false,
         });
+        const groupOriginal = makeGroup({
+            product_id: 1,
+            product_name: 'Foto 15x21',
+            rows: [originalFirst],
+        });
+        const groupSibling = makeGroup({
+            product_id: 2,
+            product_name: 'Foto 10x15',
+            rows: [sibling],
+        });
+        const classroomWithSplitOrder = makeClassroom({
+            id: 30,
+            name: '3ro A',
+            order_count: 1,
+            photoProductGroups: [groupOriginal, groupSibling],
+        });
         const schoolWithSplitOrder: EditionSchool = {
             id: 3,
             name: 'Escuela C',
-            classrooms: [
-                { id: 30, name: '3ro A', rows: [originalFirst, sibling] },
-            ],
+            classrooms: [classroomWithSplitOrder],
         };
 
         const { result } = renderHook(() =>
@@ -306,9 +450,13 @@ describe('useEditionFilters', () => {
                 ...schoolWithSplitOrder,
                 classrooms: [
                     {
-                        id: 30,
-                        name: '3ro A',
-                        rows: [{ ...sibling, is_first_of_order: true }],
+                        ...classroomWithSplitOrder,
+                        photoProductGroups: [
+                            {
+                                ...groupSibling,
+                                rows: [{ ...sibling, is_first_of_order: true }],
+                            },
+                        ],
                     },
                 ],
             },

--- a/tests/Feature/EditionTest.php
+++ b/tests/Feature/EditionTest.php
@@ -12,6 +12,7 @@ use App\Models\OrderEditingStatusChange;
 use App\Models\Product;
 use App\Models\School;
 use App\Models\User;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -19,7 +20,7 @@ use function Pest\Laravel\get;
 
 /**
  * Locates a mapped row by order_detail id inside the schools -> classrooms
- * -> rows Inertia payload.
+ * -> photoProductGroups -> rows Inertia payload.
  *
  * @param  array<int, array<string, mixed>>  $schools
  * @return array<string, mixed>
@@ -28,15 +29,32 @@ function findEditionRow(array $schools, int $detailId): ?array
 {
     foreach ($schools as $school) {
         foreach ($school['classrooms'] as $classroom) {
-            foreach ($classroom['rows'] as $row) {
-                if ($row['id'] === $detailId) {
-                    return $row;
+            foreach ($classroom['photoProductGroups'] as $group) {
+                foreach ($group['rows'] as $row) {
+                    if ($row['id'] === $detailId) {
+                        return $row;
+                    }
                 }
             }
         }
     }
 
     return null;
+}
+
+/**
+ * Flattens every row across every photo-product group of every classroom of
+ * every school in the Inertia payload.
+ *
+ * @param  array<int, array<string, mixed>>  $schools
+ * @return Collection<int, array<string, mixed>>
+ */
+function flattenEditionRows(array $schools): Collection
+{
+    return collect($schools)
+        ->pluck('classrooms')->flatten(1)
+        ->pluck('photoProductGroups')->flatten(1)
+        ->pluck('rows')->flatten(1);
 }
 
 // Route access (criterion 4 of #177, behavior beyond RoleAccessTest's matrix)
@@ -74,10 +92,7 @@ it('lists one row per photo-editable order detail and excludes non-photo product
 
     get(route('edition.index'))->assertInertia(function (Assert $page) use ($detail1, $detail2) {
         $schools = $page->toArray()['props']['schools'];
-        $rowIds = collect($schools)
-            ->pluck('classrooms')->flatten(1)
-            ->pluck('rows')->flatten(1)
-            ->pluck('id');
+        $rowIds = flattenEditionRows($schools)->pluck('id');
 
         expect($rowIds->all())->toEqualCanonicalizing([$detail1->id, $detail2->id]);
     });
@@ -98,10 +113,7 @@ it('excludes delivered details, recycled details and details of cancelled orders
 
     get(route('edition.index'))->assertInertia(function (Assert $page) use ($visible, $delivered, $recycled, $cancelled) {
         $schools = $page->toArray()['props']['schools'];
-        $rowIds = collect($schools)
-            ->pluck('classrooms')->flatten(1)
-            ->pluck('rows')->flatten(1)
-            ->pluck('id');
+        $rowIds = flattenEditionRows($schools)->pluck('id');
 
         expect($rowIds->all())->toBe([$visible->id])
             ->and($rowIds->all())->not->toContain($delivered->id, $recycled->id, $cancelled->id);
@@ -137,10 +149,7 @@ it('scopes the editor role to only their own assigned rows', function () {
 
     get(route('edition.index'))->assertInertia(function (Assert $page) use ($ownDetail, $otherEditorDetail, $unassignedDetail) {
         $schools = $page->toArray()['props']['schools'];
-        $rowIds = collect($schools)
-            ->pluck('classrooms')->flatten(1)
-            ->pluck('rows')->flatten(1)
-            ->pluck('id');
+        $rowIds = flattenEditionRows($schools)->pluck('id');
 
         expect($rowIds->all())->toBe([$ownDetail->id])
             ->and($rowIds->all())->not->toContain($otherEditorDetail->id, $unassignedDetail->id);
@@ -238,28 +247,42 @@ it('counts accessory totals once per order, not once per photo row', function ()
     });
 });
 
-// diseño derived column (criterion 3 backend note)
+// Dynamic variant columns (#193): the "variants" map replaces the hardcoded
+// diseño/tamaño columns, and the group's variant_columns is the sorted union
+// of its rows' variant labels.
 
-it('derives diseño from the "Tipo de foto" variant entry, null when absent', function () {
+it('exposes a variants map keyed by variant label, and derives variant_columns as their sorted union', function () {
     actingAsRole(UserRole::Office);
 
+    $classroom = Classroom::factory()->create();
     $product = Product::factory()->create(['has_photo' => true]);
-    $withDiseno = OrderDetail::factory()->create([
+    $withVariantOrder = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $withoutVariantOrder = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $withVariant = OrderDetail::factory()->create([
+        'order_id' => $withVariantOrder->id,
         'product_id' => $product->id,
         'variant' => [
             ['label' => 'Tipo de foto', 'value' => ['label' => 'Grupo']],
         ],
     ]);
-    $withoutDiseno = OrderDetail::factory()->create([
+    $withoutVariant = OrderDetail::factory()->create([
+        'order_id' => $withoutVariantOrder->id,
         'product_id' => $product->id,
         'variant' => [],
     ]);
 
-    get(route('edition.index'))->assertInertia(function (Assert $page) use ($withDiseno, $withoutDiseno) {
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($product, $withVariant, $withoutVariant) {
         $schools = $page->toArray()['props']['schools'];
 
-        expect(findEditionRow($schools, $withDiseno->id)['diseno'])->toBe('Grupo')
-            ->and(findEditionRow($schools, $withoutDiseno->id)['diseno'])->toBeNull();
+        expect(findEditionRow($schools, $withVariant->id)['variants'])->toBe(['Tipo de foto' => ['label' => 'Grupo']])
+            ->and(findEditionRow($schools, $withoutVariant->id)['variants'])->toBe([]);
+
+        $group = collect($schools)->pluck('classrooms')->flatten(1)
+            ->pluck('photoProductGroups')->flatten(1)
+            ->firstWhere('product_id', $product->id);
+
+        expect($group['product_name'])->toBe($product->name)
+            ->and($group['variant_columns'])->toBe(['Tipo de foto']);
     });
 });
 
@@ -289,9 +312,10 @@ it('exposes photo_number and variant_search for client-side search filtering', f
     });
 });
 
-// modelo cuadro / color / banda talle derived columns (criterion 3 backend note)
+// modelo cuadro / color / banda talle derived columns (criterion 3 backend
+// note; #193 moved all three under canManage gating)
 
-it('derives modelo cuadro and color from the order mural, and banda talle for every role', function () {
+it('derives modelo cuadro, color and banda talle from the order mural/banda, manager-only', function () {
     $editor = User::factory()->withRole(UserRole::Editor)->create();
     $manager = User::factory()->withRole(UserRole::Office)->create();
 
@@ -330,12 +354,14 @@ it('derives modelo cuadro and color from the order mural, and banda talle for ev
             ->and($row['banda_talle'])->toBe('M');
     });
 
-    // Editor view: banda talle still present, unlike accessories/editor
+    // Editor view: modelo cuadro, color and banda talle are all manager-only
     test()->actingAs($editor);
     get(route('edition.index'))->assertInertia(function (Assert $page) use ($photoDetail) {
         $row = findEditionRow($page->toArray()['props']['schools'], $photoDetail->id);
 
-        expect($row['banda_talle'])->toBe('M');
+        expect($row)->not->toHaveKey('modelo_cuadro')
+            ->and($row)->not->toHaveKey('color')
+            ->and($row)->not->toHaveKey('banda_talle');
     });
 });
 
@@ -365,7 +391,7 @@ it('reflects the current editing status per row, defaulting to pendiente', funct
 
 // Grouping by school -> classroom (structural sanity, ties #177's core shape)
 
-it('groups rows by school and then by classroom', function () {
+it('groups rows by school, classroom and photo product, with an order_count per classroom', function () {
     actingAsRole(UserRole::Office);
 
     $school = School::factory()->create();
@@ -374,7 +400,7 @@ it('groups rows by school and then by classroom', function () {
     $order = Order::factory()->create(['classroom_id' => $classroom->id]);
     $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
 
-    get(route('edition.index'))->assertInertia(function (Assert $page) use ($school, $classroom, $detail) {
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($school, $classroom, $product, $detail) {
         $schools = $page->toArray()['props']['schools'];
         $schoolGroup = collect($schools)->firstWhere('id', $school->id);
 
@@ -383,7 +409,41 @@ it('groups rows by school and then by classroom', function () {
         $classroomGroup = collect($schoolGroup['classrooms'])->firstWhere('id', $classroom->id);
 
         expect($classroomGroup)->not->toBeNull()
-            ->and(collect($classroomGroup['rows'])->pluck('id')->all())->toBe([$detail->id]);
+            ->and($classroomGroup['order_count'])->toBe(1);
+
+        $productGroup = collect($classroomGroup['photoProductGroups'])->firstWhere('product_id', $product->id);
+
+        expect($productGroup)->not->toBeNull()
+            ->and(collect($productGroup['rows'])->pluck('id')->all())->toBe([$detail->id]);
+    });
+});
+
+// order_seq: stable per-order index within the classroom, shared across
+// photo-product groups (#193 visual linking)
+
+it('assigns the same order_seq to every row of the same order, across photo-product groups', function () {
+    actingAsRole(UserRole::Office);
+
+    $classroom = Classroom::factory()->create();
+    $productA = Product::factory()->create(['has_photo' => true]);
+    $productB = Product::factory()->create(['has_photo' => true]);
+
+    $orderOne = Order::factory()->create(['classroom_id' => $classroom->id]);
+    $orderTwo = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $oneA = OrderDetail::factory()->create(['order_id' => $orderOne->id, 'product_id' => $productA->id]);
+    $oneB = OrderDetail::factory()->create(['order_id' => $orderOne->id, 'product_id' => $productB->id]);
+    $twoA = OrderDetail::factory()->create(['order_id' => $orderTwo->id, 'product_id' => $productA->id]);
+
+    get(route('edition.index'))->assertInertia(function (Assert $page) use ($oneA, $oneB, $twoA) {
+        $schools = $page->toArray()['props']['schools'];
+
+        $rowOneA = findEditionRow($schools, $oneA->id);
+        $rowOneB = findEditionRow($schools, $oneB->id);
+        $rowTwoA = findEditionRow($schools, $twoA->id);
+
+        expect($rowOneA['order_seq'])->toBe($rowOneB['order_seq'])
+            ->and($rowOneA['order_seq'])->not->toBe($rowTwoA['order_seq']);
     });
 });
 


### PR DESCRIPTION
## Qué cambia

Rediseño del cuerpo de la tabla de edición: cada curso deja de ser una tabla plana con columnas fijas y pasa a subagruparse por producto con foto (Escuela → Curso → Producto con foto), con encabezados derivados de las variantes de cada producto.

## Detalle

- **Subagrupación por producto con foto**: dentro de cada curso, una subtabla por producto con foto, encabezada por `product.name` (reemplaza la columna mal nombrada "Tamaño de foto").
- **Columnas de variantes dinámicas**: cada subtabla renderiza una columna por cada etiqueta de variante presente en ese producto (unión ordenada), en lugar de columnas fijas.
- **Vínculo visual por pedido**: las filas de un mismo pedido comparten borde/color (paleta por `order_seq`), incluso entre subtablas distintas.
- **Columna "Pedido"**: muestra `orders.photo_number` (número de orden del niño) en vez del id interno. Se verificó en navegador a 1920x1080 con el menú lateral colapsado que no fuerza scroll horizontal de página, por lo que se mantiene.
- **Contador del header de curso**: cuenta pedidos (no filas); un pedido con dos productos con foto cuenta una sola vez. Se recalcula en cliente al filtrar.
- **Gateo por rol**: todas las columnas de productos sin foto (modelo cuadro, color, talle banda) y accesorios quedan bajo `canManage`; el rol editor no las ve.
- **Totales de accesorios**: el footer se integra en la última subtabla del curso, con `colSpan` calculado según las columnas de variantes, para que los conteos queden alineados bajo sus columnas.

## Fuera de alcance

- Buscador y filtros (ya en develop, #196). Se mantienen funcionando sobre la nueva estructura agrupada.
- Guantes/escarapela en el catálogo (#177).

## Pruebas

- Backend (Pest): agrupación por escuela/curso/producto, `order_count` por pedido, `order_seq` compartido por pedido, mapa `variants` y `variant_columns`, gateo `canManage`, guarda N+1.
- Frontend (Vitest): columnas de variantes dinámicas, badge por `order_count`, celda "Pedido" con `photo_number`, vínculo de color por `order_seq`, encabezados multi-producto, recálculo de `order_count` al filtrar.

Closes #193
