### PR TITLE
feat(edition): resaltar por hover las filas del mismo pedido

### DIFF
--- a/resources/js/pages/edition/components/classroom-table.tsx
+++ b/resources/js/pages/edition/components/classroom-table.tsx
@@ -11,6 +11,7 @@ import {
     BulkAssignEditorDialog,
     PhotoProduct,
 } from '@/features/editor-assignment/BulkAssignEditorDialog';
+import { useState } from 'react';
 import { EditionRow } from './edition-row';
 import { TotalsFooter } from './totals-footer';
 
@@ -92,6 +93,8 @@ export function ClassroomTable({
     editors: AssignableEditor[];
     photoProducts: PhotoProduct[];
 }) {
+    const [hoveredOrderSeq, setHoveredOrderSeq] = useState<number | null>(null);
+
     return (
         <div className="rounded-xl border border-input">
             <header className="flex flex-wrap items-center justify-between gap-2 border-b border-input p-4">
@@ -174,6 +177,12 @@ export function ClassroomTable({
                                             }
                                             canManage={canManage}
                                             editors={editors}
+                                            isHighlighted={
+                                                hoveredOrderSeq !== null &&
+                                                hoveredOrderSeq ===
+                                                    row.order_seq
+                                            }
+                                            onHoverChange={setHoveredOrderSeq}
                                         />
                                     ))}
                                 </TableBody>

--- a/resources/js/pages/edition/components/edition-row.tsx
+++ b/resources/js/pages/edition/components/edition-row.tsx
@@ -35,19 +35,11 @@ const STATUS_VARIANTS: Record<
 
 const yesNo = (value: boolean | undefined) => (value ? 'Sí' : 'No');
 
