### PR TITLE
fix(editor-assignment): ocultar el bulk de asignar editor cuando el alcance no tiene filas elegibles

### DIFF
--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -14,6 +14,7 @@ use App\Http\Requests\BO\UpdateClassroomRequest;
 use App\Http\Resources\ClassroomStudentResource;
 use App\Models\Classroom;
 use App\Models\Order;
+use App\Models\OrderDetail;
 use App\Models\OrderDraft;
 use App\Models\Product;
 use App\Models\User;
@@ -72,6 +73,10 @@ class ClassroomController extends Controller
             'filters' => ['search' => $search],
             'assignableEditors' => User::assignableEditors()->get(['id', 'name']),
             'photoProducts' => Product::where('has_photo', true)->get(['id', 'name']),
+            'hasAssignableDetails' => OrderDetail::query()
+                ->assignableToEditor()
+                ->whereHas('order', fn ($query) => $query->where('classroom_id', $classroom->id))
+                ->exists(),
         ]);
     }
 

--- a/app/Http/Controllers/BO/SchoolController.php
+++ b/app/Http/Controllers/BO/SchoolController.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSchoolRequest;
 use App\Http\Resources\SchoolResource;
 use App\Models\Order;
+use App\Models\OrderDetail;
 use App\Models\Product;
 use App\Models\School;
 use App\Models\User;
@@ -116,6 +117,13 @@ class SchoolController extends Controller
             ])),
             'assignableEditors' => User::assignableEditors()->get(['id', 'name']),
             'photoProducts' => Product::where('has_photo', true)->get(['id', 'name']),
+            'hasAssignableDetails' => OrderDetail::query()
+                ->assignableToEditor()
+                ->whereHas('order', fn ($query) => $query->whereHas(
+                    'classroom',
+                    fn ($classroom) => $classroom->where('school_id', $school->id),
+                ))
+                ->exists(),
         ]);
     }
 }

