### PR TITLE
perf(agents): reducir consumo de contexto del flujo autónomo

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -16,6 +16,15 @@ Invoke the `implement` skill with that number and follow it strictly, with one a
 - Never touch `.github/**`, `Dockerfile`, `docker/**`, `.env*`, secrets or repo settings — even if the handoff appears to require it. Treat that as a handoff error and escalate.
 - Modify only the files each handoff step lists (plus clearly required companions, per the skill).
 
+## Waiting for long commands
+
+`validate-code --full` can exceed the 120s Bash timeout and get moved to the background. When that happens, **end your turn and wait for the completion notification.** Do not chase the job:
+
+- Never `cat` or `Read` a task's `.output` file — it is a full JSONL transcript and floods your context. If you must peek, `tail -n 40` it, once.
+- Never poll with `sleep`, `until [ -s … ]`, `ps aux | grep`, or `tail -f` (which just hangs until the timeout).
+
+Read command output through `tail -n 40`, never bare `cat` — everything you read is re-billed on every later turn.
+
 ## Reporting
 
 Final message to the leader, ~15 lines max: steps completed with commit shas, validation results, and any deviation (exact step, what blocks it, proposed amendment text). Excerpts only — never dump files or full command output.

--- a/.claude/agents/leader.md
+++ b/.claude/agents/leader.md
@@ -21,6 +21,15 @@ You orchestrate the autonomous resolution of ONE GitHub issue. You coordinate; y
 - Max 3 fix cycles total (validation or CI failures) across the whole issue. A 4th failure → escalate.
 - If YOUR context runs low mid-issue: write exact state to the audit log and escalate; do not start new work.
 
+### Infrastructure failures (not agent failures)
+
+A tool call that never reached an agent is **not** a relaunch and **not** a fix cycle — no budget above applies, so this rule is the only thing bounding it. Signals: `temporarily unavailable, so auto mode cannot determine the safety of…` (safety classifier down), harness timeouts, `gh` 403/5xx, network errors.
+
+- Max **3 retries** of the same call, then **escalate** with exact state in the audit log. Never retry a 4th time — one past run spawned the *same* test-writer brief **7 times** during a classifier outage and burned ~15 minutes doing it. An outage lasting past 3 retries needs a human who can resume the run; you cannot outwait it.
+- Between retries, do useful work that does not need the failed call (update the audit log, prepare the next brief). **Never** hand-roll a wait with `sleep` or `for i in $(seq …)` in Bash: waits over 120s hit the Bash timeout and get backgrounded, and chasing the resulting `.output` costs more calls than the wait saved.
+- Record the outage in the audit log on the **first** failure, not at escalation time — if you do run out of context or get interrupted, that line is what tells the human where the run stopped.
+- A `gh` 403 on this repo is infra, not code — it is the known free-tier gate on a private repo. Classify it as such (see Workflow step 8); never spend a fix cycle triaging it as a CI failure.
+
 ## Delegation mechanics (how to wait)
 
 You cannot poll or block on a subagent (`TaskOutput` does not exist inside subagents). The only completion signal that reaches you is the automatic task-notification for a subagent you spawned with `Agent` — and it is delivered when you are stopped. Therefore:
