### PR TITLE
refactor(seeders): move product catalog data from migrations to seeders

### DIFF
--- a/database/seeders/CatalogSeeder.php
+++ b/database/seeders/CatalogSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+/**
+ * The real product catalog: types are bootstrapped by migrations, but
+ * products/production chains/combos are business data, not schema, so
+ * they're seeded rather than inserted by a migration.
+ */
+class CatalogSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->call([
+            ProductSeeder::class,
+            ProductionStatusSeeder::class,
+            ComboSeeder::class,
+        ]);
+    }
+}

--- a/database/seeders/ComboSeeder.php
+++ b/database/seeders/ComboSeeder.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
+namespace Database\Seeders;
+
 use App\Models\Combo;
 use App\Models\Product;
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Seeder;
 
-return new class extends Migration
+class ComboSeeder extends Seeder
 {
-    /**
-     * Run the migrations.
-     */
-    public function up(): void
+    public function run(): void
     {
         $products = Product::all();
         $variants = [
@@ -70,12 +69,4 @@ return new class extends Migration
             $products->firstWhere('name', 'Taza')?->id => ['quantity' => 1, 'subtract_value' => 5000, 'variants' => null],
         ]);
     }
-
-    /**
-     * Reverse the migrations.
-     */
-    public function down(): void
-    {
-        //
-    }
-};
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            CatalogSeeder::class,
             DemoSeeder::class,
         ]);
     }

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -2,24 +2,15 @@
 
 declare(strict_types=1);
 
+namespace Database\Seeders;
+
 use App\Models\Product;
 use App\Models\ProductType;
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Seeder;
 
-return new class extends Migration
+class ProductSeeder extends Seeder
 {
-    /**
-     * Reverse the migrations.
-     */
-    public function down(): void
-    {
-        //
-    }
-
-    /**
-     * Run the migrations.
-     */
-    public function up(): void
+    public function run(): void
     {
         $product_types = ProductType::all();
 
@@ -154,4 +145,4 @@ return new class extends Migration
             Product::create($product);
         }
     }
-};
+}

--- a/database/seeders/ProductionStatusSeeder.php
+++ b/database/seeders/ProductionStatusSeeder.php
@@ -2,17 +2,19 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
-return new class extends Migration
+class ProductionStatusSeeder extends Seeder
 {
     /**
      * Every product owns its production chain. Seeded products get the
      * real chains dictated by the business; products created later
      * start with a single final stage (see CreateProduct action).
      */
-    public function up(): void
+    public function run(): void
     {
         $chainsByType = [
             'mural' => ['Sin foto', 'Impreso', 'Pegado', 'Pintado', 'Laqueado', 'Embolsado'],
@@ -50,4 +52,4 @@ return new class extends Migration
             }
         }
     }
-};
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Database\Seeders\CatalogSeeder;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected $seeder = CatalogSeeder::class;
 }


### PR DESCRIPTION
## Resumen

- Elimina las migraciones `insert_into_products_table`, `insert_into_production_statuses` e `insert_into_combos_table`: eran datos de catálogo real (no de prueba), pero al vivir en una migración quedaban mezclados con el schema.
- Mueve esos datos a seeders nuevos (`ProductSeeder`, `ProductionStatusSeeder`, `ComboSeeder`), encadenados en orden de dependencia por `CatalogSeeder`, que ahora corre antes que `DemoSeeder` en `DatabaseSeeder`.
- `product_types`, `users`, `roles` y `role_user` quedan como migraciones: son datos de producción necesarios para un arranque en blanco (cuentas reales y un enum cerrado del que depende la lógica de dominio), no catálogo de negocio.
- `tests/TestCase.php` ahora fija `$seeder = CatalogSeeder::class`, así `RefreshDatabase` sigue sembrando el catálogo una sola vez por corrida de tests (sin datos demo), sin tocar los tests existentes.

## Plan de pruebas

- [x] `sail artisan migrate:fresh --seed` corre sin errores
- [x] `sail php vendor/bin/pest` — 338 passed
- [x] `sail npm run test` — 380 passed
- [x] `validate-code --full` — All checks passed

Closes #203
