### PR TITLE
fix(ci): quality_frontend falla ante violaciones de Prettier/ESLint

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,10 +59,10 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: ✨ Prettier
-        run: npm run format -- --check
+        run: npm run format:check
 
       - name: 🔍 ESLint
-        run: npm run lint -- --max-warnings=0
+        run: npm run lint:check
 
       - name: 🛠️ TypeScript checks
         run: npx tsc --noEmit

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,8 @@
 {
     "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": false,
+    "endOfLine": "lf",
     "tailwindStylesheet": "./resources/css/app.css",
     "plugins": [
         "prettier-plugin-organize-imports",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "build": "tsc && vite build",
         "dev": "vite",
         "lint": "eslint resources/js --fix",
+        "lint:check": "eslint resources/js --max-warnings=0",
         "format": "prettier --write \"resources/{js,css}/**/*.{js,jsx,ts,tsx,css}\" \"e2e/**/*.ts\" \"playwright.config.ts\"",
+        "format:check": "prettier --check \"resources/{js,css}/**/*.{js,jsx,ts,tsx,css}\" \"e2e/**/*.ts\" \"playwright.config.ts\"",
         "test": "vitest run",
         "test:e2e": "playwright test"
     },


### PR DESCRIPTION
## Resumen

Los pasos de Prettier y ESLint del job `quality_frontend` reutilizaban los scripts de autofix (`npm run format`/`npm run lint`, con `--write`/`--fix`). Al correr en CI, esos flags reescribían los archivos en el runner y el paso salía con éxito aunque hubiera violaciones — la reescritura se descartaba al terminar el job, así que la violación quedaba en el repo pero el check aparecía en verde.

- `package.json`: nuevos scripts `format:check` (prettier `--check`) y `lint:check` (eslint sin `--fix`), sin tocar `format`/`lint` (siguen siendo autofix, usados localmente y por `validate-code.sh`).
- `.github/workflows/code-quality.yml`: los pasos ✨ Prettier y 🔍 ESLint de `quality_frontend` ahora usan `format:check`/`lint:check`.

## Test plan

- [x] `format:check` y `lint:check` corren limpio sobre el estado actual del repo (sin deuda preexistente, como ya estaba confirmado en el issue).
- [x] Verificado manualmente que un archivo mal formateado / con violación autofixeable de ESLint hace fallar ambos scripts (exit 1).
- [x] `validate-code.sh --full` (frontend): prettier, eslint, tsc, vitest — todo OK.
- [ ] CI en verde (`quality_frontend`, `quality_backend`, `tests_frontend`, `tests_backend`, `e2e`).

Closes #226