### PR TITLE
feat(orders): agregar acción para deshabilitar la fabricación por detalle

### DIFF
--- a/app/Actions/Orders/SetDetailProductionStatusAction.php
+++ b/app/Actions/Orders/SetDetailProductionStatusAction.php
@@ -24,7 +24,9 @@ class SetDetailProductionStatusAction implements ActionContract
      * Change a detail's production status from the order page. Production is
      * gated by the first installment: until it is paid nothing gets enabled.
      * A null status enables the detail as "sin empezar" (it enters /tracking);
-     * a stage delegates to the tracking flow, which deducts stock.
+     * a stage delegates to the tracking flow, which deducts stock. Disabling
+     * clears production_enabled_at only, removing the detail from /tracking
+     * without touching its stage or stock.
      *
      * @param  DetailProductionStatusSettingData  $params
      *
@@ -49,6 +51,12 @@ class SetDetailProductionStatusAction implements ActionContract
             throw ValidationException::withMessages([
                 'detail_id' => 'No se encontró el producto en este pedido.',
             ]);
+        }
+
+        if ($params->disableProduction) {
+            $this->markDisabled($detail);
+
+            return;
         }
 
         if (! $order->firstInstallmentPaid()) {
@@ -81,6 +89,17 @@ class SetDetailProductionStatusAction implements ActionContract
     {
         $detail->production_enabled_at ??= now();
         $detail->production_status_id = null;
+        $detail->status_updated_at = now();
+        $detail->save();
+    }
+
+    /**
+     * Disable the detail: it leaves /tracking, but its reached stage is
+     * preserved so re-enabling resumes from it. No stock movement happens.
+     */
+    private function markDisabled(OrderDetail $detail): void
+    {
+        $detail->production_enabled_at = null;
         $detail->status_updated_at = now();
         $detail->save();
     }

--- a/app/Actions/Orders/SetDetailProductionStatusAction.php
+++ b/app/Actions/Orders/SetDetailProductionStatusAction.php
@@ -83,12 +83,20 @@ class SetDetailProductionStatusAction implements ActionContract
     /**
      * Enable the detail with no stage yet: it shows up in /tracking as
      * "sin empezar". Already-deducted stock stays deducted, mirroring
-     * backward moves on the tracking board.
+     * backward moves on the tracking board. If the detail was disabled (its
+     * stage preserved for exactly this purpose), re-enabling resumes at that
+     * stage instead of clearing it; only an already-enabled detail explicitly
+     * set to "sin empezar" gets its stage cleared.
      */
     private function markPending(OrderDetail $detail): void
     {
+        $wasEnabled = $detail->production_enabled_at !== null;
         $detail->production_enabled_at ??= now();
-        $detail->production_status_id = null;
+
+        if ($wasEnabled) {
+            $detail->production_status_id = null;
+        }
+
         $detail->status_updated_at = now();
         $detail->save();
     }

--- a/app/Data/Orders/DetailProductionStatusSettingData.php
+++ b/app/Data/Orders/DetailProductionStatusSettingData.php
@@ -15,5 +15,6 @@ final readonly class DetailProductionStatusSettingData implements DtoContract
         public int $detailId,
         public ?int $statusId,
         public ?User $user,
+        public bool $disableProduction = false,
     ) {}
 }

--- a/app/Http/Requests/BO/UpdateDetailProductionStatusRequest.php
+++ b/app/Http/Requests/BO/UpdateDetailProductionStatusRequest.php
@@ -28,12 +28,13 @@ class UpdateDetailProductionStatusRequest extends FormRequest
         return [
             'detail_id' => ['required', 'integer'],
             'production_status_id' => ['nullable', 'integer', 'exists:production_statuses,id'],
+            'disable_production' => ['sometimes', 'boolean'],
         ];
     }
 
     public function toData(Order $order, ?User $user): DetailProductionStatusSettingData
     {
-        /** @var array{detail_id: int|string, production_status_id: int|string|null} $validated */
+        /** @var array{detail_id: int|string, production_status_id: int|string|null, disable_production?: bool} $validated */
         $validated = $this->validated();
 
         return new DetailProductionStatusSettingData(
@@ -41,6 +42,7 @@ class UpdateDetailProductionStatusRequest extends FormRequest
             detailId: (int) $validated['detail_id'],
             statusId: isset($validated['production_status_id']) ? (int) $validated['production_status_id'] : null,
             user: $user,
+            disableProduction: $validated['disable_production'] ?? false,
         );
     }
 }