--- a/resources/js/pages/classrooms/show.tsx
+++ b/resources/js/pages/classrooms/show.tsx
@@ -24,12 +24,14 @@ export default function ClassroomShow({
     filters,
     assignableEditors,
     photoProducts,
+    hasAssignableDetails,
 }: PageProps<{
     classroom: Classroom & { teacher?: Teacher; school: School };
     students: Paginated<ClassroomStudent>;
     filters: { search: string | null };
     assignableEditors: AssignableEditor[];
     photoProducts: PhotoProduct[];
+    hasAssignableDetails: boolean;
 }>) {
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -101,11 +103,13 @@ export default function ClassroomShow({
                         Alumnos ({students.data.length})
                     </h2>
                     <div className="flex flex-wrap gap-2">
-                        <BulkAssignEditorDialog
-                            assignableEditors={assignableEditors}
-                            photoProducts={photoProducts}
-                            classroomId={classroom.id}
-                        />
+                        {hasAssignableDetails && (
+                            <BulkAssignEditorDialog
+                                assignableEditors={assignableEditors}
+                                photoProducts={photoProducts}
+                                classroomId={classroom.id}
+                            />
+                        )}
                         <Link
                             href={route('photos.index', {
                                 classroom: classroom.id,

--- a/resources/js/pages/classrooms/tests/show.test.tsx
+++ b/resources/js/pages/classrooms/tests/show.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import ClassroomShow from '../show';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    Link: ({
+        href,
+        children,
+        ...props
+    }: {
+        href: string;
+        children?: ReactNode;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+    router: { get: vi.fn() },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+}));
+
+vi.mock('@/features/editor-assignment/BulkAssignEditorDialog', () => ({
+    BulkAssignEditorDialog: () => <button type="button">Asignar editor</button>,
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}?${new URLSearchParams(
+            Object.entries(params ?? {}).map(([key, value]) => [
+                key,
+                String(value),
+            ]),
+        )}`,
+);
+
+const classroom = {
+    id: 10,
+    name: '5 A',
+    school_id: 7,
+    school: { id: 7, name: 'Escuela Normal' },
+} as unknown as Classroom & { teacher?: Teacher; school: School };
+
+const baseProps = {
+    classroom,
+    students: {
+        data: [],
+        meta: {
+            current_page: 1,
+            from: 0,
+            last_page: 1,
+            links: [],
+            path: '',
+            per_page: 20,
+            to: 0,
+            total: 0,
+        },
+        links: { first: null, last: null, prev: null, next: null },
+    },
+    filters: { search: null },
+    assignableEditors: [],
+    photoProducts: [],
+} as unknown as Parameters<typeof ClassroomShow>[0];
+
+describe('ClassroomShow', () => {
+    it('hides the bulk editor assignment trigger when the scope has no assignable details', () => {
+        render(<ClassroomShow {...baseProps} hasAssignableDetails={false} />);
+
+        expect(screen.queryByText('Asignar editor')).toBeNull();
+        expect(
+            screen.getByRole('link', { name: /Gestionar fotos/ }),
+        ).toBeTruthy();
+    });
+
+    it('shows the bulk editor assignment trigger when the scope has an assignable detail', () => {
+        render(<ClassroomShow {...baseProps} hasAssignableDetails={true} />);
+
+        expect(screen.getByText('Asignar editor')).toBeTruthy();
+        expect(
+            screen.getByRole('link', { name: /Gestionar fotos/ }),
+        ).toBeTruthy();
+    });
+});

--- a/resources/js/pages/schools/show.tsx
+++ b/resources/js/pages/schools/show.tsx
@@ -15,12 +15,14 @@ export default function School({
     school,
     assignableEditors,
     photoProducts,
+    hasAssignableDetails,
 }: PageProps<{
     school: {
         data: SchoolShowData;
     };
     assignableEditors: AssignableEditor[];
     photoProducts: PhotoProduct[];
+    hasAssignableDetails: boolean;
 }>) {
     const controller = useSchoolShow();
 
@@ -44,11 +46,13 @@ export default function School({
             <SchoolInfoCard school={school.data} />
 
             <div className="flex justify-end px-6 pt-4">
-                <BulkAssignEditorDialog
-                    assignableEditors={assignableEditors}
-                    photoProducts={photoProducts}
-                    schoolId={school.data.id}
-                />
+                {hasAssignableDetails && (
+                    <BulkAssignEditorDialog
+                        assignableEditors={assignableEditors}
+                        photoProducts={photoProducts}
+                        schoolId={school.data.id}
+                    />
+                )}
             </div>
 
             <ClassroomsTable school={school.data} controller={controller} />

--- a/resources/js/pages/schools/tests/show.test.tsx
+++ b/resources/js/pages/schools/tests/show.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import School from '../show';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    Link: ({
+        href,
+        children,
+        ...props
+    }: {
+        href: string;
+        children?: ReactNode;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+    router: { get: vi.fn() },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+    onSort: vi.fn(),
+}));
+
+vi.mock('@/features/editor-assignment/BulkAssignEditorDialog', () => ({
+    BulkAssignEditorDialog: () => <button type="button">Asignar editor</button>,
+}));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}?${new URLSearchParams(
+            Object.entries(params ?? {}).map(([key, value]) => [
+                key,
+                String(value),
+            ]),
+        )}`,
+);
+
+const school = {
+    data: {
+        id: 7,
+        name: 'Escuela Normal',
+        level: 'Primaria',
+        user_id: 1,
+        user: { id: 1, name: 'Marta' },
+        classrooms: [],
+    },
+} as unknown as Parameters<typeof School>[0]['school'];
+
+const baseProps = {
+    school,
+    assignableEditors: [],
+    photoProducts: [],
+} as unknown as Parameters<typeof School>[0];
+
+describe('School show', () => {
+    it('hides the bulk editor assignment trigger when the scope has no assignable details', () => {
+        render(<School {...baseProps} hasAssignableDetails={false} />);
+
+        expect(screen.queryByText('Asignar editor')).toBeNull();
+    });
+
+    it('shows the bulk editor assignment trigger when the scope has an assignable detail', () => {
+        render(<School {...baseProps} hasAssignableDetails={true} />);
+
+        expect(screen.getByText('Asignar editor')).toBeTruthy();
+    });
+});

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Models\Classroom;
 use App\Models\Client;
 use App\Models\Order;
+use App\Models\OrderDetail;
 use App\Models\OrderDraft;
+use App\Models\Product;
 use Inertia\Testing\AssertableInertia as Assert;
 
 use function Pest\Laravel\get;
@@ -76,5 +78,35 @@ it('counts both orders and drafts in the pagination total', function () {
 
     get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
         fn (Assert $page) => $page->where('students.meta.total', 5),
+    );
+});
+
+it('reports no assignable details when the classroom has none in scope', function () {
+    $classroom = Classroom::factory()->create();
+
+    $product = Product::factory()->create(['has_photo' => false]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
+        fn (Assert $page) => $page->where('hasAssignableDetails', false),
+    );
+});
+
+it('reports assignable details when the classroom has at least one in scope', function () {
+    $classroom = Classroom::factory()->create();
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
+        fn (Assert $page) => $page->where('hasAssignableDetails', true),
     );
 });

--- a/tests/Feature/SchoolShowTest.php
+++ b/tests/Feature/SchoolShowTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Classroom;
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\School;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    actingAsRole();
+});
+
+it('reports no assignable details when none of the school classrooms have one in scope', function () {
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
+
+    $product = Product::factory()->create(['has_photo' => false]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    get(route('schools.show', ['school' => $school->id]))->assertInertia(
+        fn (Assert $page) => $page
+            ->component('schools/show')
+            ->where('hasAssignableDetails', false),
+    );
+});
+
+it('reports assignable details when at least one classroom has one in scope', function () {
+    $school = School::factory()->create();
+    $classroom = Classroom::factory()->create(['school_id' => $school->id]);
+
+    $product = Product::factory()->create(['has_photo' => true]);
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    OrderDetail::factory()->enabled()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+    ]);
+
+    get(route('schools.show', ['school' => $school->id]))->assertInertia(
+        fn (Assert $page) => $page
+            ->component('schools/show')
+            ->where('hasAssignableDetails', true),
+    );
+});


### PR DESCRIPTION
## Contexto

El punto de entrada del bulk "Asignar editor" (botón + `BulkAssignEditorDialog`) se renderizaba siempre en las vistas de escuela y curso, incluso cuando el alcance no tenía ninguna fila elegible según `OrderDetail::scopeAssignableToEditor()` (#185): producto con `has_photo`, producción habilitada, no entregado, no reciclado y pedido no cancelado.

## Cambios

- `ClassroomController@show` y `SchoolController@show` calculan un booleano `hasAssignableDetails` reutilizando el scope `OrderDetail::assignableToEditor()`, acotado por curso (`order.classroom_id`) o escuela (`order.classroom.school_id`), y lo pasan a la vista Inertia.
- `classrooms/show.tsx` y `schools/show.tsx` solo renderizan `<BulkAssignEditorDialog>` cuando `hasAssignableDetails` es `true`. Cuando es `true`, el comportamiento actual (checklist de `photoProducts`) se mantiene sin cambios.
- `photoProducts` y el resto de props no cambian; solo se agrega la señal de gating.

## Tests

- Pest por controller (`ClassroomShowTest`, `SchoolShowTest`): sin filas elegibles → la prop llega en `false`; con al menos una elegible → `true`.
- Vitest para `classrooms/show.tsx` y `schools/show.tsx`: con el booleano en `false` el botón "Asignar editor" no está en el DOM; con `true`, sí.

## Fuera de alcance

- No se toca `BulkAssignEditorAction`/`AssignEditorAction` ni el criterio de asignabilidad (ya resueltos en #185).
- La vista de edición (#177/#190) no se modifica.

Closes #188
