### PR TITLE
feat(photos): comprimir subidas client-side y carga individual desde la orden

### DIFF
--- a/app/Http/Controllers/BO/PhotoController.php
+++ b/app/Http/Controllers/BO/PhotoController.php
@@ -33,12 +33,16 @@ class PhotoController extends Controller
         /** @var UploadedFile $photo */
         $photo = $request->file('photo');
 
-        // Extract number from filename (e.g., "001.jpg" -> 1, "photo_042.png" -> 42)
-        if (! preg_match('/(\d+)/', $photo->getClientOriginalName(), $matches)) {
-            return back()->withErrors(['photo' => 'El nombre del archivo debe contener un número (ej: 001.jpg, foto_025.png)']);
-        }
+        if ($request->filled('number')) {
+            $photoNumber = (int) $request->integer('number');
+        } else {
+            // Extract number from filename (e.g., "001.jpg" -> 1, "photo_042.png" -> 42)
+            if (! preg_match('/(\d+)/', $photo->getClientOriginalName(), $matches)) {
+                return back()->withErrors(['photo' => 'El nombre del archivo debe contener un número (ej: 001.jpg, foto_025.png)']);
+            }
 
-        $photoNumber = (int) $matches[1];
+            $photoNumber = (int) $matches[1];
+        }
 
         // Reject a number already used in this classroom
         $existingPhoto = Photo::where('classroom_id', $classroom->id)

--- a/app/Http/Requests/BO/StorePhotoRequest.php
+++ b/app/Http/Requests/BO/StorePhotoRequest.php
@@ -21,6 +21,7 @@ class StorePhotoRequest extends FormRequest
     {
         return [
             'photo' => ['required', 'image', 'max:5120'], // 5MB
+            'number' => ['nullable', 'integer', 'min:1'],
         ];
     }
 }

--- a/resources/js/lib/compress-image.test.ts
+++ b/resources/js/lib/compress-image.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { compressImage } from './compress-image';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('compressImage', () => {
+    it('falls back to the original file when the canvas 2d context is unavailable', async () => {
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+        vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+            null,
+        );
+        vi.stubGlobal(
+            'Image',
+            class {
+                onload: (() => void) | null = null;
+                onerror: (() => void) | null = null;
+                width = 100;
+                height = 100;
+                set src(_value: string) {
+                    this.onload?.();
+                }
+            },
+        );
+
+        const original = new File(['data'], 'foto.jpg', {
+            type: 'image/jpeg',
+        });
+
+        const result = await compressImage(original);
+
+        expect(result).toBe(original);
+    });
+
+    it('falls back to the original file when the image fails to load', async () => {
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+        vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+        vi.stubGlobal(
+            'Image',
+            class {
+                onload: (() => void) | null = null;
+                onerror: (() => void) | null = null;
+                set src(_value: string) {
+                    this.onerror?.();
+                }
+            },
+        );
+
+        const original = new File(['data'], 'foto.jpg', {
+            type: 'image/jpeg',
+        });
+
+        await expect(compressImage(original)).resolves.toBe(original);
+    });
+});

--- a/resources/js/lib/compress-image.ts
+++ b/resources/js/lib/compress-image.ts
@@ -1,0 +1,60 @@
+const MAX_DIMENSION = 800;
+const JPEG_QUALITY = 0.78;
+
+/**
+ * Resizes and compresses an image File client-side via canvas: the longest
+ * side is capped at MAX_DIMENSION (never upscaled) and re-encoded as JPEG at
+ * JPEG_QUALITY. Never rejects — any failure (load error, missing canvas
+ * context, null blob) resolves to the original file so uploads still proceed.
+ */
+export async function compressImage(file: File): Promise<File> {
+    try {
+        const image = await loadImage(file);
+        const scale = Math.min(
+            1,
+            MAX_DIMENSION / Math.max(image.width, image.height),
+        );
+        const width = Math.round(image.width * scale);
+        const height = Math.round(image.height * scale);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return file;
+        }
+
+        context.drawImage(image, 0, 0, width, height);
+
+        const blob = await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob(resolve, 'image/jpeg', JPEG_QUALITY);
+        });
+
+        if (!blob) {
+            return file;
+        }
+
+        const baseName = file.name.replace(/\.[^./\\]+$/, '');
+
+        return new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' });
+    } catch {
+        return file;
+    }
+}
+
+async function loadImage(file: File): Promise<HTMLImageElement> {
+    const objectUrl = URL.createObjectURL(file);
+
+    try {
+        return await new Promise<HTMLImageElement>((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = () => reject(new Error('Failed to load image'));
+            image.src = objectUrl;
+        });
+    } finally {
+        URL.revokeObjectURL(objectUrl);
+    }
+}

