### PR TITLE
feat(classrooms): mostrar progreso de pago en el listado de alumnos

### DIFF
--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -34,6 +34,7 @@ class ClassroomController extends Controller
         $orders = Order::where('classroom_id', $classroom->id)
             ->with('client')
             ->withCount('products')
+            ->withSum('payments', 'amount')
             ->search($search)
             ->get();
 

--- a/app/Http/Resources/ClassroomStudentResource.php
+++ b/app/Http/Resources/ClassroomStudentResource.php
@@ -35,6 +35,7 @@ class ClassroomStudentResource extends JsonResource
                 'products_count' => count($row->products ?? []),
                 'total_price' => $row->total_price,
                 'payment_plan' => $row->payment_plan,
+                'paid_installments' => 0,
                 'due_date' => $row->due_date?->isoFormat('D [de] MMM Y'),
             ];
         }
@@ -55,7 +56,33 @@ class ClassroomStudentResource extends JsonResource
             'products_count' => is_numeric($productsCount) ? (int) $productsCount : 0,
             'total_price' => $row->total_price,
             'payment_plan' => $row->payment_plan,
+            'paid_installments' => $this->paidInstallments($row),
             'due_date' => $row->due_date->isoFormat('D [de] MMM Y'),
         ];
+    }
+
+    /**
+     * Installments actually covered by payments, capped at the plan.
+     * Mirrors the semantics of `Order::firstInstallmentPaid()`.
+     */
+    private function paidInstallments(Order $order): int
+    {
+        $plan = (int) $order->payment_plan;
+
+        if ($plan <= 0) {
+            return 0;
+        }
+
+        $paidAttribute = $order->getAttribute('payments_sum_amount');
+        $paid = is_numeric($paidAttribute) ? (int) $paidAttribute : 0;
+
+        $totalPrice = (int) $order->total_price;
+        $installment = $totalPrice / $plan;
+
+        if ($installment == 0) {
+            return 0;
+        }
+
+        return min($plan, (int) floor($paid / $installment));
     }
 }

--- a/resources/js/pages/classrooms/components/students-table.test.tsx
+++ b/resources/js/pages/classrooms/components/students-table.test.tsx
@@ -37,6 +37,7 @@ const makeStudent = (
     products_count: 2,
     total_price: 15000,
     payment_plan: 3,
+    paid_installments: 1,
     due_date: '1 de ago 2026',
     ...overrides,
 });

--- a/resources/js/pages/classrooms/components/students-table.test.tsx
+++ b/resources/js/pages/classrooms/components/students-table.test.tsx
@@ -107,4 +107,66 @@ describe('StudentsTable', () => {
 
         expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 rows
     });
+
+    it('renders one filled square per paid installment and the rest empty', () => {
+        const { container } = render(
+            <StudentsTable
+                students={[
+                    makeStudent({ payment_plan: 3, paid_installments: 1 }),
+                ]}
+            />,
+        );
+
+        const squares = container.querySelectorAll('span.rounded-sm');
+        const filled = container.querySelectorAll('span.bg-primary');
+
+        expect(squares).toHaveLength(3);
+        expect(filled).toHaveLength(1);
+        expect(squares.length - filled.length).toBe(2);
+    });
+
+    it('fills every square when the plan is fully paid', () => {
+        const { container } = render(
+            <StudentsTable
+                students={[
+                    makeStudent({ payment_plan: 4, paid_installments: 4 }),
+                ]}
+            />,
+        );
+
+        const squares = container.querySelectorAll('span.rounded-sm');
+        const filled = container.querySelectorAll('span.bg-primary');
+
+        expect(squares).toHaveLength(4);
+        expect(filled).toHaveLength(4);
+    });
+
+    it('renders no squares and a dash when there is no payment plan', () => {
+        const { container } = render(
+            <StudentsTable
+                students={[
+                    makeStudent({ payment_plan: 0, paid_installments: 0 }),
+                ]}
+            />,
+        );
+
+        const row = screen.getAllByRole('row')[1];
+
+        expect(container.querySelectorAll('span.rounded-sm')).toHaveLength(0);
+        expect(within(row).getByText('—')).toBeTruthy();
+    });
+
+    it('still shows the plan count and per-installment price alongside the squares', () => {
+        const { getAllByRole } = render(
+            <StudentsTable
+                students={[
+                    makeStudent({ payment_plan: 3, paid_installments: 1 }),
+                ]}
+            />,
+        );
+
+        const dataRow = getAllByRole('row')[1];
+
+        expect(within(dataRow).getByText(/3 \(/)).toBeTruthy();
+    });
 });

