### PR TITLE
fix(schools): hacer opcional el teléfono del director

### DIFF
--- a/app/Http/Requests/StoreSchoolRequest.php
+++ b/app/Http/Requests/StoreSchoolRequest.php
@@ -32,7 +32,7 @@ class StoreSchoolRequest extends FormRequest
             'school.level' => ['required'],
             'principal' => ['nullable'],
             'principal.name' => ['sometimes'],
-            'principal.phone' => ['present_with:principal.name', 'numeric'],
+            'principal.phone' => ['nullable', 'numeric'],
             'address' => ['required'],
             'address.street' => ['sometimes'],
             'address.number' => ['sometimes'],

--- a/tests/Feature/StoreSchoolRequestTest.php
+++ b/tests/Feature/StoreSchoolRequestTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\School;
+use App\Models\User;
+
+use function Pest\Laravel\post;
+
+it('accepts a principal name without a phone', function () {
+    actingAsRole();
+
+    $user = User::factory()->create();
+
+    post(route('schools.store'), [
+        'school' => [
+            'user_id' => $user->id,
+            'name' => 'Escuela N°1',
+            'level' => 'primary',
+        ],
+        'principal' => [
+            'name' => 'María Pérez',
+            'phone' => '',
+        ],
+        'address' => [
+            'city' => 'Tobares',
+        ],
+    ])->assertSessionHasNoErrors();
+
+    expect(School::where('name', 'Escuela N°1')->exists())->toBeTrue();
+});
+
+it('accepts a request without any principal data', function () {
+    actingAsRole();
+
+    $user = User::factory()->create();
+
+    post(route('schools.store'), [
+        'school' => [
+            'user_id' => $user->id,
+            'name' => 'Escuela N°2',
+            'level' => 'primary',
+        ],
+        'address' => [
+            'city' => 'Tobares',
+        ],
+    ])->assertSessionHasNoErrors();
+
+    expect(School::where('name', 'Escuela N°2')->exists())->toBeTrue();
+});
+
+it('accepts a principal name with a valid numeric phone', function () {
+    actingAsRole();
+
+    $user = User::factory()->create();
+
+    post(route('schools.store'), [
+        'school' => [
+            'user_id' => $user->id,
+            'name' => 'Escuela N°3',
+            'level' => 'primary',
+        ],
+        'principal' => [
+            'name' => 'María Pérez',
+            'phone' => '1234567890',
+        ],
+        'address' => [
+            'city' => 'Tobares',
+        ],
+    ])->assertSessionHasNoErrors();
+
+    expect(School::where('name', 'Escuela N°3')->exists())->toBeTrue();
+});
+
+it('rejects a non-numeric principal phone', function () {
+    actingAsRole();
+
+    $user = User::factory()->create();
+
+    post(route('schools.store'), [
+        'school' => [
+            'user_id' => $user->id,
+            'name' => 'Escuela N°4',
+            'level' => 'primary',
+        ],
+        'principal' => [
+            'name' => 'María Pérez',
+            'phone' => 'abc',
+        ],
+        'address' => [
+            'city' => 'Tobares',
+        ],
+    ])->assertSessionHasErrors('principal.phone');
+
+    expect(School::where('name', 'Escuela N°4')->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Qué

El teléfono del director de una escuela ahora es siempre opcional. Antes, la regla de `principal.phone` en `StoreSchoolRequest` era `present_with:principal.name` + `numeric`: al completar el nombre del director y dejar el teléfono vacío, la validación fallaba porque un valor vacío no pasa `numeric`. En los hechos, el teléfono quedaba obligatorio en cuanto se escribía el nombre.

## Cambios

- `principal.phone` pasa a `['nullable', 'numeric']`: el teléfono vacío o ausente guarda sin error, y si se ingresa un valor debe ser numérico. Como `StoreSchoolRequest` se usa tanto en crear como en editar, cubre ambos casos.
- Nuevo test `StoreSchoolRequestTest` con 4 casos: nombre sin teléfono guarda (regresión), sin nombre ni teléfono guarda, nombre + teléfono numérico guarda, y teléfono no numérico se rechaza.

## Fuera de alcance

- Classroom (maestro/teléfono) ya era opcional (`nullable`) y no se toca.
- Sin cambios en el frontend.

Closes #207