--- a/resources/js/pages/orders/components/detail-item.tsx
+++ b/resources/js/pages/orders/components/detail-item.tsx
@@ -16,6 +16,7 @@ export function DetailItem({
     onTogglePriority,
     firstInstallmentPaid,
     onStatusChange,
+    onDisableProduction,
     canEditVariant,
 }: {
     orderId: number;
@@ -24,6 +25,7 @@ export function DetailItem({
     onTogglePriority: () => void;
     firstInstallmentPaid: boolean;
     onStatusChange: (statusId: number | null) => void;
+    onDisableProduction: () => void;
     canEditVariant: boolean;
 }) {
     const [showEditVariant, setShowEditVariant] = useState(false);
@@ -108,6 +110,7 @@ export function DetailItem({
                             product={product}
                             firstInstallmentPaid={firstInstallmentPaid}
                             onChange={onStatusChange}
+                            onDisable={onDisableProduction}
                         />
                         <Button
                             variant="ghost"

--- a/resources/js/pages/orders/components/details.tsx
+++ b/resources/js/pages/orders/components/details.tsx
@@ -11,7 +11,9 @@ import { DetailItem } from './detail-item';
 
 export function Details({ order }: { order: Order }) {
     const { toggle } = useDetailPriority(order.id);
-    const { setStatus } = useDetailProductionStatus(order.id);
+    const { setStatus, disableProduction } = useDetailProductionStatus(
+        order.id,
+    );
     const products = order.products || [];
     const isCancelled = Boolean(order.cancelled_at);
 
@@ -43,6 +45,9 @@ export function Details({ order }: { order: Order }) {
                             )}
                             onStatusChange={(statusId) =>
                                 setStatus(product.order_detail_id, statusId)
+                            }
+                            onDisableProduction={() =>
+                                disableProduction(product.order_detail_id)
                             }
                             canEditVariant={
                                 !isCancelled &&

--- a/resources/js/pages/orders/components/production-disable-confirmation.tsx
+++ b/resources/js/pages/orders/components/production-disable-confirmation.tsx
@@ -1,0 +1,49 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+export function ProductionDisableConfirmation({
+    show,
+    productName,
+    onConfirm,
+    onCancel,
+}: {
+    show: boolean;
+    productName: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}) {
+    return (
+        <AlertDialog open={show} onOpenChange={() => onCancel()}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>
+                        ¿Deshabilitar la fabricación de {productName}?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                        El producto dejará de aparecer en /tracking. La etapa
+                        alcanzada se conserva para retomarla al volver a
+                        habilitar la fabricación, y no se revierte stock.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={onCancel}>
+                        Cancelar
+                    </AlertDialogCancel>
+
+                    <AlertDialogAction onClick={onConfirm}>
+                        Deshabilitar
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/resources/js/pages/orders/components/production-status-control.test.tsx
+++ b/resources/js/pages/orders/components/production-status-control.test.tsx
@@ -164,4 +164,116 @@ describe('ProductionStatusControl', () => {
         expect(onChange).not.toHaveBeenCalled();
         expect(trigger.textContent).toContain('Pegado');
     });
+
+    it('offers to disable production for an enabled detail', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct()}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        expect(screen.getByText('Deshabilitar fabricación')).toBeTruthy();
+    });
+
+    it('does not offer to disable production for a not-enabled detail', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({ production_enabled: false })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        expect(screen.getByText('Habilitar fabricación')).toBeTruthy();
+        expect(screen.queryByText('Deshabilitar fabricación')).toBeNull();
+    });
+
+    it('disables immediately when the detail has no stage yet', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct()}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Deshabilitar fabricación'));
+
+        expect(onDisable).toHaveBeenCalledTimes(1);
+        expect(screen.queryByText(/¿Deshabilitar la fabricación/)).toBeNull();
+    });
+
+    it('asks for confirmation before disabling a detail with a reached stage', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Impreso',
+                    production_status_id: 21,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Deshabilitar fabricación'));
+
+        expect(screen.getByText(/¿Deshabilitar la fabricación/)).toBeTruthy();
+        expect(onDisable).not.toHaveBeenCalled();
+    });
+
+    it('disables the detail once the confirmation is accepted', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Impreso',
+                    production_status_id: 21,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Deshabilitar fabricación'));
+        fireEvent.click(screen.getByText('Deshabilitar'));
+
+        expect(onDisable).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the detail enabled when the disable confirmation is cancelled', () => {
+        const onChange = vi.fn();
+        const onDisable = vi.fn();
+        render(
+            <ProductionStatusControl
+                product={makeProduct({
+                    production_status: 'Impreso',
+                    production_status_id: 21,
+                })}
+                firstInstallmentPaid={true}
+                onChange={onChange}
+                onDisable={onDisable}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Deshabilitar fabricación'));
+        fireEvent.click(screen.getByText('Cancelar'));
+
+        expect(onDisable).not.toHaveBeenCalled();
+    });
 });