--- a/resources/js/pages/classrooms/components/students-table.tsx
+++ b/resources/js/pages/classrooms/components/students-table.tsx
@@ -23,6 +23,7 @@ export interface ClassroomStudent {
     products_count: number;
     total_price: number;
     payment_plan: number;
+    paid_installments: number;
     due_date: string | null;
 }
 
@@ -97,12 +98,36 @@ export function StudentsTable({ students, search }: StudentsTableProps) {
                             {formatPrice(student.total_price)}
                         </TableCell>
                         <TableCell>
-                            {student.payment_plan > 0
-                                ? `${student.payment_plan} (${formatPrice(
-                                      student.total_price /
-                                          student.payment_plan,
-                                  )})`
-                                : '—'}
+                            {student.payment_plan > 0 ? (
+                                <div className="flex flex-col gap-1">
+                                    <span>
+                                        {student.payment_plan} (
+                                        {formatPrice(
+                                            student.total_price /
+                                                student.payment_plan,
+                                        )}
+                                        )
+                                    </span>
+                                    <div className="flex flex-wrap gap-1">
+                                        {Array.from({
+                                            length: student.payment_plan,
+                                        }).map((_, index) => (
+                                            <span
+                                                key={index}
+                                                className={cn(
+                                                    'size-3 rounded-sm',
+                                                    index <
+                                                        student.paid_installments
+                                                        ? 'bg-primary'
+                                                        : 'border bg-transparent',
+                                                )}
+                                            />
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : (
+                                '—'
+                            )}
                         </TableCell>
                         <TableCell>{student.due_date ?? '—'}</TableCell>
                         <TableCell>

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -7,6 +7,7 @@ use App\Models\Client;
 use App\Models\Order;
 use App\Models\OrderDetail;
 use App\Models\OrderDraft;
+use App\Models\Payment;
 use App\Models\Product;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -109,4 +110,86 @@ it('reports assignable details when the classroom has at least one in scope', fu
     get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
         fn (Assert $page) => $page->where('hasAssignableDetails', true),
     );
+});
+
+it('reports zero paid installments for an order with no payments', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(0);
+});
+
+it('reports one paid installment for an order with a single installment payment', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 16000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(1);
+});
+
+it('reports all installments paid for a fully paid order', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 64000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(4);
+});
+
+it('caps paid installments at the payment plan when overpaid', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 80000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(4);
+});
+
+it('reports zero paid installments for a partial payment below one installment', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 8000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(0);
+});
+
+it('reports zero paid installments for a draft', function () {
+    $classroom = Classroom::factory()->create();
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $draft->id);
+
+    expect($row['paid_installments'])->toBe(0);
 });


### PR DESCRIPTION
## Qué

En el listado de alumnos de un curso, cada alumno ahora muestra su progreso de pago real: cuadraditos pintados por cada cuota efectivamente pagada y cuadraditos sin pintar por las pendientes. Se conserva la información del plan (cantidad de cuotas y monto por cuota) que ya se mostraba.

## Cómo

- El controlador agrega `withSum('payments', 'amount')` a la consulta de órdenes, evitando lazy loading bajo `Model::shouldBeStrict()`.
- El recurso expone `paid_installments`, calculado como `min(payment_plan, floor(pagado / (total / payment_plan)))`, con guardas para `payment_plan <= 0` y división por cero. Los borradores siempre reportan 0.
- La tabla de alumnos renderiza `payment_plan` cuadraditos en la celda de Cuotas: los primeros `paid_installments` pintados, el resto vacíos, con `flex-wrap` para no generar scroll horizontal.

## Alcance

Sin cambios al cálculo de cuotas en sí (fuera de alcance).

Derivado de #205.

Closes #211