--- a/resources/js/pages/orders/components/order-info-card.tsx
+++ b/resources/js/pages/orders/components/order-info-card.tsx
@@ -14,6 +14,7 @@ import { Ban, Edit2, User } from 'lucide-react';
 import { useState } from 'react';
 import { useEditClientForm } from '../hooks/use-edit-client-form';
 import { EditClientModal } from './edit-client-modal';
+import { OrderPhotoUpload } from './order-photo-upload';
 
 const STATUS_STYLES: Record<string, string> = {
     'sin habilitar': 'bg-zinc-400 hover:bg-zinc-400',
@@ -125,6 +126,7 @@ export function OrderInfoCard({ order, onCancel }: OrderInfoCardProps) {
                             />
                         </a>
                     )}
+                    <OrderPhotoUpload order={order} />
                     <CardDescription>
                         Total: {formatPrice(order.total_price)}
                     </CardDescription>

--- a/resources/js/pages/orders/components/order-photo-upload.tsx
+++ b/resources/js/pages/orders/components/order-photo-upload.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/components/ui/button';
+import { Upload } from 'lucide-react';
+import { useOrderPhotoUpload } from '../hooks/use-order-photo-upload';
+
+interface OrderPhotoUploadProps {
+    order: Order;
+}
+
+export function OrderPhotoUpload({ order }: OrderPhotoUploadProps) {
+    const {
+        enabled,
+        fileInputRef,
+        file,
+        processing,
+        handleFileChange,
+        submit,
+    } = useOrderPhotoUpload(order);
+
+    if (!enabled) {
+        return null;
+    }
+
+    return (
+        <div className="mt-2 flex items-center gap-2">
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="block text-xs text-gray-500 file:mr-2 file:rounded-full file:border-0 file:bg-blue-50 file:px-2 file:py-1 file:text-xs file:font-semibold file:text-blue-700 hover:file:bg-blue-100 dark:text-gray-400 dark:file:bg-blue-900 dark:file:text-blue-200 dark:hover:file:bg-blue-800"
+            />
+            <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!file || processing}
+                onClick={submit}
+            >
+                <Upload className="mr-1 h-4 w-4" />
+                {processing ? 'Subiendo...' : 'Subir foto'}
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/pages/orders/hooks/use-order-photo-upload.ts
+++ b/resources/js/pages/orders/hooks/use-order-photo-upload.ts
@@ -1,0 +1,79 @@
+import { compressImage } from '@/lib/compress-image';
+import { router } from '@inertiajs/react';
+import { ChangeEvent, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Uploads a single photo for this order's assigned `photo_number`, reusing
+ * the classroom `photos.store` endpoint with the number sent explicitly
+ * (filename parsing is irrelevant for this flow). No-op when the order has
+ * no `photo_number` assigned yet.
+ */
+export function useOrderPhotoUpload(order: Order) {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [file, setFile] = useState<File | null>(null);
+    const [processing, setProcessing] = useState(false);
+
+    const enabled =
+        order.photo_number !== null && order.photo_number !== undefined;
+
+    const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setFile(e.target.files?.[0] ?? null);
+    };
+
+    const submit = async () => {
+        if (!enabled || !file || processing) {
+            return;
+        }
+
+        setProcessing(true);
+
+        try {
+            const compressed = await compressImage(file);
+
+            await new Promise<void>((resolve, reject) => {
+                router.post(
+                    route('photos.store', {
+                        classroom: order.classroom.id,
+                    }),
+                    { photo: compressed, number: order.photo_number },
+                    {
+                        forceFormData: true,
+                        preserveScroll: true,
+                        onSuccess: () => resolve(),
+                        onError: (errors) =>
+                            reject(
+                                new Error(
+                                    Object.values(errors)[0] ??
+                                        'No se pudo subir la foto',
+                                ),
+                            ),
+                    },
+                );
+            });
+
+            toast.success('Foto subida');
+            setFile(null);
+            if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+            }
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : 'No se pudo subir la foto',
+            );
+        } finally {
+            setProcessing(false);
+        }
+    };
+
+    return {
+        enabled,
+        fileInputRef,
+        file,
+        processing,
+        handleFileChange,
+        submit,
+    };
+}