--- a/resources/js/pages/orders/components/production-status-control.test.tsx
+++ b/resources/js/pages/orders/components/production-status-control.test.tsx
@@ -25,6 +25,7 @@ describe('ProductionStatusControl', () => {
                 product={makeProduct({ production_enabled: false })}
                 firstInstallmentPaid={false}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -41,6 +42,7 @@ describe('ProductionStatusControl', () => {
                 product={makeProduct({ production_enabled: false })}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -59,6 +61,7 @@ describe('ProductionStatusControl', () => {
                 })}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -78,6 +81,7 @@ describe('ProductionStatusControl', () => {
                 product={makeProduct()}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -100,6 +104,7 @@ describe('ProductionStatusControl', () => {
                 })}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -123,6 +128,7 @@ describe('ProductionStatusControl', () => {
                 })}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 
@@ -145,6 +151,7 @@ describe('ProductionStatusControl', () => {
                 })}
                 firstInstallmentPaid={true}
                 onChange={onChange}
+                onDisable={() => {}}
             />,
         );
 

--- a/resources/js/pages/orders/components/production-status-control.tsx
+++ b/resources/js/pages/orders/components/production-status-control.tsx
@@ -9,6 +9,7 @@ import {
 import { Factory } from 'lucide-react';
 import { useState } from 'react';
 import { getStageRollback } from '../production-stage';
+import { ProductionDisableConfirmation } from './production-disable-confirmation';
 import { StageRollbackConfirmation } from './stage-rollback-confirmation';
 
 const PENDING = 'none';
@@ -22,11 +23,14 @@ export function ProductionStatusControl({
     product,
     firstInstallmentPaid,
     onChange,
+    onDisable,
 }: {
     product: OrderProduct;
     firstInstallmentPaid: boolean;
     onChange: (statusId: number | null) => void;
+    onDisable: () => void;
 }) {
+    const [confirmingDisable, setConfirmingDisable] = useState(false);
     const [pendingRollback, setPendingRollback] = useState<{
         targetId: number | null;
         stepsBack: number;
@@ -79,31 +83,56 @@ export function ProductionStatusControl({
         onChange(targetId);
     };
 
+    const handleDisableClick = () => {
+        if (product.production_status_id === null) {
+            onDisable();
+
+            return;
+        }
+
+        setConfirmingDisable(true);
+    };
+
     return (
         <>
-            <Select
-                value={
-                    product.production_status_id
-                        ? String(product.production_status_id)
-                        : PENDING
-                }
-                onValueChange={handleValueChange}
-            >
-                <SelectTrigger
-                    className="mt-2 h-8 w-fit gap-2 text-xs"
-                    aria-label={`Estado de fabricación de ${product.name}`}
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+                <Select
+                    value={
+                        product.production_status_id
+                            ? String(product.production_status_id)
+                            : PENDING
+                    }
+                    onValueChange={handleValueChange}
                 >
-                    <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                    <SelectItem value={PENDING}>Sin empezar</SelectItem>
-                    {statuses.map((status) => (
-                        <SelectItem key={status.id} value={String(status.id)}>
-                            {status.name}
-                        </SelectItem>
-                    ))}
-                </SelectContent>
-            </Select>
+                    <SelectTrigger
+                        className="h-8 w-fit gap-2 text-xs"
+                        aria-label={`Estado de fabricación de ${product.name}`}
+                    >
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={PENDING}>Sin empezar</SelectItem>
+                        {statuses.map((status) => (
+                            <SelectItem
+                                key={status.id}
+                                value={String(status.id)}
+                            >
+                                {status.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-auto px-2 py-1 text-xs"
+                    onClick={handleDisableClick}
+                >
+                    <Factory className="mr-1 h-3 w-3" />
+                    Deshabilitar fabricación
+                </Button>
+            </div>
 
             <StageRollbackConfirmation
                 show={pendingRollback !== null}
@@ -115,6 +144,16 @@ export function ProductionStatusControl({
                     setPendingRollback(null);
                 }}
                 onCancel={() => setPendingRollback(null)}
+            />
+
+            <ProductionDisableConfirmation
+                show={confirmingDisable}
+                productName={product.name}
+                onConfirm={() => {
+                    setConfirmingDisable(false);
+                    onDisable();
+                }}
+                onCancel={() => setConfirmingDisable(false)}
             />
         </>
     );

--- a/resources/js/pages/orders/hooks/use-detail-production-status.ts
+++ b/resources/js/pages/orders/hooks/use-detail-production-status.ts
@@ -2,6 +2,15 @@ import { router } from '@inertiajs/react';
 import { toast } from 'sonner';
 
 export function useDetailProductionStatus(orderId: number) {
+    const requestOptions = (successMessage: string) => ({
+        preserveScroll: true as const,
+        onSuccess: () => toast.success(successMessage),
+        onError: (errors: Record<string, string>) =>
+            toast.error(
+                Object.values(errors)[0] ?? 'No se pudo actualizar el estado',
+            ),
+    });
+
     const setStatus = (detailId: number, statusId: number | null) => {
         router.put(
             route('orders.production-status', { order: orderId }),
@@ -9,18 +18,20 @@ export function useDetailProductionStatus(orderId: number) {
                 detail_id: detailId,
                 production_status_id: statusId,
             },
-            {
-                preserveScroll: true,
-                onSuccess: () =>
-                    toast.success('Estado de fabricación actualizado'),
-                onError: (errors) =>
-                    toast.error(
-                        Object.values(errors)[0] ??
-                            'No se pudo actualizar el estado',
-                    ),
-            },
+            requestOptions('Estado de fabricación actualizado'),
         );
     };
 
-    return { setStatus };
+    const disableProduction = (detailId: number) => {
+        router.put(
+            route('orders.production-status', { order: orderId }),
+            {
+                detail_id: detailId,
+                disable_production: true,
+            },
+            requestOptions('Fabricación deshabilitada'),
+        );
+    };
+
+    return { setStatus, disableProduction };
 }

--- a/tests/Feature/DetailProductionStatusTest.php
+++ b/tests/Feature/DetailProductionStatusTest.php
@@ -310,6 +310,40 @@ it('re-enables a disabled detail without creating duplicate stock movements', fu
         ->and($detail->refresh()->production_enabled_at)->not->toBeNull();
 });
 
+it('restores the preserved stage when re-enabling a detail disabled at that stage', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = productWithChain(['Impreso', 'Pegado']);
+    $planchas = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => -2]);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+        'disable_production' => true,
+    ]);
+
+    $countBeforeReEnable = StockMovement::count();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasNoErrors();
+
+    $detail->refresh();
+    expect($detail->production_status_id)->toBe(stageOf($product, 2)->id)
+        ->and($detail->production_enabled_at)->not->toBeNull()
+        ->and(StockMovement::count())->toBe($countBeforeReEnable);
+});
+
 it('rejects disabling production on a cancelled order', function () {
     actingAsRole(UserRole::Office);
 

--- a/tests/Feature/DetailProductionStatusTest.php
+++ b/tests/Feature/DetailProductionStatusTest.php
@@ -6,6 +6,7 @@ use App\Enums\UserRole;
 use App\Models\Order;
 use App\Models\OrderDetail;
 use App\Models\Stockable;
+use App\Models\StockMovement;
 use Inertia\Testing\AssertableInertia as Assert;
 
 use function Pest\Laravel\get;
@@ -183,6 +184,166 @@ it('rejects a cancelled order', function () {
         'detail_id' => $detail->id,
         'production_status_id' => null,
     ])->assertSessionHasErrors('order');
+
+    expect($detail->refresh()->production_enabled_at)->toBeNull();
+});
+
+it('disables production, clearing production_enabled_at', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+        'disable_production' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect($detail->refresh()->production_enabled_at)->toBeNull();
+});
+
+it('preserves the reached stage when disabling production', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = productWithChain(['Impreso', 'Pegado']);
+    $planchas = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => -2]);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+        'disable_production' => true,
+    ])->assertSessionHasNoErrors();
+
+    $detail->refresh();
+    expect($detail->production_enabled_at)->toBeNull()
+        ->and($detail->production_status_id)->toBe(stageOf($product, 2)->id);
+});
+
+it('creates no stock movement when disabling production', function () {
+    actingAsRole(UserRole::Office);
+
+    $product = productWithChain(['Impreso', 'Pegado']);
+    $planchas = Stockable::factory()->create(['quantity' => 10]);
+    stageOf($product, 2)->stockables()->attach($planchas->id, ['quantity' => -2]);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+    ]);
+
+    $countBeforeDisable = StockMovement::count();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => stageOf($product, 2)->id,
+        'disable_production' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect(StockMovement::count())->toBe($countBeforeDisable)
+        ->and($planchas->refresh()->quantity)->toBe(8);
+});
+
+it('removes a disabled detail from tracking', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ]);
+
+    get(route('tracking.index'))->assertInertia(
+        fn (Assert $page) => $page->has('details', 1),
+    );
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+        'disable_production' => true,
+    ]);
+
+    get(route('tracking.index'))->assertInertia(
+        fn (Assert $page) => $page->has('details', 0),
+    );
+});
+
+it('re-enables a disabled detail without creating duplicate stock movements', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = orderWithFirstInstallmentPaid();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    $countBeforeRoundTrip = StockMovement::count();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+        'disable_production' => true,
+    ])->assertSessionHasNoErrors();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ])->assertSessionHasNoErrors();
+
+    expect(StockMovement::count())->toBe($countBeforeRoundTrip)
+        ->and($detail->refresh()->production_enabled_at)->not->toBeNull();
+});
+
+it('rejects disabling production on a cancelled order', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->cancelled()->create();
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+        'disable_production' => true,
+    ])->assertSessionHasErrors('order');
+});
+
+it('disables production even when the first installment is no longer paid', function () {
+    actingAsRole(UserRole::Office);
+
+    $order = Order::factory()->create(['total_price' => 64000, 'payment_plan' => 4]);
+    $order->payments()->create(['amount' => 16000, 'type' => 'efectivo', 'paid_on' => now()->toDateString()]);
+    $detail = OrderDetail::factory()->create(['order_id' => $order->id]);
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+    ]);
+
+    // The installment is no longer considered paid once refunded below
+    // the gate threshold, but the disable branch runs before that gate.
+    $order->payments()->delete();
+
+    put(route('orders.production-status', $order), [
+        'detail_id' => $detail->id,
+        'production_status_id' => null,
+        'disable_production' => true,
+    ])->assertSessionHasNoErrors();
 
     expect($detail->refresh()->production_enabled_at)->toBeNull();
 });


