### PR TITLE
fix(orders): mostrar total reactivo en la pestaña Productos

### DIFF
--- a/resources/js/pages/orders/components/products-step.test.tsx
+++ b/resources/js/pages/orders/components/products-step.test.tsx
@@ -1,0 +1,80 @@
+import { Accordion } from '@/components/ui/accordion';
+import { formatPrice } from '@/lib/utils';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OrderFormController } from '../hooks/use-create-order-form';
+import { ProductsStep } from './products-step';
+
+const makeForm = (
+    overrides: Partial<OrderFormController> = {},
+): OrderFormController =>
+    ({
+        data: { order_details: [] },
+        errors: {},
+        errorFlags: {},
+        toStep: () => vi.fn(),
+        comboDropdownOpen: false,
+        setComboDropdownOpen: vi.fn(),
+        productDropdownOpen: false,
+        setProductDropdownOpen: vi.fn(),
+        handleAddCombo: vi.fn(),
+        handleAddProduct: vi.fn(),
+        handleEditProduct: vi.fn(),
+        handleRemoveProduct: vi.fn(),
+        handleRemoveCombo: vi.fn(),
+        breakdown: { lines: [], total: 0 },
+        ...overrides,
+    }) as unknown as OrderFormController;
+
+const renderProductsStep = (form: OrderFormController) =>
+    render(
+        <Accordion type="single" collapsible defaultValue="products">
+            <ProductsStep form={form} products={[]} combos={[]} />
+        </Accordion>,
+    );
+
+// RTL's default text matcher collapses whitespace (including formatPrice's
+// non-breaking space) on the DOM side only, so the expected string needs the
+// same normalization to compare equal.
+const totalText = (amount: number) =>
+    `Total: ${formatPrice(amount)}`.replace(/\s+/g, ' ');
+
+describe('ProductsStep', () => {
+    it('renders the chosen-products total from breakdown.total', () => {
+        const form = makeForm({ breakdown: { lines: [], total: 15000 } });
+
+        renderProductsStep(form);
+
+        expect(screen.getByText(totalText(15000))).toBeTruthy();
+    });
+
+    it('shows a zero total when no products are chosen', () => {
+        // makeForm already defaults to an empty order_details / total cart
+        const form = makeForm();
+
+        renderProductsStep(form);
+
+        expect(screen.getByText(totalText(0))).toBeTruthy();
+    });
+
+    it('reflects an updated total after re-render (add/remove reactivity)', () => {
+        const form = makeForm({ breakdown: { lines: [], total: 10000 } });
+
+        const { rerender } = renderProductsStep(form);
+
+        expect(screen.getByText(totalText(10000))).toBeTruthy();
+
+        const updatedForm = makeForm({
+            breakdown: { lines: [], total: 25000 },
+        });
+
+        rerender(
+            <Accordion type="single" collapsible defaultValue="products">
+                <ProductsStep form={updatedForm} products={[]} combos={[]} />
+            </Accordion>,
+        );
+
+        expect(screen.getByText(totalText(25000))).toBeTruthy();
+        expect(screen.queryByText(totalText(10000))).toBeNull();
+    });
+});

--- a/resources/js/pages/orders/components/products-step.tsx
+++ b/resources/js/pages/orders/components/products-step.tsx
@@ -7,6 +7,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
+import { formatPrice } from '@/lib/utils';
 import { AlertCircle, PlusIcon } from 'lucide-react';
 import { ComboWithProducts } from '../form';
 import { groupDetails } from '../grouping';
@@ -34,6 +35,7 @@ export function ProductsStep({ form, products, combos }: ProductsStepProps) {
         handleEditProduct,
         handleRemoveProduct,
         handleRemoveCombo,
+        breakdown,
     } = form;
 
     const { comboGroups, extras } = groupDetails(data.order_details, combos);
@@ -83,6 +85,10 @@ export function ProductsStep({ form, products, combos }: ProductsStepProps) {
                         <PlusIcon />
                     </Button>
                 </Combobox>
+
+                <div className="mt-3 text-right text-sm font-medium">
+                    Total: {formatPrice(breakdown.total)}
+                </div>
 
                 {comboGroups.map(({ combo, items }) => (
                     <DetailGroup


### PR DESCRIPTION
## Qué

En el wizard de creación de un pedido, la pestaña "Productos" ahora muestra un total con la suma de los productos/combos elegidos, arriba de la lista. El total se actualiza de inmediato al agregar o quitar un producto o combo, sin necesidad de cambiar de pestaña.

## Por qué

Antes la pestaña "Productos" no renderizaba ningún total (solo el precio fijo de cada combo en su encabezado). El dato reactivo `breakdown` ya existía en el controlador del formulario pero no se usaba en este componente.

## Cómo

- `products-step.tsx` consume `breakdown` del `form` y renderiza `formatPrice(breakdown.total)` arriba de la lista. Se recalcula en cada render a partir de `data.order_details`, por lo que la actualización es inmediata. Sin estado nuevo.

## Fuera de alcance

- El wizard de edición (`edit-products-step.tsx`) y la pestaña "Pedido" (`order-step.tsx`), que ya funcionaba.

## Pruebas

- Nuevo `products-step.test.tsx`: total visible, total en cero sin productos, y reactividad al re-render (guarda la regresión).

Closes #210