--- a/resources/js/pages/orders/tests/use-order-photo-upload.test.tsx
+++ b/resources/js/pages/orders/tests/use-order-photo-upload.test.tsx
@@ -1,0 +1,105 @@
+import { router } from '@inertiajs/react';
+import { act, renderHook } from '@testing-library/react';
+import { ChangeEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOrderPhotoUpload } from '../hooks/use-order-photo-upload';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: vi.fn() },
+}));
+
+const compressImage = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/compress-image', () => ({ compressImage }));
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast }));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.classroom ?? ''}`,
+);
+
+const post = vi.mocked(router.post);
+
+function makeOrder(photoNumber: number | null): Order {
+    return {
+        photo_number: photoNumber,
+        classroom: { id: 5, name: 'Sala Azul' },
+    } as Order;
+}
+
+function selectFile(
+    handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void,
+    file: File,
+) {
+    act(() => {
+        handleFileChange({
+            target: { files: [file] },
+        } as unknown as ChangeEvent<HTMLInputElement>);
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useOrderPhotoUpload', () => {
+    it('sends the order photo_number explicitly', async () => {
+        const order = makeOrder(42);
+        const compressed = new File(['compressed'], 'compressed.jpg');
+        compressImage.mockResolvedValue(compressed);
+        post.mockImplementation((_url, _data, options) => {
+            options?.onSuccess?.({} as never);
+        });
+
+        const file = new File(['data'], 'foto.jpg', { type: 'image/jpeg' });
+        const { result } = renderHook(() => useOrderPhotoUpload(order));
+
+        selectFile(result.current.handleFileChange, file);
+
+        await act(() => result.current.submit());
+
+        expect(post).toHaveBeenCalledWith(
+            'http://localhost/photos.store/5',
+            { photo: compressed, number: 42 },
+            expect.objectContaining({ forceFormData: true }),
+        );
+    });
+
+    it('is disabled and does not upload when photo_number is null', async () => {
+        const order = makeOrder(null);
+        const file = new File(['data'], 'foto.jpg', { type: 'image/jpeg' });
+
+        const { result } = renderHook(() => useOrderPhotoUpload(order));
+
+        expect(result.current.enabled).toBe(false);
+
+        selectFile(result.current.handleFileChange, file);
+
+        await act(() => result.current.submit());
+
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('shows a success toast and clears the file on success', async () => {
+        const order = makeOrder(42);
+        const compressed = new File(['compressed'], 'compressed.jpg');
+        compressImage.mockResolvedValue(compressed);
+        post.mockImplementation((_url, _data, options) => {
+            options?.onSuccess?.({} as never);
+        });
+
+        const file = new File(['data'], 'foto.jpg', { type: 'image/jpeg' });
+        const { result } = renderHook(() => useOrderPhotoUpload(order));
+
+        selectFile(result.current.handleFileChange, file);
+
+        await act(() => result.current.submit());
+
+        expect(toast.success).toHaveBeenCalled();
+        expect(result.current.file).toBeNull();
+    });
+});

--- a/resources/js/pages/photos/components/photo-upload-form.tsx
+++ b/resources/js/pages/photos/components/photo-upload-form.tsx
@@ -1,23 +1,36 @@
 import { Button } from '@/components/ui/button';
 import { Upload } from 'lucide-react';
 import { ChangeEvent, FormEventHandler, RefObject } from 'react';
+import { FileUploadStatus } from '../hooks/use-photo-index';
 
 interface PhotoUploadFormProps {
     submit: FormEventHandler;
     handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
     fileInputRef: RefObject<HTMLInputElement | null>;
-    previewUrl: string | null;
-    photoFile: File | null;
+    uploads: FileUploadStatus[];
     processing: boolean;
     totalPhotos: number;
 }
+
+const STATUS_LABEL: Record<FileUploadStatus['status'], string> = {
+    pending: 'Pendiente',
+    uploading: 'Subiendo...',
+    done: 'Subida',
+    error: 'Error',
+};
+
+const STATUS_STYLES: Record<FileUploadStatus['status'], string> = {
+    pending: 'text-gray-500',
+    uploading: 'text-blue-600',
+    done: 'text-green-600',
+    error: 'text-red-600',
+};
 
 export function PhotoUploadForm({
     submit,
     handleFileChange,
     fileInputRef,
-    previewUrl,
-    photoFile,
+    uploads,
     processing,
     totalPhotos,
 }: PhotoUploadFormProps) {
@@ -25,45 +38,51 @@ export function PhotoUploadForm({
         <div className="lg:col-span-1">
             <div className="sticky top-8 rounded-lg bg-gray-50 p-6 dark:bg-gray-800">
                 <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
-                    Subir nueva foto
+                    Subir nuevas fotos
                 </h2>
 
                 <form onSubmit={submit} className="space-y-4">
                     <div>
                         <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            Seleccionar archivo
+                            Seleccionar archivos
                         </label>
                         <input
                             ref={fileInputRef}
                             type="file"
                             accept="image/*"
+                            multiple
                             onChange={handleFileChange}
                             className="block w-full text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100 dark:text-gray-400 dark:file:bg-blue-900 dark:file:text-blue-200 dark:hover:file:bg-blue-800"
                         />
                     </div>
 
-                    {previewUrl && (
-                        <div className="mb-4">
-                            <img
-                                src={previewUrl}
-                                alt="Vista previa"
-                                className="h-auto max-h-64 w-full rounded-lg object-cover"
-                            />
-                        </div>
-                    )}
-
-                    {photoFile && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                            Archivo: {photoFile.name}
-                        </p>
+                    {uploads.length > 0 && (
+                        <ul className="max-h-64 space-y-1 overflow-auto text-sm">
+                            {uploads.map((upload, index) => (
+                                <li
+                                    key={`${upload.name}-${index}`}
+                                    className="flex items-center justify-between gap-2 text-gray-600 dark:text-gray-400"
+                                >
+                                    <span className="truncate">
+                                        {upload.name}
+                                    </span>
+                                    <span
+                                        className={STATUS_STYLES[upload.status]}
+                                        title={upload.error}
+                                    >
+                                        {STATUS_LABEL[upload.status]}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
                     )}
 
                     <Button
-                        disabled={!photoFile || processing}
+                        disabled={uploads.length === 0 || processing}
                         className="w-full gap-2"
                     >
                         <Upload className="h-4 w-4" />
-                        {processing ? 'Subiendo...' : 'Subir foto'}
+                        {processing ? 'Subiendo...' : 'Subir fotos'}
                     </Button>
                 </form>
 

--- a/resources/js/pages/photos/hooks/use-photo-index.ts
+++ b/resources/js/pages/photos/hooks/use-photo-index.ts
@@ -1,62 +1,105 @@
-import { useForm } from '@inertiajs/react';
+import { compressImage } from '@/lib/compress-image';
+import { router } from '@inertiajs/react';
 import { ChangeEvent, FormEventHandler, useRef, useState } from 'react';
 
 interface UsePhotoIndexParams {
     classroom: Classroom & { school: School };
 }
 
-export function usePhotoIndex({ classroom }: UsePhotoIndexParams) {
-    const {
-        post,
-        delete: destroy,
-        processing,
-        data,
-        setData,
-    } = useForm({
-        photo: null as File | null,
-    });
+export type FileUploadState = 'pending' | 'uploading' | 'done' | 'error';
 
+export interface FileUploadStatus {
+    name: string;
+    status: FileUploadState;
+    error?: string;
+}
+
+function uploadPhoto(classroomId: number, photo: File): Promise<void> {
+    return new Promise((resolve, reject) => {
+        router.post(
+            route('photos.store', { classroom: classroomId }),
+            { photo },
+            {
+                forceFormData: true,
+                preserveScroll: true,
+                onSuccess: () => resolve(),
+                onError: (errors) =>
+                    reject(
+                        new Error(
+                            Object.values(errors)[0] ??
+                                'No se pudo subir la foto',
+                        ),
+                    ),
+            },
+        );
+    });
+}
+
+export function usePhotoIndex({ classroom }: UsePhotoIndexParams) {
     const fileInputRef = useRef<HTMLInputElement>(null);
-    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [files, setFiles] = useState<File[]>([]);
+    const [uploads, setUploads] = useState<FileUploadStatus[]>([]);
+    const [processing, setProcessing] = useState(false);
 
     const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (file) {
-            setData('photo', file);
-            // Create preview
-            const reader = new FileReader();
-            reader.onloadend = () => {
-                setPreviewUrl(reader.result as string);
-            };
-            reader.readAsDataURL(file);
-        }
+        const selected = Array.from(e.target.files ?? []);
+        setFiles(selected);
+        setUploads(
+            selected.map((file) => ({ name: file.name, status: 'pending' })),
+        );
     };
 
-    const submit: FormEventHandler = (e) => {
+    const updateStatus = (index: number, patch: Partial<FileUploadStatus>) => {
+        setUploads((prev) =>
+            prev.map((upload, i) =>
+                i === index ? { ...upload, ...patch } : upload,
+            ),
+        );
+    };
+
+    const submit: FormEventHandler = async (e) => {
         e.preventDefault();
-        post(route('photos.store', { classroom: classroom.id }), {
-            forceFormData: true,
-            onSuccess: () => {
-                setData('photo', null);
-                setPreviewUrl(null);
-                if (fileInputRef.current) {
-                    fileInputRef.current.value = '';
-                }
-            },
-        });
+        if (files.length === 0 || processing) {
+            return;
+        }
+
+        setProcessing(true);
+
+        for (let i = 0; i < files.length; i++) {
+            updateStatus(i, { status: 'uploading' });
+
+            try {
+                const compressed = await compressImage(files[i]);
+                await uploadPhoto(classroom.id, compressed);
+                updateStatus(i, { status: 'done' });
+            } catch (error) {
+                updateStatus(i, {
+                    status: 'error',
+                    error:
+                        error instanceof Error
+                            ? error.message
+                            : 'No se pudo subir la foto',
+                });
+            }
+        }
+
+        setProcessing(false);
+        setFiles([]);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
     };
 
     const handleDelete = (photo: Photo) => {
         if (confirm(`¿Deseas eliminar la foto #${photo.number}?`)) {
