### PR TITLE
fix(orders): match phone number fragments in order search

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -25,9 +25,6 @@ class Order extends Model
 
     use SoftDeletes;
 
-    /** Below this many digits a search term is an order number, not a phone. */
-    private const MIN_PHONE_DIGITS = 4;
-
     /**
      * @return BelongsTo<Client, $this>
      */
@@ -84,9 +81,10 @@ class Order extends Model
      * child, client and — the WhatsApp use case — the client's phone, matched
      * digit by digit so separators and the +549 prefix don't get in the way.
      *
-     * The phone is only searched with at least MIN_PHONE_DIGITS digits, or a
-     * short numeric search (an order number) would match every phone
-     * containing those digits.
+     * The phone is only searched when `Phone::searchPattern` returns a
+     * pattern (see its docblock for the minimum-digits and normalization
+     * rules), so a short numeric search (an order number) doesn't
+     * necessarily match every phone containing those digits.
      *
      * @param  Builder<Order>  $query
      * @return Builder<Order>
@@ -100,8 +98,7 @@ class Order extends Model
         }
 
         $like = '%'.addcslashes($term, '%_\\').'%';
-        $digits = Phone::localDigits($term);
-        $phone = strlen($digits) >= self::MIN_PHONE_DIGITS ? '%'.$digits.'%' : null;
+        $phone = Phone::searchPattern($term);
 
         return $query->where(function (Builder $query) use ($like, $phone) {
             $query->where('orders.id', 'like', $like)

--- a/app/Models/OrderDraft.php
+++ b/app/Models/OrderDraft.php
@@ -16,9 +16,6 @@ class OrderDraft extends Model
     /** @use HasFactory<OrderDraftFactory> */
     use HasFactory;
 
-    /** Below this many digits a search term is a draft number, not a phone. */
-    private const MIN_PHONE_DIGITS = 4;
-
     /**
      * @return BelongsTo<Classroom, $this>
      */
@@ -43,8 +40,7 @@ class OrderDraft extends Model
         }
 
         $like = '%'.addcslashes($term, '%_\\').'%';
-        $digits = Phone::localDigits($term);
-        $phone = strlen($digits) >= self::MIN_PHONE_DIGITS ? '%'.$digits.'%' : null;
+        $phone = Phone::searchPattern($term);
 
         return $query->where(function (Builder $query) use ($like, $phone) {
             $query->where('order_drafts.id', 'like', $like)

--- a/app/Support/Phone.php
+++ b/app/Support/Phone.php
@@ -12,25 +12,35 @@ namespace App\Support;
  */
 class Phone
 {
+    /** Below this many digits a numeric search term is too short to match a phone. */
+    private const MIN_SEARCH_DIGITS = 3;
+
     /**
-     * The dialable part of a number: digits only, without the country code
-     * (54), the mobile 9, or the domestic trunk 0.
+     * The SQL `LIKE` pattern to match a phone-search term, or `null` when the
+     * term has too few digits to search the phone column.
+     *
+     * Prefix/trunk stripping (country code 54, mobile 9, domestic trunk 0)
+     * only applies when what remains is still a full 10-digit local number —
+     * that's the "looks like a complete number" case. Anything shorter is a
+     * fragment and is matched literally, digit by digit, leading zeros kept.
      */
-    public static function localDigits(string $phone): string
+    public static function searchPattern(string $term): ?string
     {
-        $digits = preg_replace('/\D/', '', $phone) ?? '';
+        $digits = preg_replace('/\D/', '', $term) ?? '';
 
-        if (str_starts_with($digits, '549')) {
+        if (str_starts_with($digits, '549') && strlen($digits) >= 13) {
             $digits = substr($digits, 3);
-        } elseif (str_starts_with($digits, '54')) {
+        } elseif (str_starts_with($digits, '54') && strlen($digits) >= 12) {
             $digits = substr($digits, 2);
-        }
-
-        if (str_starts_with($digits, '0')) {
+        } elseif (str_starts_with($digits, '0') && strlen($digits) >= 11) {
             $digits = substr($digits, 1);
         }
 
-        return $digits;
+        if (strlen($digits) < self::MIN_SEARCH_DIGITS) {
+            return null;
+        }
+
+        return '%'.$digits.'%';
     }
 
     /**

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -69,6 +69,20 @@ it('matches a draft by phone digits', function () {
     expect(array_map(fn (array $row) => (int) $row['id'], $students))->toBe([$draft->id]);
 });
 
+it('matches a draft by a leading-zero phone fragment', function () {
+    $classroom = Classroom::factory()->create();
+
+    $draft = OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'client_phone' => '3804000001']);
+    OrderDraft::factory()->create(['classroom_id' => $classroom->id, 'client_phone' => '3804999999']);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id, 'search' => '001']));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+
+    expect(array_map(fn (array $row) => (int) $row['id'], $students))->toBe([$draft->id]);
+});
+
 it('counts both orders and drafts in the pagination total', function () {
     $classroom = Classroom::factory()->create();
 

--- a/tests/Feature/OrderSearchTest.php
+++ b/tests/Feature/OrderSearchTest.php
@@ -97,10 +97,16 @@ it('still finds an order by its number', function () {
     expect(searchedOrderIds((string) $order->id))->toContain($order->id);
 });
 
-it('does not match phones on a short numeric term, which is an order number', function () {
+it('matches phones on a 3-digit numeric fragment', function () {
+    $order = orderFor('Carla López', '3804380999');
+
+    expect(searchedOrderIds('380'))->toBe([$order->id]);
+});
+
+it('does not match phones on a 2-digit numeric term, below the minimum', function () {
     orderFor('Carla López', '3804380999');
 
-    expect(searchedOrderIds('380'))->toBe([]);
+    expect(searchedOrderIds('38'))->toBe([]);
 });
 
 it('returns nothing when no order matches', function () {

--- a/tests/Feature/OrderSearchTest.php
+++ b/tests/Feature/OrderSearchTest.php
@@ -103,6 +103,13 @@ it('matches phones on a 3-digit numeric fragment', function () {
     expect(searchedOrderIds('380'))->toBe([$order->id]);
 });
 
+it('matches an order by a leading-zero phone fragment', function () {
+    $order = orderFor('Carla López', '3804000001');
+    orderFor('Otro Cliente', '3804999999');
+
+    expect(searchedOrderIds('001'))->toBe([$order->id]);
+});
+
 it('does not match phones on a 2-digit numeric term, below the minimum', function () {
     orderFor('Carla López', '3804380999');
 


### PR DESCRIPTION
## Problema

Buscar un fragmento corto como `001` en `/orders` no devolvía los pedidos cuyos clientes tienen teléfonos que contienen ese substring (`3804000001`, `3804000010`, etc.).

**Causa**: `Phone::localDigits('001')` devolvía `'01'` — la normalización quitaba el `0` de trunk doméstico, correcto para un número completo pero incorrecto para un fragmento. Al quedar en 2 dígitos, no alcanzaba el mínimo y la columna `clients.phone` nunca se consultaba.

## Solución

- Nuevo `Phone::searchPattern()` que centraliza la lógica de búsqueda por teléfono: la normalización de prefijos (`54`, `549`, `0` inicial) se aplica **solo cuando el término parece un número completo** (10 dígitos locales); un fragmento corto se usa tal cual, dígito a dígito, conservando los ceros iniciales.
- El mínimo de dígitos para consultar el teléfono baja de 4 a **3**.
- `Order::scopeSearch` y `OrderDraft::scopeSearch` comparten esta lógica en vez de duplicarla; se eliminó `MIN_PHONE_DIGITS` de ambos modelos.

## Comportamiento

- `001` ahora devuelve los pedidos con teléfonos que contienen `001`.
- Un número completo copiado de WhatsApp (`+54 9 380 400-0003`) sigue encontrando al cliente guardado como `3804000003`.
- Aplica a los buscadores de pedidos y de borradores de un aula.
- Los términos no numéricos siguen buscando por nº de pedido, nº de foto, nombre de chico y nombre de cliente, sin cambios.

## Tests

Pest cubre: fragmento con ceros iniciales (`001`) en ambos scopes, fragmento numérico de 3 dígitos, término de 2 dígitos por debajo del mínimo, y números completos con prefijo y separadores.

Closes #208
