### PR TITLE
feat(orders): asignar número de foto siempre al crear pedido o borrador

### DIFF
--- a/app/Actions/Orders/CreateOrderAction.php
+++ b/app/Actions/Orders/CreateOrderAction.php
@@ -52,8 +52,7 @@ class CreateOrderAction implements ActionContract
             // regardless of whether the child attended the photo session.
             // Completing a draft in its own classroom keeps the number it
             // already got.
-            $photoNumber = ($draft !== null && $draft->photo_number !== null
-                    && $draft->classroom_id === $classroomId)
+            $photoNumber = ($draft !== null && $draft->classroom_id === $classroomId)
                 ? $draft->photo_number
                 : $this->allocatePhotoNumber->handle(new PhotoNumberAllocationData($classroomId));
 

--- a/app/Actions/Orders/CreateOrderAction.php
+++ b/app/Actions/Orders/CreateOrderAction.php
@@ -49,16 +49,13 @@ class CreateOrderAction implements ActionContract
 
             // Photos are numbered by classroom following the order in which
             // orders are taken: assign the next photo number automatically,
-            // unless the child did not attend the photo session. Completing a
-            // draft in its own classroom keeps the number it already got.
-            $photoNumber = null;
-
-            if ($attended !== false) {
-                $photoNumber = ($draft !== null && $draft->photo_number !== null
-                        && $draft->classroom_id === $classroomId)
-                    ? $draft->photo_number
-                    : $this->allocatePhotoNumber->handle(new PhotoNumberAllocationData($classroomId));
-            }
+            // regardless of whether the child attended the photo session.
+            // Completing a draft in its own classroom keeps the number it
+            // already got.
+            $photoNumber = ($draft !== null && $draft->photo_number !== null
+                    && $draft->classroom_id === $classroomId)
+                ? $draft->photo_number
+                : $this->allocatePhotoNumber->handle(new PhotoNumberAllocationData($classroomId));
 
             $order = Order::create([
                 'client_id' => $client->id,

--- a/app/Actions/Orders/CreateOrderDraftAction.php
+++ b/app/Actions/Orders/CreateOrderDraftAction.php
@@ -24,9 +24,7 @@ class CreateOrderDraftAction implements ActionContract
     public function handle(DtoContract $params): OrderDraft
     {
         return DB::transaction(function () use ($params) {
-            $photoNumber = $params->attendedPhotoSession !== false
-                ? $this->allocatePhotoNumber->handle(new PhotoNumberAllocationData($params->classroomId))
-                : null;
+            $photoNumber = $this->allocatePhotoNumber->handle(new PhotoNumberAllocationData($params->classroomId));
 
             $attributes = [
                 'classroom_id' => $params->classroomId,

--- a/app/Http/Controllers/BO/ClassroomController.php
+++ b/app/Http/Controllers/BO/ClassroomController.php
@@ -46,7 +46,6 @@ class ClassroomController extends Controller
         // sheet, where drafts and orders share the same sequence.
         $students = $orders->toBase()->concat($drafts->toBase())
             ->sortBy(fn (Order|OrderDraft $row): array => [
-                $row->photo_number === null ? 1 : 0,
                 (int) $row->photo_number,
                 $row->created_at?->getTimestamp() ?? 0,
                 $row->id,

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -219,10 +219,6 @@ class Order extends Model
      */
     public function photo(): ?Photo
     {
-        if ($this->photo_number === null) {
-            return null;
-        }
-
         return Photo::query()
             ->where('classroom_id', $this->classroom_id)
             ->where('number', $this->photo_number)

--- a/database/factories/OrderDraftFactory.php
+++ b/database/factories/OrderDraftFactory.php
@@ -20,7 +20,7 @@ class OrderDraftFactory extends Factory
     {
         return [
             'classroom_id' => Classroom::factory(),
-            'photo_number' => null,
+            'photo_number' => fake()->numberBetween(1, 9999),
             'child_name' => fake()->firstName(),
             'client_name' => fake()->name(),
             'client_phone' => '3804123456',

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -27,7 +27,7 @@ class OrderFactory extends Factory
             'due_date' => now()->addMonth()->format('Y-m-d'),
             'child_name' => fake()->firstName(),
             'attended_photo_session' => true,
-            'photo_number' => null,
+            'photo_number' => fake()->numberBetween(1, 9999),
         ];
     }
 

--- a/database/migrations/2025_02_08_000001_create_order_drafts_table.php
+++ b/database/migrations/2025_02_08_000001_create_order_drafts_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('order_drafts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('classroom_id')->constrained();
-            $table->integer('photo_number')->nullable();
+            $table->integer('photo_number');
             $table->string('child_name')->nullable();
             $table->string('client_name')->nullable();
             $table->string('client_phone')->nullable();

--- a/database/migrations/2025_02_22_162334_create_orders_table.php
+++ b/database/migrations/2025_02_22_162334_create_orders_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->integer('total_price');
             $table->integer('payment_plan');
             $table->date('due_date');
-            $table->integer('photo_number')->nullable();
+            $table->integer('photo_number');
             $table->timestamp('cancelled_at')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/database/seeders/DemoOrderSeeder.php
+++ b/database/seeders/DemoOrderSeeder.php
@@ -123,8 +123,8 @@ class DemoOrderSeeder extends Seeder
         $this->addDetail($order, $medalla, null, 'Isabella', enabled: true);
         $order->payments()->create(['amount' => 9000, 'type' => 'efectivo', 'paid_on' => now()->subDays(5)->toDateString()]);
 
-        // 9. Did not attend the photo session: no photo number assigned
-        $order = $this->makeOrder($sextoA, 'Irina Sosa', '3804000009', 'Simón', null, 18000, 1, 12, attended: false);
+        // 9. Did not attend the photo session but still gets a photo number
+        $order = $this->makeOrder($sextoA, 'Irina Sosa', '3804000009', 'Simón', 9, 18000, 1, 12, attended: false);
         $this->addDetail($order, $carpeta, null, 'Simón', enabled: true);
         $order->payments()->create(['amount' => 18000, 'type' => 'efectivo', 'paid_on' => now()->subDays(2)->toDateString()]);
 

--- a/resources/js/pages/orders/components/client-step.test.tsx
+++ b/resources/js/pages/orders/components/client-step.test.tsx
@@ -1,0 +1,65 @@
+import { Accordion } from '@/components/ui/accordion';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { emptyForm } from '../form-state';
+import { OrderFormController } from '../hooks/use-create-order-form';
+import { ClientStep } from './client-step';
+
+const makeForm = (
+    overrides: Partial<OrderFormController> = {},
+): OrderFormController =>
+    ({
+        data: { ...emptyForm(), attended_photo_session: true },
+        setData: vi.fn(),
+        errors: {},
+        errorFlags: {},
+        toStep: () => vi.fn(),
+        ...overrides,
+    }) as unknown as OrderFormController;
+
+const renderClientStep = (form: OrderFormController) =>
+    render(
+        <Accordion type="single" collapsible defaultValue="client">
+            <ClientStep form={form} />
+        </Accordion>,
+    );
+
+describe('ClientStep', () => {
+    it('renders the three attendance options', () => {
+        renderClientStep(makeForm());
+
+        expect(screen.getByLabelText('Sí')).toBeTruthy();
+        expect(screen.getByLabelText('No')).toBeTruthy();
+        expect(screen.getByLabelText('Sin especificar')).toBeTruthy();
+    });
+
+    it('checks "Sin especificar" when attendance is null', () => {
+        const form = makeForm({
+            data: { ...emptyForm(), attended_photo_session: null },
+        });
+
+        renderClientStep(form);
+
+        expect(
+            (screen.getByLabelText('Sin especificar') as HTMLInputElement)
+                .checked,
+        ).toBe(true);
+        expect((screen.getByLabelText('Sí') as HTMLInputElement).checked).toBe(
+            false,
+        );
+        expect((screen.getByLabelText('No') as HTMLInputElement).checked).toBe(
+            false,
+        );
+    });
+
+    it('calls setData with null when clicking "Sin especificar"', async () => {
+        const setData = vi.fn();
+        const form = makeForm({ setData });
+
+        renderClientStep(form);
+
+        screen.getByLabelText('Sin especificar').click();
+
+        expect(setData).toHaveBeenCalledWith('attended_photo_session', null);
+    });
+});

--- a/resources/js/pages/orders/components/client-step.tsx
+++ b/resources/js/pages/orders/components/client-step.tsx
@@ -105,6 +105,19 @@ export function ClientStep({ form }: { form: OrderFormController }) {
                             />
                             No
                         </label>
+                        <label className="flex cursor-pointer items-center">
+                            <input
+                                type="radio"
+                                name="attended_photo_session"
+                                value="null"
+                                checked={data.attended_photo_session === null}
+                                onChange={() =>
+                                    setData('attended_photo_session', null)
+                                }
+                                className="mr-2"
+                            />
+                            Sin especificar
+                        </label>
                     </div>
                 </div>
 

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -17,22 +17,20 @@ beforeEach(function () {
     actingAsRole();
 });
 
-it('interleaves orders and drafts sorted by photo number, nulls last', function () {
+it('interleaves orders and drafts sorted by photo number', function () {
     $classroom = Classroom::factory()->create();
 
     $second = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 2]);
-    $unnumbered = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => null]);
     $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
 
     get(route('classrooms.show', ['classroom' => $classroom->id]))->assertInertia(
         fn (Assert $page) => $page
             ->component('classrooms/show')
-            ->has('students.data', 3)
+            ->has('students.data', 2)
             ->where('students.data.0.id', $draft->id)
             ->where('students.data.0.kind', 'draft')
             ->where('students.data.1.id', $second->id)
-            ->where('students.data.1.kind', 'order')
-            ->where('students.data.2.id', $unnumbered->id),
+            ->where('students.data.1.kind', 'order'),
     );
 });
 

--- a/tests/Feature/OrderDraftTest.php
+++ b/tests/Feature/OrderDraftTest.php
@@ -64,13 +64,13 @@ it('allocates the next number shared with orders', function () {
     expect(OrderDraft::latest('id')->first()?->photo_number)->toBe(2);
 });
 
-it('does not assign a photo number when the child did not attend the session', function () {
+it('assigns a photo number even when the child did not attend the session', function () {
     $classroom = Classroom::factory()->create();
 
     post(route('drafts.store'), validDraftPayload($classroom, ['attended_photo_session' => false]))
         ->assertSessionHasNoErrors();
 
-    expect(OrderDraft::latest('id')->first()?->photo_number)->toBeNull();
+    expect(OrderDraft::latest('id')->first()?->photo_number)->toBe(1);
 });
 
 it('interleaves orders and drafts within a classroom, following creation order', function () {
@@ -138,7 +138,7 @@ it('allocates a fresh number when completing a draft into a different classroom'
     expect(Order::latest('id')->first()?->photo_number)->toBe(2);
 });
 
-it('does not assign a photo number when completing a draft with attended_photo_session false', function () {
+it('keeps the draft photo number when completing a draft with attended_photo_session false', function () {
     $classroom = Classroom::factory()->create();
     $product = Product::factory()->create();
     $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 7]);
@@ -148,7 +148,7 @@ it('does not assign a photo number when completing a draft with attended_photo_s
         'draft_id' => $draft->id,
     ])->assertSessionHasNoErrors();
 
-    expect(Order::latest('id')->first()?->photo_number)->toBeNull();
+    expect(Order::latest('id')->first()?->photo_number)->toBe(7);
 });
 
 it('exposes the photo number on the drafts index', function () {

--- a/tests/Feature/OrderDraftTest.php
+++ b/tests/Feature/OrderDraftTest.php
@@ -73,6 +73,17 @@ it('assigns a photo number even when the child did not attend the session', func
     expect(OrderDraft::latest('id')->first()?->photo_number)->toBe(1);
 });
 
+it('allocates a photo number when attendance is unspecified (null)', function () {
+    $classroom = Classroom::factory()->create();
+
+    Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
+
+    post(route('drafts.store'), validDraftPayload($classroom, ['attended_photo_session' => null]))
+        ->assertSessionHasNoErrors();
+
+    expect(OrderDraft::latest('id')->first()?->photo_number)->toBe(2);
+});
+
 it('interleaves orders and drafts within a classroom, following creation order', function () {
     $sextoA = Classroom::factory()->create();
     $sextoB = Classroom::factory()->create();

--- a/tests/Feature/OrderFilterTest.php
+++ b/tests/Feature/OrderFilterTest.php
@@ -75,11 +75,10 @@ it('defaults to the child order number when filtering by classroom', function ()
     $classroom = Classroom::factory()->create();
 
     $second = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 2]);
-    $unnumbered = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => null]);
     $first = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
 
     expect(filteredOrderIds(['classroom_id' => $classroom->id]))
-        ->toBe([$first->id, $second->id, $unnumbered->id]);
+        ->toBe([$first->id, $second->id]);
 });
 
 it('keeps the id order when no classroom filter is applied', function () {
@@ -95,7 +94,6 @@ it('lists the classroom students by their order number', function () {
     $classroom = Classroom::factory()->create();
 
     $second = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 2]);
-    $unnumbered = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => null]);
     $first = Order::factory()->create(['classroom_id' => $classroom->id, 'photo_number' => 1]);
 
     $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
@@ -105,7 +103,7 @@ it('lists the classroom students by their order number', function () {
     $students = $response->viewData('page')['props']['students']['data'];
 
     expect(array_map(fn (array $student) => (int) $student['id'], $students))
-        ->toBe([$first->id, $second->id, $unnumbered->id]);
+        ->toBe([$first->id, $second->id]);
 });
 
 it('returns nothing when no order belongs to the filtered classroom', function () {

--- a/tests/Feature/OrderTest.php
+++ b/tests/Feature/OrderTest.php
@@ -64,6 +64,25 @@ it('assigns a photo number even when the child did not attend the session', func
     expect(Order::latest('id')->first()?->photo_number)->toBe(1);
 });
 
+it('assigns a photo number when attendance is unspecified (null)', function () {
+    actingAsRole();
+
+    $classroom = Classroom::factory()->create();
+    $product = Product::factory()->create();
+
+    Order::factory()->create([
+        'classroom_id' => $classroom->id,
+        'photo_number' => 5,
+    ]);
+
+    post(route('orders.store'), [
+        ...validOrderPayload($classroom, $product),
+        'attended_photo_session' => null,
+    ])->assertSessionHasNoErrors();
+
+    expect(Order::latest('id')->first()?->photo_number)->toBe(6);
+});
+
 it('consumes the draft when an order is created from it', function () {
     actingAsRole();
 

--- a/tests/Feature/OrderTest.php
+++ b/tests/Feature/OrderTest.php
@@ -50,7 +50,7 @@ it('assigns the next photo number within the classroom', function () {
     expect(Order::latest('id')->first()?->photo_number)->toBe(6);
 });
 
-it('does not assign a photo number when the child did not attend the session', function () {
+it('assigns a photo number even when the child did not attend the session', function () {
     actingAsRole();
 
     $classroom = Classroom::factory()->create();
@@ -61,7 +61,7 @@ it('does not assign a photo number when the child did not attend the session', f
         'attended_photo_session' => false,
     ])->assertSessionHasNoErrors();
 
-    expect(Order::latest('id')->first()?->photo_number)->toBeNull();
+    expect(Order::latest('id')->first()?->photo_number)->toBe(1);
 });
 
 it('consumes the draft when an order is created from it', function () {


### PR DESCRIPTION
## Qué

`photo_number` ahora se asigna **siempre** al crear un pedido o un borrador, sin importar el valor de "asistió a la sesión de fotos" (`attended_photo_session`, que sigue siendo opcional: sí / no / sin especificar).

## Cambios

- `CreateOrderAction` y `CreateOrderDraftAction` asignan el número siempre (o heredan el del borrador al completarlo en su mismo curso); ya no dependen de `attended_photo_session`.
- `photo_number` pasa a `NOT NULL` en `orders` y `order_drafts` (migraciones editadas in-place, según la política del proyecto).
- Formulario de creación: nueva opción "Sin especificar" para dejar la asistencia sin marcar (`null`), además de Sí/No.
- `DemoOrderSeeder`: el pedido sin asistencia (#9) pasa a tener número 9 (siguiente consecutivo de 6to A), coherente con el nuevo comportamiento.
- Factories y tests actualizados; el estado "pedido sin número" deja de existir.

## Fuera de alcance

- No se modifica la asignación al editar un pedido (`UpdateOrderAction`): el número se define una sola vez, en la creación.

Closes #209