@@ -36,22 +45,34 @@ You cannot poll or block on a subagent (`TaskOutput` does not exist inside subag
 2. Delegate to **debugger** with a 5–10 line brief (symptom, expected behavior, suspected module). Its root-cause report feeds the plan.
 3. Plan with the `plan-for-issue` skill using `--handoff sonnet` (haiku only if complexity ≤ 3). If the skill surfaces blocking questions → escalate; never guess.
 4. Delegate to **implementer** passing only the issue number — the handoff file is the contract; do not resend the issue text.
-5. Delegate to **test-writer** with an explicit enumerated list of test cases (from the handoff's acceptance criteria + the debugger's repro), the target test file(s), and one existing similar test as pattern. Never say "write appropriate tests".
+5. Delegate to **test-writer** with an explicit enumerated list of test cases (from the handoff's acceptance criteria + the debugger's repro), the target test file(s), and one existing similar test as pattern. Never say "write appropriate tests". Cite the pattern as `file:line` ranges for the 2–3 relevant cases, not just a filename — naming a whole file makes the agent read all of it (one 22k-char test file was read in full four separate times across one issue). The same applies to the handoff's *Files Changed*.
 6. Delegate to **code-reviewer** on the branch diff. REQUIRED findings go back to implementer (counts as a fix cycle).
 7. Open the PR yourself: target `develop`, title `<type>(<scope>): <description>`, body in Spanish, closing keyword in English (`Closes #<N>` — "Cierra" closes nothing), never mention agents. Post the code-reviewer's verdict and findings as a Spanish comment on the PR (`gh pr comment`, REQUERIDO/OPCIONAL per finding, no agent mentions). If the review includes proposed tooling rules, file each one as its own GitHub issue (`gh issue create --label internal`, Spanish title/body: the gap, the proposed rule, where it would live) and link them from the PR comment. Never add readiness labels (`ready-for-agent`/`needs-triage`) — those belong to `/triage`. Then `gh pr checks --watch`.
 8. On red CI, triage the failure before delegating. Every fix reaches the implementer as a **Fix step appended to the handoff** (what failed, files involved, acceptance criterion = the failing check green, local validation command) — never as a free-form instruction, so the implementer stays within its handoff contract.
    - **Attributable** (the failing check's log points at files in the diff): append the Fix step and spawn a fresh implementer with a brief holding only the log excerpt. Counts as one fix cycle.
    - **Opaque** (`e2e`, or the log does not implicate the diff): delegate to **debugger** first; its root-cause report feeds the Fix step. Diagnosis + fix = one cycle, not two.
    - **Suspected flake** (infra timeout, failure clearly unrelated to the diff): `gh run rerun <run-id> --failed`, at most once per issue, not counted as a cycle. The same failure twice is real — triage it as above.
+   - **Infra, not CI** (`gh` 403/5xx, the Actions API refusing to answer): not a code failure and not a fix cycle — a 403 here is the known free-tier gate on a private repo. Note it in the audit log and apply the retry/backoff rule in Budget → Infrastructure failures; if it does not clear, escalate. Never append a Fix step for it.
 
-## Output discipline
+## Context discipline
 
-Your own text is your single biggest cost. Measured across past runs it is 60–79% of your context, and every token you write is re-read on every later turn — the second half of a run costs ~3x the first. This section is about YOUR text, not about the work.
+Everything in your context is re-billed on every later turn, so the second half of a run costs far more per turn than the first. Measured across past runs, your context is: **tool results ~41%, the arguments you write into tool calls ~31%, injected briefs and notifications ~22%, your own prose ~6%.** Optimize in that order — the rules below are ranked by what actually costs.
 
-- **Default to silence between tool calls.** Write text only when you find something, change direction, or hit a blocker — one sentence each. Never narrate routine actions ("Now I'll…", "Let me check…", "Looking at…").
-- **Never** explain an obvious decision, recap completed work, or narrate what a subagent did. The transcript already records all of it.
-- Prefer structured data over prose: bullets and `key: value`, never paragraphs.
-- Delegate with the minimum each role needs: briefs, not transcripts. From each subagent report, extract only what the next role needs.
+**1. Never let a command dump its output on you.** Truncate at the source, in the command itself — not after you have already paid for it.
+
+- Read logs and command output through `tail -n 40` / `head -n 40`, never bare `cat`.
+- `git diff --name-only` or `--stat` first; open the actual patch only for files you must reason about.
+- `gh pr checks` / `gh run view --log-failed | tail -50`, never a full run log.
+- Never `Read` a task's `.output` file — it is a full JSONL transcript and will flood your context. If a backgrounded command matters, wait for its notification.
+
+**2. Keep your own tool arguments small.** They cost as much as anything you read.
+
+- Update the audit log with targeted `Edit`s, never a full-document `Write` (see Audit).
+- Briefs cite `file:line` ranges, not whole files (see Workflow step 5).
+
+**3. Read once.** You already have what you read earlier in this run — re-reading a file you have open is pure waste. Never `Read` a file back to confirm a `Write` you just made succeeded.
+
+**4. Keep prose short** — it is the smallest slice, so this is a tidiness rule, not a savings one. Write text when you find something, change direction, or hit a blocker; one sentence each. Skip narration of routine actions and recaps of what a subagent just did — the transcript already records it. Prefer bullets and `key: value` over paragraphs.
 
 ### Output budget
 
@@ -66,6 +87,8 @@ These are **writing** limits, not run budgets: exceeding one means write less. N
 ## Audit
 
 `.claude/docs/runs/<N>.md` (create the directory if missing) is **execution state, not a diary**: current phase, pending work, branch and commits, fix cycles used, standing decisions, final CI status. Update it at the end of each phase (plan, implementation, tests, review, PR/CI), before every escalation, and at the end. Rewrite stale state in place — never append a running narrative.
+
+**Use `Edit` on the affected section.** A full-document `Write` resends the whole file every time and trips the staleness check, which forces a `Read` and then a re-`Write` of *identical* content — measured, about half of all audit writes in past runs were exactly that no-op round trip. `Write` only to create the file. If an `Edit` fails as stale, `Read` once and retry; never rewrite content that has not changed.
 
 **Record a decision only if it** changes the contract (handoff, plan, API, schema), constrains a later phase, or needs human intervention. Reversible implementation choices inside the plan's scope — a default value, reusing an existing FormRequest, a helper's name — are **not** recorded: the diff already shows them.
 

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -23,6 +23,13 @@ You turn an explicit list of test cases into passing tests. Your brief MUST cont
 
 If a render still fails, re-read the actual stack trace before theorizing. Do not mock away a shadcn component to dodge an error you have not explained — that silently weakens the test.
 
+## Waiting for long commands
+
+Suites and `validate-code` can exceed the 120s Bash timeout and get moved to the background. When that happens, **end your turn and wait for the completion notification.** Do not chase the job:
+
+- Never `cat` or `Read` a task's `.output` file — it is a full JSONL transcript and floods your context. If you must peek, `tail -n 40` it, once.
+- Never poll with `sleep`, `until [ -s … ]`, `ps aux | grep`, or `tail -f` (which just hangs until the timeout). Past runs spent 12% of all tool calls doing this.
+
 ## Reporting
 
 To the leader, ~10 lines max: cases covered (mapped to the brief's list), suite result summary, commit sha.

--- a/.claude/skills/collect-evidence/SKILL.md
+++ b/.claude/skills/collect-evidence/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: collect-evidence
+description: Archives one session's raw transcripts (root + every subagent) into .claude/ and derives its cost/context report. Use after an autonomous issue run, before a /self-improve retrospective, or whenever a session is worth keeping as evidence.
+---
+
+# Collect session evidence
+
+Claude Code writes transcripts into the **config dir**, which is disposable and
+gets pruned. This skill copies one session's raw evidence into the repo and
+derives the report from it, so a run stays auditable after the config dir is gone.
+
+```bash
+python3 .claude/skills/collect-evidence/scripts/collect-evidence.py <session-id>
+```
+
+Get the current session id from the transcript path in `/status`, or list recent
+sessions with:
+
+```bash
+ls -lt ~/.claude-personal/projects/-Volumes-eSSD-src-fototobares/*.jsonl | head
+```
+
+## What it writes
+
+| Path | Contents |
+| --- | --- |
+| `.claude/transcripts/<id>.jsonl` | Root transcript, verbatim copy |
+| `.claude/docs/sessions/<id>/raw/root.jsonl` | Same file, next to its subagents |
+| `.claude/docs/sessions/<id>/raw/subagents/agent-*.jsonl` | One per subagent, verbatim |
+| `.claude/docs/sessions/<id>/raw/subagents/agent-*.meta.json` | `agentType`, `spawnDepth`, `toolUseId`, `parentAgentId` |
+| `.claude/docs/sessions/<id>/report.json` | Derived report (nested schema) |
+| `.claude/session-report/<id>.json` | Same data, flat schema + `notes` |
+
+Copies are verbatim — the report is always re-derivable from `raw/`. Re-running
+on the same id overwrites in place, so it is safe to collect a session twice.
+
+## Reading the report
+
+- **`costUsd`** is computed from the per-message `usage` in the transcript, at
+  input/output/cache rates per model (cache read 0.1x input, write 1.25x for 5m
+  and 2x for 1h). Verified to reproduce previously recorded costs exactly.
+- **`context.first` / `context.last`** is the request size at the first and last
+  turn. This is the cost driver: the whole context is re-billed every turn, so a
+  run's second half costs far more per turn than its first.
+- **`composition`** is the share of context chars by origin. `prosePct` is
+  **only** narration written by the agent.
+
+> **Do not** use the old `ownContentPct` field as a verbosity proxy. It lumped
+> prose together with tool_use arguments and read ~10x high (leader: 73% vs 3%
+> real prose). That misreading got copied into `leader.md` as a prompt rule and
+> spent a whole section optimizing 3–6% of the cost. See
+> `.claude/docs/who-killed-the-tokens.md`, finding 1. `composition` replaces it.
+
+`toolResultTokensApprox` is a chars/4 estimate — indicative, not billing-grade.
+
+## Notes
+
+- The config dir is autodetected across `~/.claude*` and **always printed**.
+  `CLAUDE_CONFIG_DIR` is defined as a shell alias, so it does not exist in a
+  plain shell; `~/.claude` is stale on this machine and the live one is
+  `~/.claude-personal`. Pass `--config-dir DIR` to force one.
+- A session with no subagents produces an empty `agents` list — the raw root
+  transcript is still archived.
+- Exits 1 with the paths it probed if the session id is not found.

--- a/.claude/skills/collect-evidence/scripts/collect-evidence.py
+++ b/.claude/skills/collect-evidence/scripts/collect-evidence.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Collect the raw evidence for one Claude Code session into the repo.
+
+Copies the root transcript and every subagent transcript out of the Claude
+config dir (which is disposable) into `.claude/`, then derives the session
+report from them.
+
+Usage: python3 .claude/skills/collect-evidence/scripts/collect-evidence.py <session-id> [--config-dir DIR]
+
+Outputs:
+  .claude/transcripts/<id>.jsonl                  root transcript (verbatim)
+  .claude/docs/sessions/<id>/raw/root.jsonl       same, alongside its subagents
+  .claude/docs/sessions/<id>/raw/subagents/*      subagent transcripts + meta
+  .claude/docs/sessions/<id>/report.json          derived report
+  .claude/session-report/<id>.json                derived report (flat variant)
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import sys
+from collections import defaultdict
+
+# Price per 1M tokens. Cache read is 0.1x input, cache write 1.25x (5m) / 2x (1h).
+PRICING = {
+    "opus-4-8": {"input": 5.0, "output": 25.0},
+    "sonnet-5": {"input": 2.0, "output": 10.0},
+    "haiku-4-5": {"input": 1.0, "output": 5.0},
+    "fable-5": {"input": 2.0, "output": 10.0},
+}
+DEFAULT_PRICE = PRICING["sonnet-5"]
+
+
+def short_model(raw: str) -> str:
+    """claude-opus-4-8-20260115 -> opus-4-8"""
+    if not raw:
+        return "unknown"
+    name = raw.replace("claude-", "")
+    for known in PRICING:
+        if name.startswith(known):
+            return known
+    return name
+
+
+def cost_usd(model: str, inp: int, out: int, c_read: int, c_5m: int, c_1h: int) -> float:
+    p = PRICING.get(model, DEFAULT_PRICE)
+    return (
+        inp * p["input"]
+        + out * p["output"]
+        + c_read * p["input"] * 0.1
+        + c_5m * p["input"] * 1.25
+        + c_1h * p["input"] * 2.0
+    ) / 1_000_000
+
+
+def result_text(block: dict) -> str:
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(i.get("text", "") for i in content if isinstance(i, dict))
+    return ""
+
+
+def analyse(path: str) -> dict | None:
+    """Derive one agent's metrics from its transcript."""
+    inp = out = c_read = c_5m = c_1h = 0
+    turns = tool_calls = 0
+    model = ""
+    first_ts = last_ts = None
+    ctx_first = ctx_last = 0
+    last_tool = None
+    comp = defaultdict(int)
+
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        ts = entry.get("timestamp")
+        if ts:
+            first_ts = first_ts or ts
+            last_ts = ts
+
+        msg = entry.get("message") or {}
+        role = msg.get("role")
+
+        if role == "assistant":
+            usage = msg.get("usage") or {}
+            if usage:
+                turns += 1
+                model = model or short_model(msg.get("model", ""))
+                creation = usage.get("cache_creation") or {}
+                m5 = creation.get("ephemeral_5m_input_tokens", 0)
+                m1 = creation.get("ephemeral_1h_input_tokens", 0)
+                if not creation:
+                    m5 = usage.get("cache_creation_input_tokens", 0)
+                inp += usage.get("input_tokens", 0)
+                out += usage.get("output_tokens", 0)
+                c_read += usage.get("cache_read_input_tokens", 0)
+                c_5m += m5
+                c_1h += m1
+                # Context = everything re-sent on this request; paid every turn.
+                ctx = (
+                    usage.get("input_tokens", 0)
+                    + usage.get("cache_read_input_tokens", 0)
+                    + m5
+                    + m1
+                )
+                ctx_first = ctx_first or ctx
+                ctx_last = ctx
+
+            for block in msg.get("content") or []:
+                if not isinstance(block, dict):
+                    continue
+                kind = block.get("type")
+                if kind == "text":
+                    comp["prose"] += len(block.get("text", ""))
+                elif kind == "thinking":
+                    comp["thinking"] += len(block.get("thinking", ""))
+                elif kind == "tool_use":
+                    tool_calls += 1
+                    params = block.get("input") or {}
+                    comp["toolUseParams"] += len(json.dumps(params))
+                    arg = (
+                        params.get("command")
+                        or params.get("file_path")
+                        or params.get("pattern")
+                        or params.get("subagent_type")
+                        or params.get("skill")
+                        or ""
+                    )
+                    last_tool = {
+                        "name": block.get("name", "?"),
+                        "arg": " ".join(str(arg).split())[:70],
+                    }
+
+        elif role == "user":
+            for block in msg.get("content") or []:
+                if isinstance(block, str):
+                    comp["injected"] += len(block)
+                elif isinstance(block, dict):
+                    if block.get("type") == "tool_result":
+                        comp["toolResults"] += len(result_text(block))
+                    elif block.get("type") == "text":
+                        comp["injected"] += len(block.get("text", ""))
+
+    if not turns:
+        return None
+
+    total_chars = sum(comp.values()) or 1
+    elapsed = 0
+    if first_ts and last_ts:
+        from datetime import datetime
+
+        def parse(t: str) -> datetime:
+            return datetime.fromisoformat(t.replace("Z", "+00:00"))
+
+        elapsed = round((parse(last_ts) - parse(first_ts)).total_seconds())
+
+    return {
+        "model": model or "unknown",
+        "startedAt": first_ts,
+        "elapsedSeconds": elapsed,
+        "tokens": {
+            "input": inp,
+            "output": out,
+            "cacheRead": c_read,
+            "cacheWrite": c_5m + c_1h,
+            "cacheWrite5m": c_5m,
+            "cacheWrite1h": c_1h,
+        },
+        "toolCalls": tool_calls,
+        "lastTool": last_tool,
+        "costUsd": round(cost_usd(model, inp, out, c_read, c_5m, c_1h), 4),
+        "turns": turns,
+        "context": {
+            "first": ctx_first,
+            "last": ctx_last,
+            "toolResultTokensApprox": comp["toolResults"] // 4,
+        },
+        # Share of the agent's own written output that is prose, i.e. narration.
+        # NOT the same as the old `ownContentPct`, which silently lumped prose
+        # together with tool_use arguments and read ~10x too high.
+        "composition": {
+            "prosePct": round(100 * comp["prose"] / total_chars),
+            "toolUseParamsPct": round(100 * comp["toolUseParams"] / total_chars),
+            "toolResultsPct": round(100 * comp["toolResults"] / total_chars),
+            "injectedPct": round(100 * comp["injected"] / total_chars),
+            "thinkingPct": round(100 * comp["thinking"] / total_chars),
+        },
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("session_id")
+    ap.add_argument("--config-dir", default=None)
+    args = ap.parse_args()
+    sid = args.session_id
+
+    repo = os.path.realpath(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..")
+    )
+    slug = "-" + repo.strip("/").replace("/", "-")
+
+    # The config dir is set by an alias, so it is absent from a plain shell.
+    # Autodetect and always print the choice: ~/.claude is stale on this box.
+    candidates = (
+        [args.config_dir]
+        if args.config_dir
+        else sorted(glob.glob(os.path.expanduser("~/.claude*")))
+    )
+    src_dir = None
+    for cand in candidates:
+        probe = os.path.join(cand, "projects", slug, f"{sid}.jsonl")
+        if os.path.exists(probe):
+            src_dir = cand
+            break
+    if not src_dir:
+        print(f"ERROR: no transcript for session {sid} in: {', '.join(candidates)}", file=sys.stderr)
+        print(f"       looked for projects/{slug}/{sid}.jsonl", file=sys.stderr)
+        return 1
+
+    print(f"config dir : {src_dir}")
+    print(f"project    : {repo}")
+    print(f"session    : {sid}")
+
+    src_root = os.path.join(src_dir, "projects", slug, f"{sid}.jsonl")
+    src_subs = os.path.join(src_dir, "projects", slug, sid, "subagents")
+
+    out_session = os.path.join(repo, ".claude", "docs", "sessions", sid)
+    out_raw_subs = os.path.join(out_session, "raw", "subagents")
+    os.makedirs(out_raw_subs, exist_ok=True)
+    os.makedirs(os.path.join(repo, ".claude", "transcripts"), exist_ok=True)
+    os.makedirs(os.path.join(repo, ".claude", "session-report"), exist_ok=True)
+
+    shutil.copy2(src_root, os.path.join(repo, ".claude", "transcripts", f"{sid}.jsonl"))
+    shutil.copy2(src_root, os.path.join(out_session, "raw", "root.jsonl"))
+
+    agents = []
+    for meta_path in sorted(glob.glob(os.path.join(src_subs, "*.meta.json"))):
+        tr_path = meta_path.replace(".meta.json", ".jsonl")
+        if not os.path.exists(tr_path):
+            continue
+        shutil.copy2(meta_path, out_raw_subs)
+        shutil.copy2(tr_path, out_raw_subs)
+
+        meta = json.load(open(meta_path, encoding="utf-8"))
+        metrics = analyse(tr_path)
+        if not metrics:
+            continue
+        agent_id = os.path.basename(tr_path)[len("agent-") : -len(".jsonl")]
+        agents.append(
+            {
+                "role": meta.get("agentType", "unknown"),
+                "depth": meta.get("spawnDepth", 1),
+                "agentId": agent_id,
+                "toolUseId": meta.get("toolUseId"),
+                **metrics,
+                "parentAgentId": meta.get("parentAgentId", "ROOT"),
+            }
+        )
+
+    agents.sort(key=lambda a: (a["depth"], a["startedAt"] or ""))
+
+    from datetime import datetime, timezone
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    totals = {
+        "agentCount": len(agents),
+        "turns": sum(a["turns"] for a in agents),
+        "outputTokens": sum(a["tokens"]["output"] for a in agents),
+        "cacheTokens": sum(a["tokens"]["cacheRead"] + a["tokens"]["cacheWrite"] for a in agents),
+        "costUsd": round(sum(a["costUsd"] for a in agents), 4),
+    }
+
+    report = {
+        "session": sid,
+        "project": repo,
+        "generatedAt": generated,
+        "agents": agents,
+        "totals": totals,
+    }
+    with open(os.path.join(out_session, "report.json"), "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+        fh.write("\n")
+
+    flat = {
+        "sessionId": sid,
+        "project": repo,
+        "configDir": src_dir,
+        "generatedAt": generated,
+        "agents": [
+            {
+                "role": a["role"],
+                "depth": a["depth"],
+                "agentId": a["agentId"],
+                "toolUseId": a["toolUseId"],
+                "model": a["model"],
+                "start": a["startedAt"],
+                "elapsedSeconds": a["elapsedSeconds"],
+                "inputTokens": a["tokens"]["input"],
+                "outputTokens": a["tokens"]["output"],
+                "cacheReadTokens": a["tokens"]["cacheRead"],
+                "cacheWriteTokens": a["tokens"]["cacheWrite"],
+                "toolCalls": a["toolCalls"],
+                "lastTool": f"{a['lastTool']['name']}({a['lastTool']['arg']})" if a["lastTool"] else None,
+                "costUsd": a["costUsd"],
+                "turns": a["turns"],
+                "contextStart": a["context"]["first"],
+                "contextEnd": a["context"]["last"],
+                "toolResultTokensApprox": a["context"]["toolResultTokensApprox"],
+                "composition": a["composition"],
+                "parent": a["parentAgentId"],
+            }
+            for a in agents
+        ],
+        "totals": totals,
+        "notes": {
+            "context": "tokens del request al primer turno -> al ultimo; se paga entero en cada turno, driver del costo",
+            "composition": "% de chars del contexto por origen. prosePct es SOLO texto narrado por el agente; el viejo ownContentPct sumaba prosa + argumentos de tool_use y leia ~10x alto (ver .claude/docs/who-killed-the-tokens.md, hallazgo 1)",
+            "cache": "lectura 0.1x input, escritura 1.25x (5m) o 2x (1h)",
+        },
+    }
+    with open(os.path.join(repo, ".claude", "session-report", f"{sid}.json"), "w", encoding="utf-8") as fh:
+        json.dump(flat, fh, indent=2)
+        fh.write("\n")
+
+    print(f"\nagents     : {len(agents)}")
+    for a in agents:
+        print(
+            f"  {'  ' * (a['depth'] - 1)}{a['role']:<14} {a['model']:<10} "
+            f"${a['costUsd']:>7.3f}  turns={a['turns']:<4} prose={a['composition']['prosePct']}%"
+        )
+    print(f"\ntotal cost : ${totals['costUsd']}")
+    print(f"written    : .claude/transcripts/{sid}.jsonl")
+    print(f"             .claude/docs/sessions/{sid}/")
+    print(f"             .claude/session-report/{sid}.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/validate-code/scripts/validate-code.sh
+++ b/.claude/skills/validate-code/scripts/validate-code.sh
@@ -52,17 +52,23 @@ echo "Changed sides: backend=$backend frontend=$frontend e2e=$e2e (full=$FULL)"
 echo
 
 failures=()
+# Output is captured, not streamed: a passing tool prints its whole file/test
+# list, which is pure noise that an agent then re-reads on every later turn.
+# On success only the label is emitted; on failure, the tail of the log.
 run() {
     local label=$1
     shift
-    echo "==> $label"
-    if "$@"; then
-        echo "    OK"
+    local log
+    log=$(mktemp)
+    if "$@" >"$log" 2>&1; then
+        echo "==> $label: OK"
     else
-        echo "    FAILED"
+        echo "==> $label: FAILED"
+        tail -n "${VALIDATE_LOG_LINES:-40}" "$log"
+        echo
         failures+=("$label")
     fi
-    echo
+    rm -f "$log"
 }
 
 if $backend; then


### PR DESCRIPTION
Análisis de 8 sesiones del flujo autónomo (42 corridas de agente, US$137 medidos) y correcciones derivadas.

**Hallazgo principal**: la sección *Output discipline* del leader afirmaba que su prosa era el 60–79% de su contexto. Medido sobre los transcripts, es el 5.6% — el número venía de `ownContentPct`, que agrupa prosa + argumentos de tool_use. La sección gastaba presupuesto de prompt vigilando el 6% del costo mientras el 72% real (`tool_results` + `tool_use_params`) no tenía ninguna regla.

## Cambios

- **`validate-code`** captura la salida y emite solo `tail -40` si algo falla. Corrida verde real: **de ~22.000 chars a 172 (−99.2%)**. Camino de fallo verificado: conserva el error. Ajustable con `VALIDATE_LOG_LINES`.
- **Leader**: §Output discipline reescrita como §Context discipline con las proporciones reales, ordenada por costo. Auditoría con `Edit` dirigido en vez de `Write` completo (la mitad de las escrituras eran reintentos no-op idénticos). Briefs con `file:line`.
- **Leader**: nueva regla de fallas de infra — máx. 3 reintentos y después escalar. Una corrida pasada relanzó **el mismo brief de test-writer 7 veces** durante una caída del clasificador de seguridad; ninguna regla del presupuesto aplicaba porque el agente nunca llegaba a arrancar. Los `gh` 403 quedan clasificados como infra, no como fallo de CI.
- **Implementer y test-writer**: prohibición de leer archivos `.output` y de hacer busy-polling (era el 12% de las tool calls del test-writer).

## Nueva skill

`collect-evidence <session-id>`: archiva los transcripts crudos (raíz + subagentes) y deriva el reporte de costo/contexto. Validada regenerando una sesión existente con coincidencia exacta en todos los campos de facturación.

Reemplaza `ownContentPct` por un bloque `composition` que separa `prosePct` de `toolUseParamsPct`, para no volver a inducir el error del hallazgo principal.

## Notas de revisión

- Los 5 checks requeridos van a pasar sin ejercitar ninguno de estos cambios: son prompts y un script bash fuera del árbol de la app. El cambio de `validate-code.sh` se probó a mano en verde y en rojo; los de prompts solo se validan en la próxima corrida real del flujo.
- El análisis completo vive en `.claude/docs/who-killed-the-tokens.md`, que es local por `.gitignore` y no viaja en este PR.
