### PR TITLE
perf(validate-code): filtrar el output capturado en los fallos

### DIFF
--- a/.claude/skills/validate-code/SKILL.md
+++ b/.claude/skills/validate-code/SKILL.md
@@ -29,3 +29,11 @@ matching tools, all through Sail:
 - Requires Sail up (`./vendor/bin/sail up -d`); the script aborts early if not.
 - pint/prettier/eslint write fixes in place — review what they changed before
   staging.
+- On a failure, the script prints a log filtered per tool (phpstan, tsc,
+  eslint, vitest, pest each get their own filter; pint/prettier pass through
+  raw), trimmed to `VALIDATE_LOG_LINES` (default 40) from the **start** of the
+  filtered text — root-cause errors sit at the top. If a filter matches
+  nothing, it falls back to the tail of the raw log instead of an empty block.
+- `--full` runs the test suites too and can exceed the default 120s Bash
+  timeout — run it with an extended timeout (600000 ms) or expect it to move
+  to the background.

--- a/.claude/skills/validate-code/scripts/validate-code.sh
+++ b/.claude/skills/validate-code/scripts/validate-code.sh
@@ -54,17 +54,50 @@ echo
 failures=()
 # Output is captured, not streamed: a passing tool prints its whole file/test
 # list, which is pure noise that an agent then re-reads on every later turn.
-# On success only the label is emitted; on failure, the tail of the log.
+# On success only the label is emitted; on failure, a per-tool filtered log
+# (falling back to the raw tail when the filter matches nothing).
+filter_log() {
+    local filter=$1 log=$2
+    case "$filter" in
+        phpstan)
+            # Drop PHPStan's fixed preamble/table borders — keep only
+            # "path:line:message" lines — and strip the container path prefix.
+            grep -E '^[^:]+:[0-9]+:' "$log" | sed -E 's#^/var/www/html/##'
+            ;;
+        tsc)
+            grep -E 'error TS' "$log"
+            ;;
+        eslint)
+            sed -E 's/^[[:space:]]+//; s/[[:space:]]{2,}/ /g' "$log"
+            ;;
+        vitest)
+            grep -E '^::error' "$log"
+            ;;
+        pest)
+            sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' "$log"
+            ;;
+        raw | *)
+            cat "$log"
+            ;;
+    esac
+}
+
 run() {
-    local label=$1
-    shift
+    local label=$1 filter=$2
+    shift 2
     local log
     log=$(mktemp)
     if "$@" >"$log" 2>&1; then
         echo "==> $label: OK"
     else
         echo "==> $label: FAILED"
-        tail -n "${VALIDATE_LOG_LINES:-40}" "$log"
+        local filtered
+        filtered=$(filter_log "$filter" "$log")
+        if [ -z "$filtered" ]; then
+            tail -n "${VALIDATE_LOG_LINES:-40}" "$log"
+        else
+            echo "$filtered" | head -n "${VALIDATE_LOG_LINES:-40}"
+        fi
         echo
         failures+=("$label")
     fi
@@ -72,26 +105,26 @@ run() {
 }
 
 if $backend; then
-    run "pint" "$SAIL" php ./vendor/bin/pint
-    run "phpstan" "$SAIL" php ./vendor/bin/phpstan analyse
+    run "pint" "raw" "$SAIL" php ./vendor/bin/pint
+    run "phpstan" "phpstan" "$SAIL" php ./vendor/bin/phpstan analyse --error-format=raw --no-progress
 fi
 
 if $frontend || $e2e; then
-    run "prettier (write)" "$SAIL" npm run format
+    run "prettier (write)" "raw" "$SAIL" npm run format
 fi
 
 if $frontend; then
-    run "eslint (fix)" "$SAIL" npm run lint -- --max-warnings=0
-    run "tsc" "$SAIL" npx tsc --noEmit
+    run "eslint (fix)" "eslint" "$SAIL" npm run lint -- --max-warnings=0
+    run "tsc" "tsc" "$SAIL" npx tsc --noEmit
 fi
 
 if $e2e; then
-    run "tsc (e2e)" "$SAIL" npx tsc -p e2e --noEmit
+    run "tsc (e2e)" "tsc" "$SAIL" npx tsc -p e2e --noEmit
 fi
 
 if $FULL; then
-    $backend && run "pest" "$SAIL" php ./vendor/bin/pest
-    $frontend && run "vitest" "$SAIL" npm run test
+    $backend && run "pest" "pest" "$SAIL" php ./vendor/bin/pest --compact --colors=never
+    $frontend && run "vitest" "vitest" "$SAIL" npm run test -- --reporter=github-actions
     # Playwright is CI-only: a local run resets the dev database. The e2e
     # required check covers it on every PR.
     $e2e && echo "==> playwright: skipped locally (runs in CI; local run would reset the dev DB)" && echo


### PR DESCRIPTION
## Qué resuelve

`validate-code.sh` recortaba el log de cada herramienta fallida con un `tail -40` global. Ese recorte es el peor posible para las herramientas cuyos errores raíz salen al principio (`tsc`, `phpstan`) y se ahoga en el ruido de las que emiten mucho padding o listados de tests que pasan (`eslint`, `pest`, `vitest`).

## Cambios

- **Flags de salida mínima por herramienta**: `phpstan --error-format=raw --no-progress`, `pest --compact --colors=never`, `vitest --reporter=github-actions` (por CLI, sin tocar `vitest.config.ts`). `tsc` y `eslint` quedan igual.
- **Filtro de log propio de cada herramienta** en `run()`, nunca un patrón global: `tsc` emite `error` en minúscula, así que un `grep -E 'FAIL|Error'` único habría perdido todos sus errores. El filtro de `phpstan` descarta el preámbulo fijo y recorta el prefijo `/var/www/html/`; el de `eslint` colapsa las corridas de espacios; el de `pest` elimina los códigos ANSI.
- **Fallback obligatorio**: si un filtro no produce ninguna línea, se emite el log crudo recortado. Nunca un bloque vacío.
- El texto filtrado se recorta desde el principio (`head`), no desde el final, porque ahí están las causas raíz.
- `SKILL.md` documenta el filtrado y advierte que `--full` supera los 120s por defecto y necesita timeout extendido.

## Medición

| Herramienta | Antes | Después |
|---|---|---|
| vitest (2 fallos) | 52 líneas / 1379 bytes | 4 líneas / 600 bytes |
| phpstan (3 errores) | ~20 líneas | 3 líneas / 423 bytes |
| pest (subset 2 archivos) | 59 líneas / 2090 bytes | 41 líneas / 1472 bytes |
| eslint (2 problemas) | 23 líneas / 2071 bytes | 1305 bytes (−37%) |

Con `tail -40`, vitest a 52 líneas perdía el primer fallo entero.

## Validación

El diff toca sólo `.claude/**`, que el detector de sides del propio script no reconoce, así que no puede validarse a sí mismo. Se validó con sondas que fallan a propósito, una por herramienta, verificando que el error inyectado aparece en el log filtrado y que el exit code sigue siendo 1.

Closes #223