### PR TITLE
fix(ui): show cursor-not-allowed on disabled buttons

### DIFF
--- a/resources/js/components/ui/button.test.tsx
+++ b/resources/js/components/ui/button.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Button } from './button';
+
+describe('Button', () => {
+    it('wraps a disabled button in a cursor-not-allowed span', () => {
+        render(<Button disabled>Editar</Button>);
+
+        const button = screen.getByRole('button', { name: 'Editar' });
+        const wrapper = button.parentElement as HTMLElement;
+
+        expect(wrapper.tagName).toBe('SPAN');
+        expect(wrapper.classList.contains('inline-flex')).toBe(true);
+        expect(wrapper.classList.contains('cursor-not-allowed')).toBe(true);
+        expect(wrapper.contains(button)).toBe(true);
+    });
+
+    it('keeps the disabled button non-interactive', () => {
+        const onClick = vi.fn();
+        render(
+            <Button disabled onClick={onClick}>
+                Editar
+            </Button>,
+        );
+
+        const button = screen.getByRole('button', { name: 'Editar' });
+
+        expect(button.hasAttribute('disabled')).toBe(true);
+        expect(button.className).toContain('pointer-events-none');
+
+        fireEvent.click(button);
+
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('does not wrap an enabled button and keeps it clickable', () => {
+        const onClick = vi.fn();
+        const { container } = render(<Button onClick={onClick}>Editar</Button>);
+
+        const button = screen.getByRole('button', { name: 'Editar' });
+
+        expect(container.firstElementChild).toBe(button);
+        expect(button.className).not.toContain('cursor-not-allowed');
+
+        fireEvent.click(button);
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves click-blocking for disabled asChild anchors', () => {
+        render(
+            <Button asChild disabled>
+                <a href="/x">Cancelar</a>
+            </Button>,
+        );
+
+        const link = screen.getByText('Cancelar');
+        const wrapper = link.parentElement as HTMLElement;
+
+        expect(wrapper.tagName).toBe('SPAN');
+        expect(wrapper.classList.contains('cursor-not-allowed')).toBe(true);
+        expect(link.className).toContain('pointer-events-none');
+    });
+});

--- a/resources/js/components/ui/button.tsx
+++ b/resources/js/components/ui/button.tsx
@@ -45,13 +45,23 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ({ className, variant, size, asChild = false, ...props }, ref) => {
         const Comp = asChild ? Slot : 'button';
-        return (
+        const element = (
             <Comp
                 className={cn(buttonVariants({ variant, size, className }))}
                 ref={ref}
                 {...props}
             />
         );
+
+        if (props.disabled) {
+            return (
+                <span className="inline-flex cursor-not-allowed">
+                    {element}
+                </span>
+            );
+        }
+
+        return element;
     },
 );
 Button.displayName = 'Button';


### PR DESCRIPTION
## Qué

Los botones deshabilitados de shadcn/ui (`components/ui/button.tsx`) no mostraban el cursor `not-allowed` al pasar el mouse por encima: se veían como habilitados salvo por la opacidad. El motivo es que `disabled:pointer-events-none` anula el hover del propio elemento, por lo que ningún `cursor-*` aplicado sobre él llega a renderizarse.

## Cómo

Cuando el `Button` está deshabilitado, se envuelve el elemento renderizado en un `<span className="inline-flex cursor-not-allowed">`. El span conserva los eventos de puntero y muestra el cursor en hover; el elemento interno mantiene `disabled:pointer-events-none`, así que sigue sin ser clickeable y no arrastra estilos de hover.

Se conserva `pointer-events-none` a propósito: es lo único que bloquea la navegación en botones `asChild` que envuelven un enlace (p. ej. el enlace "Cancelar" durante el envío), donde el atributo `disabled` nativo no tiene efecto sobre un `<a>`.

## Pruebas

- `resources/js/components/ui/button.test.tsx`: wrapper presente al deshabilitar, ausente al habilitar, click bloqueado en botón y en ancla `asChild`.

Closes #214