-            destroy(route('photos.destroy', { photo: photo.id }));
+            router.delete(route('photos.destroy', { photo: photo.id }));
         }
     };
 
     return {
-        data,
-        processing,
         fileInputRef,
-        previewUrl,
+        uploads,
+        processing,
         handleFileChange,
         submit,
         handleDelete,

--- a/resources/js/pages/photos/index.tsx
+++ b/resources/js/pages/photos/index.tsx
@@ -11,10 +11,9 @@ export default function PhotoIndex({
     photos: Photo[];
 }) {
     const {
-        data,
-        processing,
         fileInputRef,
-        previewUrl,
+        uploads,
+        processing,
         handleFileChange,
         submit,
         handleDelete,
@@ -30,8 +29,7 @@ export default function PhotoIndex({
                         submit={submit}
                         handleFileChange={handleFileChange}
                         fileInputRef={fileInputRef}
-                        previewUrl={previewUrl}
-                        photoFile={data.photo}
+                        uploads={uploads}
                         processing={processing}
                         totalPhotos={photos.length}
                     />

--- a/resources/js/pages/photos/tests/use-photo-index.test.tsx
+++ b/resources/js/pages/photos/tests/use-photo-index.test.tsx
@@ -1,0 +1,128 @@
+import { router } from '@inertiajs/react';
+import { act, renderHook } from '@testing-library/react';
+import { ChangeEvent, FormEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePhotoIndex } from '../hooks/use-photo-index';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: vi.fn(), delete: vi.fn() },
+}));
+
+const compressImage = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/compress-image', () => ({ compressImage }));
+
+vi.stubGlobal(
+    'route',
+    (name: string, params?: Record<string, unknown>) =>
+        `http://localhost/${name}/${params?.classroom ?? ''}`,
+);
+
+const post = vi.mocked(router.post);
+
+const classroom = { id: 5, school: { id: 1, name: 'Escuela' } } as Classroom & {
+    school: School;
+};
+
+function makeFile(name: string): File {
+    return new File(['data'], name, { type: 'image/jpeg' });
+}
+
+function selectFiles(
+    handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void,
+    files: File[],
+) {
+    act(() => {
+        handleFileChange({
+            target: { files },
+        } as unknown as ChangeEvent<HTMLInputElement>);
+    });
+}
+
+function submitEvent(): FormEvent {
+    return { preventDefault: vi.fn() } as unknown as FormEvent;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('usePhotoIndex', () => {
+    it('uploads each selected file sequentially through compressImage', async () => {
+        const files = [
+            makeFile('001.jpg'),
+            makeFile('002.jpg'),
+            makeFile('003.jpg'),
+        ];
+        const compressed = files.map(
+            (file, i) => new File(['compressed'], `compressed-${i}.jpg`),
+        );
+        compressImage.mockImplementation(
+            async (file: File) => compressed[files.indexOf(file)],
+        );
+        post.mockImplementation((_url, _data, options) => {
+            options?.onSuccess?.({} as never);
+        });
+
+        const { result } = renderHook(() => usePhotoIndex({ classroom }));
+
+        selectFiles(result.current.handleFileChange, files);
+
+        await act(() => result.current.submit(submitEvent()));
+
+        expect(compressImage).toHaveBeenCalledTimes(3);
+        expect(post).toHaveBeenCalledTimes(3);
+        files.forEach((_, i) => {
+            expect(post).toHaveBeenNthCalledWith(
+                i + 1,
+                'http://localhost/photos.store/5',
+                { photo: compressed[i] },
+                expect.objectContaining({ forceFormData: true }),
+            );
+        });
+        expect(
+            result.current.uploads.every((upload) => upload.status === 'done'),
+        ).toBe(true);
+    });
+
+    it('one failing file does not abort the batch', async () => {
+        const files = [
+            makeFile('001.jpg'),
+            makeFile('002.jpg'),
+            makeFile('003.jpg'),
+        ];
+        compressImage.mockImplementation(async (file: File) => file);
+
+        let call = 0;
+        post.mockImplementation((_url, _data, options) => {
+            call += 1;
+            if (call === 2) {
+                options?.onError?.({ photo: 'dup' });
+            } else {
+                options?.onSuccess?.({} as never);
+            }
+        });
+
+        const { result } = renderHook(() => usePhotoIndex({ classroom }));
+
+        selectFiles(result.current.handleFileChange, files);
+
+        await act(() => result.current.submit(submitEvent()));
+
+        expect(post).toHaveBeenCalledTimes(3);
+        expect(result.current.uploads.map((upload) => upload.status)).toEqual([
+            'done',
+            'error',
+            'done',
+        ]);
+        expect(result.current.uploads[1].error).toBe('dup');
+    });
+
+    it('submit with no files selected is a no-op', async () => {
+        const { result } = renderHook(() => usePhotoIndex({ classroom }));
+
+        await act(() => result.current.submit(submitEvent()));
+
+        expect(post).not.toHaveBeenCalled();
+    });
+});

--- a/tests/Feature/PhotoTest.php
+++ b/tests/Feature/PhotoTest.php
@@ -50,6 +50,47 @@ it('rejects a filename without a number', function () {
     ])->assertSessionHasErrors('photo');
 });
 
