### PR TITLE
feat(orders): confirmar retroceso de etapa de producción

### DIFF
--- a/resources/js/pages/orders/components/production-status-control.test.tsx
+++ b/resources/js/pages/orders/components/production-status-control.test.tsx
@@ -89,4 +89,72 @@ describe('ProductionStatusControl', () => {
 
         expect(onChange).toHaveBeenCalledWith(21);
     });
+
+    it('asks for confirmation before rolling back to an earlier stage', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Pegado',
+                    production_status_id: 22,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Impreso' }));
+
+        expect(
+            screen.getByText(/¿Estás seguro que querés retroceder/),
+        ).toBeTruthy();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('rolls back once the confirmation is accepted', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Pegado',
+                    production_status_id: 22,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Impreso' }));
+
+        fireEvent.click(screen.getByText('Retroceder'));
+
+        expect(onChange).toHaveBeenCalledWith(21);
+    });
+
+    it('keeps the current stage when the rollback is cancelled', () => {
+        const onChange = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Pegado',
+                    production_status_id: 22,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+            />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        fireEvent.keyDown(trigger, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('option', { name: 'Impreso' }));
+
+        fireEvent.click(screen.getByText('Cancelar'));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(trigger.textContent).toContain('Pegado');
+    });
 });

--- a/resources/js/pages/orders/components/production-status-control.tsx
+++ b/resources/js/pages/orders/components/production-status-control.tsx
@@ -7,6 +7,9 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Factory } from 'lucide-react';
+import { useState } from 'react';
+import { getStageRollback } from '../production-stage';
+import { StageRollbackConfirmation } from './stage-rollback-confirmation';
 
 const PENDING = 'none';
 