-// Repeating palette applied by order_seq so every row of the same order
-// shares a left-border + subtle background, including across sub-tables.
-const ORDER_LINK_CLASSES = [
-    'border-l-blue-400 bg-blue-50/70 dark:bg-blue-950/20',
-    'border-l-emerald-400 bg-emerald-50/70 dark:bg-emerald-950/20',
-    'border-l-amber-400 bg-amber-50/70 dark:bg-amber-950/20',
-    'border-l-purple-400 bg-purple-50/70 dark:bg-purple-950/20',
-    'border-l-rose-400 bg-rose-50/70 dark:bg-rose-950/20',
-    'border-l-cyan-400 bg-cyan-50/70 dark:bg-cyan-950/20',
-];
-
-function orderLinkClassName(orderSeq: number): string {
-    return ORDER_LINK_CLASSES[orderSeq % ORDER_LINK_CLASSES.length];
+function rowClassName(isHighlighted: boolean): string {
+    return cn(
+        'border-l-4 border-l-transparent',
+        isHighlighted && 'border-l-blue-400 bg-blue-50/70 dark:bg-blue-950/20',
+    );
 }
 
 function VariantCell({ value }: { value: EditionVariantValue | null }) {
@@ -77,17 +69,23 @@ export function EditionRow({
     variantColumns,
     canManage,
     editors,
+    isHighlighted,
+    onHoverChange,
 }: {
     row: EditionRowData;
     variantColumns: string[];
     canManage: boolean;
     editors: AssignableEditor[];
+    isHighlighted: boolean;
+    onHoverChange: (orderSeq: number | null) => void;
 }) {
     const first = row.is_first_of_order;
 
     return (
         <TableRow
-            className={cn('border-l-4', orderLinkClassName(row.order_seq))}
+            className={rowClassName(isHighlighted)}
+            onMouseEnter={() => onHoverChange(row.order_seq)}
+            onMouseLeave={() => onHoverChange(null)}
         >
             <TableCell>
                 {row.photo_number !== null ? (

--- a/resources/js/pages/edition/tests/classroom-table.test.tsx
+++ b/resources/js/pages/edition/tests/classroom-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import {
     ClassroomTable,
@@ -190,5 +190,105 @@ describe('ClassroomTable', () => {
 
         expect(screen.getByText('Foto 15x21')).toBeTruthy();
         expect(screen.getByText('Foto 10x15')).toBeTruthy();
+    });
+
+    it('highlights every row sharing an order_seq across sub-tables on hover, leaving other orders untouched', () => {
+        const linkedClassroom: EditionClassroom = {
+            ...classroom,
+            photoProductGroups: [
+                ...classroom.photoProductGroups,
+                {
+                    product_id: 2,
+                    product_name: 'Foto 10x15',
+                    variant_columns: ['Tipo de foto'],
+                    rows: [
+                        {
+                            id: 2,
+                            order_id: 10,
+                            order_seq: 0,
+                            photo_size: 'Foto 10x15',
+                            variants: {
+                                'Tipo de foto': { label: 'Grupal' },
+                            },
+                            child_name: 'Lola',
+                            photo_number: 13,
+                            variant_search: 'Grupal',
+                            editing_status: 'pendiente',
+                            note: null,
+                            allowed_targets: [],
+                            is_first_of_order: true,
+                            editor: null,
+                            modelo_cuadro: null,
+                            color: null,
+                            banda_talle: null,
+                            observaciones_generales: [],
+                            accessories: {
+                                carpeta: false,
+                                banda: false,
+                                medalla: false,
+                                taza: false,
+                                guantes: false,
+                                escarapela: false,
+                            },
+                        },
+                        {
+                            id: 3,
+                            order_id: 11,
+                            order_seq: 5,
+                            photo_size: 'Foto 10x15',
+                            variants: {
+                                'Tipo de foto': { label: 'Grupal' },
+                            },
+                            child_name: 'Nico',
+                            photo_number: 14,
+                            variant_search: 'Grupal',
+                            editing_status: 'pendiente',
+                            note: null,
+                            allowed_targets: [],
+                            is_first_of_order: true,
+                            editor: null,
+                            modelo_cuadro: null,
+                            color: null,
+                            banda_talle: null,
+                            observaciones_generales: [],
+                            accessories: {
+                                carpeta: false,
+                                banda: false,
+                                medalla: false,
+                                taza: false,
+                                guantes: false,
+                                escarapela: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        render(
+            <ClassroomTable
+                classroom={linkedClassroom}
+                canManage={true}
+                editors={editors}
+                photoProducts={photoProducts}
+            />,
+        );
+
+        const firstGroupRow = screen.getByText('12').closest('tr')!;
+        const secondGroupMatchingRow = screen.getByText('13').closest('tr')!;
+        const secondGroupOtherRow = screen.getByText('14').closest('tr')!;
+
+        expect(firstGroupRow.className).not.toContain('border-l-blue-400');
+        expect(secondGroupMatchingRow.className).not.toContain(
+            'border-l-blue-400',
+        );
+
+        fireEvent.mouseEnter(firstGroupRow);
+
+        expect(firstGroupRow.className).toContain('border-l-blue-400');
+        expect(secondGroupMatchingRow.className).toContain('border-l-blue-400');
+        expect(secondGroupOtherRow.className).not.toContain(
+            'border-l-blue-400',
+        );
     });
 });

--- a/resources/js/pages/edition/tests/edition-row.test.tsx
+++ b/resources/js/pages/edition/tests/edition-row.test.tsx
@@ -45,7 +45,16 @@ const makeRow = (overrides: Partial<EditionRowData> = {}): EditionRowData => ({
     ...overrides,
 });
 
-function renderRow(row: EditionRowData, canManage: boolean) {
+function renderRow(
+    row: EditionRowData,
+    canManage: boolean,
+    options: {
+        isHighlighted?: boolean;
+        onHoverChange?: (orderSeq: number | null) => void;
+    } = {},
+) {
+    const { isHighlighted = false, onHoverChange = () => {} } = options;
+
     return render(
         <table>
             <tbody>
@@ -54,6 +63,8 @@ function renderRow(row: EditionRowData, canManage: boolean) {
                     variantColumns={variantColumns}
                     canManage={canManage}
                     editors={editors}
+                    isHighlighted={isHighlighted}
+                    onHoverChange={onHoverChange}
                 />
             </tbody>
         </table>,
@@ -134,6 +145,8 @@ describe('EditionRow', () => {
                         variantColumns={variantColumns}
                         canManage={false}
                         editors={editors}
+                        isHighlighted={false}
+                        onHoverChange={() => {}}
                     />
                 </tbody>
             </table>,
@@ -230,28 +243,41 @@ describe('EditionRow', () => {
         expect(container.querySelector('[title]')).toBeNull();
     });
 
-    it('applies the same order-link classes to rows sharing an order_seq', () => {
-        const { container: containerZero } = renderRow(
-            makeRow({ order_seq: 0 }),
-            false,
-        );
-        const { container: containerSix } = renderRow(
-            makeRow({ order_seq: 6 }),
-            false,
-        );
-        const { container: containerOne } = renderRow(
-            makeRow({ order_seq: 1 }),
-            false,
-        );
+    it('renders no order-grouping mark by default (no hover)', () => {
+        const { container } = renderRow(makeRow({ order_seq: 3 }), false);
 
-        const rowZero = within(containerZero).getByRole('row');
-        const rowSix = within(containerSix).getByRole('row');
-        const rowOne = within(containerOne).getByRole('row');
+        const row = within(container).getByRole('row');
+        expect(row.className).not.toContain('border-l-blue-400');
+        expect(row.className).not.toContain('bg-blue-50');
+    });
 
-        // order_seq 0 and 6 are equal mod 6, so they share the same palette entry.
-        expect(rowZero.className).toContain('border-l-blue-400');
-        expect(rowSix.className).toContain('border-l-blue-400');
-        // order_seq 1 maps to a different palette entry.
-        expect(rowOne.className).not.toContain('border-l-blue-400');
+    it('calls onHoverChange with the order_seq on mouse enter, and null on mouse leave', () => {
+        const onHoverChange = vi.fn();
+        const { container } = renderRow(makeRow({ order_seq: 4 }), false, {
+            onHoverChange,
+        });
+
+        const row = within(container).getByRole('row');
+
+        fireEvent.mouseEnter(row);
+        expect(onHoverChange).toHaveBeenCalledWith(4);
+
+        fireEvent.mouseLeave(row);
+        expect(onHoverChange).toHaveBeenCalledWith(null);
+    });
+
+    it('carries the highlight classes when isHighlighted is true, and not when false', () => {
+        const { container: highlighted } = renderRow(makeRow(), false, {
+            isHighlighted: true,
+        });
+        const { container: notHighlighted } = renderRow(makeRow(), false, {
+            isHighlighted: false,
+        });
+
+        const highlightedRow = within(highlighted).getByRole('row');
+        const notHighlightedRow = within(notHighlighted).getByRole('row');
+
+        expect(highlightedRow.className).toContain('border-l-blue-400');
+        expect(notHighlightedRow.className).not.toContain('border-l-blue-400');
     });
 });


### PR DESCRIPTION
## Resumen

Reemplaza la paleta de color persistente por pedido del tablero de edición (`ORDER_LINK_CLASSES`, cicleada por `order_seq`) por un resaltado guiado por hover. Con muchos pedidos por curso la paleta se repetía y pedidos no relacionados terminaban compartiendo color, lo que anulaba su propósito.

## Cambios

- Se elimina por completo la paleta persistente: sin hover, ninguna fila muestra marca de agrupación por pedido.
- El estado de hover (`hoveredOrderSeq`) se eleva a `ClassroomTable`, de modo que al pasar el mouse sobre una fila se resaltan todas las filas con el mismo `order_seq` dentro del curso, incluso si están en distintas sub-tablas de producto con foto.
- Al mover el mouse a otro pedido el resaltado se traslada; los demás pedidos no se ven afectados.
- El borde izquierdo se mantiene transparente en reposo para conservar el ancho de fila estable.

## Fuera de alcance

- No se toca el layout Escuela → Curso → Producto con foto de #193.

## Tests

- `edition-row.test.tsx`: se reemplazan las aserciones de color fijo por casos de hover (sin marca por defecto, callbacks de `mouseEnter`/`mouseLeave`, clase de resaltado cuando `isHighlighted`).
- `classroom-table.test.tsx`: nuevo caso que verifica el resaltado entre sub-tablas al pasar el mouse, dejando intactos los demás pedidos.

Closes #198