+it('uses an explicit number over the filename', function () {
+    Storage::fake('public');
+    actingAsRole(UserRole::Editor);
+
+    $classroom = Classroom::factory()->create();
+
+    post(route('photos.store', $classroom), [
+        'photo' => UploadedFile::fake()->image('retrato.jpg'),
+        'number' => 7,
+    ])->assertSessionHasNoErrors();
+
+    $photo = Photo::where('classroom_id', $classroom->id)->first();
+
+    expect($photo?->number)->toBe(7);
+});
+
+it('rejects a duplicated explicit number in the classroom', function () {
+    Storage::fake('public');
+    actingAsRole(UserRole::Editor);
+
+    $classroom = Classroom::factory()->create();
+    Photo::factory()->create(['classroom_id' => $classroom->id, 'number' => 7]);
+
+    post(route('photos.store', $classroom), [
+        'photo' => UploadedFile::fake()->image('foto.jpg'),
+        'number' => 7,
+    ])->assertSessionHasErrors('photo');
+});
+
+it('rejects an explicit number below 1', function () {
+    Storage::fake('public');
+    actingAsRole(UserRole::Editor);
+
+    $classroom = Classroom::factory()->create();
+
+    post(route('photos.store', $classroom), [
+        'photo' => UploadedFile::fake()->image('foto.jpg'),
+        'number' => 0,
+    ])->assertSessionHasErrors('number');
+});
+
 it('renumbers the remaining photos after deleting one', function () {
     Storage::fake('public');
     actingAsRole(UserRole::Editor);


### PR DESCRIPTION
## Qué

Agrega compresión/resize client-side (canvas) a la subida de fotos y unifica los dos puntos de entrada sobre el mismo endpoint (`PhotoController@store`).

- **Compresión**: cada archivo se redimensiona (lado más largo máx. 800px, sin agrandar) y se re-codifica a JPEG (~0.78) en el navegador antes de subirse. Si algo falla, se sube el archivo original (nunca rompe la subida).
- **Curso (`classroom/:id`)**: el input acepta múltiples archivos; se procesan de forma secuencial (comprimir → subir) con feedback de progreso por archivo. Un fallo en un archivo (nombre sin número, número duplicado) no interrumpe el resto del lote. El número se sigue tomando del nombre del archivo.
- **Orden (`order/:id`)**: nuevo control de subida individual junto a la foto en la tarjeta del pedido; el número se toma de `order.photo_number` y se envía explícito. El control queda oculto/inactivo cuando la orden todavía no tiene número asignado.
- **Backend**: `StorePhotoRequest` acepta un `number` opcional (`nullable|integer|min:1`) y `PhotoController@store` lo usa cuando viene, cayendo al parseo por nombre en su ausencia. El rechazo por número duplicado en el curso se mantiene en ambos flujos (sin overwrite).

## Cómo probar

1. En un curso, seleccionar varios archivos (probar 20+) y subir: se ven los estados por archivo y el lote continúa aunque uno falle.
2. En un pedido con número de foto asignado, subir una foto desde la tarjeta: se envía con ese número.
3. En un pedido sin número asignado, el control no permite subir.

## Fuera de alcance

- Corrección del pixelado existente (#112), procesamiento server-side, cambios de roles, tracking de origen de subida.

Closes #173