### PR DESCRIPTION
## Qué

Agrega una acción "Deshabilitar fabricación" por detalle del pedido, junto al selector de etapa. Al deshabilitarla, el detalle deja de aparecer en `/tracking` y su badge vuelve a "Sin habilitar".

## Cómo

- Se reutiliza el endpoint `PUT orders.production-status` con un campo explícito `disable_production`; no se agrega ninguna ruta.
- Deshabilitar limpia únicamente `production_enabled_at`. La etapa alcanzada (`production_status_id`) se conserva, de modo que volver a habilitar devuelve el detalle a donde estaba.
- La confirmación aparece solo cuando el detalle ya tiene una etapa asignada, reutilizando el patrón del diálogo de retroceso de etapa.
- No se genera ni se revierte ningún movimiento de stock.

## Detalle de implementación

La rama de deshabilitación se ubica después del guard de pedido cancelado pero **antes** del gate de primera cuota paga: deshacer debe seguir siendo posible aunque cambie la situación de pago del pedido.

`production_status_id: null` estaba sobrecargado — significaba tanto "habilitar como sin empezar" como "retroceder un detalle ya habilitado a sin empezar". Se distinguen ahora en `markPending()`: la etapa se limpia solo si el detalle ya estaba habilitado. Sin esta distinción, volver a habilitar borraba la etapa que deshabilitar había preservado.

## Tests

14 casos nuevos (8 backend en Pest, 6 frontend en Vitest) que cubren el limpiado de `production_enabled_at`, la preservación de la etapa, la ausencia de movimientos de stock en ida y vuelta, la desaparición de `/tracking`, el rechazo en pedidos cancelados y los caminos de confirmación/cancelación del diálogo.

## Fuera de alcance

- Reversión de stock o de etapas ya alcanzadas.
- Deshabilitar en bloque desde `/tracking` o desde el listado.
- Cambios en el gate de `/edition`. Que deshabilitar vuelva a bloquear el avance de edición es una consecuencia aceptada.

Closes #213