### PR TITLE
fix(editor-assignments): unificar el scope de asignabilidad entre bulk e individual

### DIFF
--- a/app/Actions/EditorAssignments/AssignEditorAction.php
+++ b/app/Actions/EditorAssignments/AssignEditorAction.php
@@ -18,9 +18,10 @@ use Illuminate\Validation\ValidationException;
 class AssignEditorAction implements ActionContract
 {
     /**
-     * Assign (or reassign) an editor to an order detail. The detail's
-     * product must be editable by photo (`has_photo`); reassigning
-     * overwrites the previous assignment (unique per detail, no history).
+     * Assign (or reassign) an editor to an order detail. The detail must be
+     * assignable (`OrderDetail::assignableToEditor`, the same scope used by
+     * the bulk path); reassigning overwrites the previous assignment
+     * (unique per detail, no history).
      *
      * @param  EditorAssignmentData  $params
      *
@@ -28,11 +29,16 @@ class AssignEditorAction implements ActionContract
      */
     public function handle(DtoContract $params): void
     {
-        $detail = OrderDetail::with('product')->findOrFail($params->orderDetailId);
+        $detail = OrderDetail::findOrFail($params->orderDetailId);
 
-        if ($detail->product?->has_photo !== true) {
+        $isAssignable = OrderDetail::query()
+            ->assignableToEditor()
+            ->whereKey($params->orderDetailId)
+            ->exists();
+
+        if (! $isAssignable) {
             throw ValidationException::withMessages([
-                'order_detail_id' => 'Este producto no admite edición de foto.',
+                'order_detail_id' => 'Esta fila no admite asignación de editor.',
             ]);
         }
 

--- a/app/Actions/EditorAssignments/BulkAssignEditorAction.php
+++ b/app/Actions/EditorAssignments/BulkAssignEditorAction.php
@@ -28,13 +28,9 @@ class BulkAssignEditorAction implements ActionContract
     public function handle(DtoContract $params): BulkEditorAssignmentResult
     {
         $inScope = OrderDetail::query()
-            ->whereHas('product', fn ($query) => $query->where('has_photo', true)->whereIn('id', $params->productIds))
-            ->whereNotNull('production_enabled_at')
-            ->whereNull('delivered_at')
-            ->whereNull('recycled_to')
+            ->assignableToEditor()
+            ->whereHas('product', fn ($query) => $query->whereIn('id', $params->productIds))
             ->whereHas('order', function ($query) use ($params) {
-                $query->whereNull('cancelled_at');
-
                 if ($params->classroomId !== null) {
                     $query->where('classroom_id', $params->classroomId);
                 } else {

--- a/app/Models/OrderDetail.php
+++ b/app/Models/OrderDetail.php
@@ -104,6 +104,23 @@ class OrderDetail extends Pivot
         return $query->whereDoesntHave('editingStatusChanges');
     }
 
+    /**
+     * Details assignable to an editor: photo product, production enabled,
+     * not delivered, not recycled, and belonging to a non-cancelled order.
+     *
+     * @param  Builder<OrderDetail>  $query
+     * @return Builder<OrderDetail>
+     */
+    public function scopeAssignableToEditor(Builder $query): Builder
+    {
+        return $query
+            ->whereHas('product', fn ($query) => $query->where('has_photo', true))
+            ->whereNotNull('production_enabled_at')
+            ->whereNull('delivered_at')
+            ->whereNull('recycled_to')
+            ->whereHas('order', fn ($query) => $query->whereNull('cancelled_at'));
+    }
+
     protected $casts = [
         'variant' => 'array',
         'priority' => 'boolean',

--- a/tests/Feature/EditorAssignmentTest.php
+++ b/tests/Feature/EditorAssignmentTest.php
@@ -22,7 +22,7 @@ it('assigns an editor to a photo detail', function (UserRole $role) {
     $actor = actingAsRole($role);
 
     $product = Product::factory()->create(['has_photo' => true]);
-    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
     $editor = User::factory()->withRole(UserRole::Editor)->create();
 
     post(route('editor-assignments.store'), [
@@ -45,7 +45,7 @@ it('accepts an editor_id belonging to a user with the administración role', fun
     actingAsRole(UserRole::Office);
 
     $product = Product::factory()->create(['has_photo' => true]);
-    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
     $admin = User::factory()->withRole(UserRole::Admin)->create();
 
     post(route('editor-assignments.store'), [
@@ -61,7 +61,7 @@ it('overwrites the previous assignment on reassignment', function () {
     actingAsRole(UserRole::Office);
 
     $product = Product::factory()->create(['has_photo' => true]);
-    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $detail = OrderDetail::factory()->enabled()->create(['product_id' => $product->id]);
     $firstEditor = User::factory()->withRole(UserRole::Editor)->create();
     $secondEditor = User::factory()->withRole(UserRole::Editor)->create();
 

--- a/tests/Feature/EditorAssignmentTest.php
+++ b/tests/Feature/EditorAssignmentTest.php
@@ -129,6 +129,70 @@ it('rejects assigning a detail whose product does not admit photo editing', func
     expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
 });
 
+it('rejects assigning a detail not enabled for production', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors('order_detail_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects assigning a delivered detail', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->delivered()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors('order_detail_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects assigning a recycled detail', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $detail = OrderDetail::factory()->enabled()->recycled()->create(['product_id' => $product->id]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors('order_detail_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
+it('rejects assigning a detail whose order is cancelled', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $cancelledOrder = Order::factory()->cancelled()->create();
+    $detail = OrderDetail::factory()->enabled()->create([
+        'order_id' => $cancelledOrder->id,
+        'product_id' => $product->id,
+    ]);
+    $editor = User::factory()->withRole(UserRole::Editor)->create();
+
+    post(route('editor-assignments.store'), [
+        'order_detail_id' => $detail->id,
+        'editor_id' => $editor->id,
+    ])->assertSessionHasErrors('order_detail_id');
+
+    expect(EditorOrderDetailAssignment::where('order_detail_id', $detail->id)->exists())->toBeFalse();
+});
+
 it('denies editor and taller from assigning individually', function (UserRole $role) {
     actingAsRole($role);
 


### PR DESCRIPTION
## Qué

Unifica el criterio de "qué `order_detail` es asignable a un editor" para que la asignación individual y por lote usen una única definición compartida. Antes, `BulkAssignEditorAction` aplicaba las cinco condiciones y `AssignEditorAction` solo `has_photo`, de modo que `POST /editor-assignments` creaba filas que el bulk omitía a propósito.

## Cómo

- Nuevo scope reutilizable `OrderDetail::scopeAssignableToEditor()` con las cinco condiciones: producto con `has_photo`, `production_enabled_at` no nulo, `delivered_at` nulo, `recycled_to` nulo y pedido no cancelado.
- `BulkAssignEditorAction` lo consume y conserva sus filtros propios (`product_ids` y escuela/curso); su comportamiento no cambia.
- `AssignEditorAction` lo consume y rechaza con `ValidationException` (clave `order_detail_id`, mensaje en castellano) cuando la fila queda fuera de scope. Se conserva el guard de estado de edición `pendiente`.
- `UnassignEditorAction` no se toca: la desasignación no se scopea.

## Tests

- Cuatro casos nuevos en el path individual: fila no habilitada, entregada, reciclada y pedido cancelado.
- Los happy-path individuales existentes se actualizan a filas habilitadas, ahora que el criterio también aplica al path individual.

Closes #185