@@ -24,6 +27,12 @@ export function ProductionStatusControl({
     firstInstallmentPaid: boolean;
     onChange: (statusId: number | null) => void;
 }) {
+    const [pendingRollback, setPendingRollback] = useState<{
+        targetId: number | null;
+        stepsBack: number;
+        targetName: string;
+    } | null>(null);
+
     if (!product.production_enabled) {
         if (!firstInstallmentPaid) {
             return (
@@ -49,31 +58,64 @@ export function ProductionStatusControl({
 
     const statuses = product.statuses ?? [];
 
+    const handleValueChange = (value: string) => {
+        const targetId = value === PENDING ? null : Number(value);
+        const rollback = getStageRollback(
+            statuses,
+            product.production_status_id,
+            targetId,
+        );
+
+        if (rollback.isRollback) {
+            setPendingRollback({
+                targetId,
+                stepsBack: rollback.stepsBack,
+                targetName: rollback.targetName,
+            });
+
+            return;
+        }
+
+        onChange(targetId);
+    };
+
     return (
-        <Select
-            value={
-                product.production_status_id
-                    ? String(product.production_status_id)
-                    : PENDING
-            }
-            onValueChange={(value) =>
-                onChange(value === PENDING ? null : Number(value))
-            }
-        >
-            <SelectTrigger
-                className="mt-2 h-8 w-fit gap-2 text-xs"
-                aria-label={`Estado de fabricación de ${product.name}`}
+        <>
+            <Select
+                value={
+                    product.production_status_id
+                        ? String(product.production_status_id)
+                        : PENDING
+                }
+                onValueChange={handleValueChange}
             >
-                <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-                <SelectItem value={PENDING}>Sin empezar</SelectItem>
-                {statuses.map((status) => (
-                    <SelectItem key={status.id} value={String(status.id)}>
-                        {status.name}
-                    </SelectItem>
-                ))}
-            </SelectContent>
-        </Select>
+                <SelectTrigger
+                    className="mt-2 h-8 w-fit gap-2 text-xs"
+                    aria-label={`Estado de fabricación de ${product.name}`}
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={PENDING}>Sin empezar</SelectItem>
+                    {statuses.map((status) => (
+                        <SelectItem key={status.id} value={String(status.id)}>
+                            {status.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <StageRollbackConfirmation
+                show={pendingRollback !== null}
+                productName={product.name}
+                stepsBack={pendingRollback?.stepsBack ?? 0}
+                targetName={pendingRollback?.targetName ?? ''}
+                onConfirm={() => {
+                    if (pendingRollback) onChange(pendingRollback.targetId);
+                    setPendingRollback(null);
+                }}
+                onCancel={() => setPendingRollback(null)}
+            />
+        </>
     );
 }

--- a/resources/js/pages/orders/components/stage-rollback-confirmation.tsx
+++ b/resources/js/pages/orders/components/stage-rollback-confirmation.tsx
@@ -1,0 +1,49 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+export function StageRollbackConfirmation({
+    show,
+    productName,
+    stepsBack,
+    targetName,
+    onConfirm,
+    onCancel,
+}: {
+    show: boolean;
+    productName: string;
+    stepsBack: number;
+    targetName: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}) {
+    return (
+        <AlertDialog open={show} onOpenChange={() => onCancel()}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>
+                        ¿Estás seguro que querés retroceder {productName}{' '}
+                        {stepsBack} etapa{stepsBack === 1 ? '' : 's'} hacia{' '}
+                        {targetName}?
+                    </AlertDialogTitle>
+                </AlertDialogHeader>
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={onCancel}>
+                        Cancelar
+                    </AlertDialogCancel>
+
+                    <AlertDialogAction onClick={onConfirm}>
+                        Retroceder
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/resources/js/pages/orders/production-stage.test.ts
+++ b/resources/js/pages/orders/production-stage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getStageRollback } from './production-stage';
+
+const statuses: ProductionStatus[] = [
+    { id: 21, name: 'Impreso', position: 1 },
+    { id: 22, name: 'Pegado', position: 2 },
+    { id: 23, name: 'Terminado', position: 3 },
+];
+
+describe('getStageRollback', () => {
+    it('is not a rollback when moving forward', () => {
+        expect(getStageRollback(statuses, 21, 22)).toMatchObject({
+            isRollback: false,
+        });
+    });
+
+    it('flags a backward move of one stage', () => {
+        expect(getStageRollback(statuses, 22, 21)).toEqual({
+            isRollback: true,
+            stepsBack: 1,
+            targetName: 'Impreso',
+        });
+    });
+
+    it('flags a backward move across multiple stages', () => {
+        expect(getStageRollback(statuses, 23, 21)).toEqual({
+            isRollback: true,
+            stepsBack: 2,
+            targetName: 'Impreso',
+        });
+    });
+
+    it('is not a rollback when the stage does not change', () => {
+        expect(getStageRollback(statuses, 22, 22)).toMatchObject({
+            isRollback: false,
+            stepsBack: 0,
+        });
+    });
+
+    it('treats moving to "Sin empezar" as a one-stage rollback', () => {
+        expect(getStageRollback(statuses, 21, null)).toEqual({
+            isRollback: true,
+            stepsBack: 1,
+            targetName: 'Sin empezar',
+        });
+    });
+
+    it('is not a rollback when starting from "Sin empezar"', () => {
+        expect(getStageRollback(statuses, null, 21)).toMatchObject({
+            isRollback: false,
+        });
+    });
+});

--- a/resources/js/pages/orders/production-stage.ts
+++ b/resources/js/pages/orders/production-stage.ts
@@ -1,0 +1,27 @@
+/**
+ * Detects whether a production status change is a rollback (moving to an
+ * earlier stage) and, if so, how many stages back it goes.
+ *
+ * `statuses` must already be ordered by position. `null` represents
+ * "Sin empezar", which is treated as the stage before the first one.
+ */
+export function getStageRollback(
+    statuses: ProductionStatus[],
+    currentStatusId: number | null | undefined,
+    targetStatusId: number | null,
+): { isRollback: boolean; stepsBack: number; targetName: string } {
+    const indexOf = (statusId: number | null | undefined) =>
+        statusId == null
+            ? -1
+            : statuses.findIndex((status) => status.id === statusId);
+
+    const currentIndex = indexOf(currentStatusId);
+    const targetIndex = indexOf(targetStatusId);
+
+    const isRollback = targetIndex < currentIndex;
+    const stepsBack = currentIndex - targetIndex;
+    const targetName =
+        targetStatusId == null ? 'Sin empezar' : statuses[targetIndex].name;
+
+    return { isRollback, stepsBack, targetName };
+}


### PR DESCRIPTION
## Qué

En `/orders`, al cambiar el estado de fabricación de un producto hacia una etapa **anterior** a la actual (retroceso), ahora se pide confirmación mediante un diálogo `AlertDialog` antes de aplicar el cambio.

## Cómo

- Nueva función pura `getStageRollback` (`production-stage.ts`) que detecta el retroceso según el orden de las etapas (`position`) y calcula cuántas etapas se retrocede y hacia cuál. "Sin empezar" se trata como la etapa previa a la primera.
- Nuevo componente `stage-rollback-confirmation.tsx` (`AlertDialog`, reutilizando el patrón de `delete-confirmation.tsx`).
- `production-status-control.tsx` intercepta la selección: si es un retroceso abre el diálogo; confirmar aplica el cambio como hoy, cancelar no modifica nada (el `Select` es controlado y vuelve a la etapa actual).

## Comportamiento

- Retroceder a una etapa anterior (o a "Sin empezar"): pide confirmación.
- Avanzar a una etapa posterior o iniciar la fabricación por primera vez: sin confirmación, igual que antes.
- La lógica de reversión de stock al retroceder no se toca (fuera de alcance).

## Pruebas

- Vitest: `production-stage.test.ts` (6 casos de la función pura) y casos nuevos en `production-status-control.test.tsx` (abrir diálogo, confirmar, cancelar). 13 pruebas nuevas, suite completa en verde.

Closes #212