### PR TITLE
fix(highlight): resaltar fragmentos de teléfono con cero inicial

### DIFF
--- a/resources/js/lib/highlight.test.ts
+++ b/resources/js/lib/highlight.test.ts
@@ -60,6 +60,12 @@ describe('highlightPhoneSegments', () => {
         ).toEqual(['3804000003']);
     });
 
+    it('highlights a leading-zero fragment in full', () => {
+        expect(matched(highlightPhoneSegments('3804000001', '0001'))).toEqual([
+            '0001',
+        ]);
+    });
+
     it('marks nothing when the digits do not match', () => {
         expect(
             matched(highlightPhoneSegments('3804000003', '3804111111')),

--- a/resources/js/lib/highlight.ts
+++ b/resources/js/lib/highlight.ts
@@ -1,4 +1,4 @@
-import { localPhoneDigits } from '@/lib/whatsapp';
+import { phoneSearchDigits } from '@/lib/whatsapp';
 
 export interface HighlightSegment {
     text: string;
@@ -75,7 +75,7 @@ export function highlightPhoneSegments(
     phone: string,
     term: string | null | undefined,
 ): HighlightSegment[] {
-    const needle = localPhoneDigits(term?.trim() ?? '');
+    const needle = phoneSearchDigits(term?.trim() ?? '');
 
     if (!needle) {
         return [{ text: phone, match: false }];

--- a/resources/js/lib/whatsapp.ts
+++ b/resources/js/lib/whatsapp.ts
@@ -20,6 +20,29 @@ export function localPhoneDigits(phone: string): string {
 }
 
 /**
+ * Digits to match against when searching a phone column. Mirrors the
+ * backend `App\Support\Phone::searchPattern()`'s conditional stripping:
+ * the country code (54), the mobile 9, and the domestic trunk 0 are only
+ * stripped when what remains is still a full local number (length
+ * thresholds); shorter fragments are matched literally, leading zeros
+ * kept. Distinct from `localPhoneDigits`, which always strips those
+ * prefixes to build a dialable number.
+ */
+export function phoneSearchDigits(phone: string): string {
+    let digits = phone.replace(/\D/g, '');
+
+    if (digits.startsWith('549') && digits.length >= 13) {
+        digits = digits.slice(3);
+    } else if (digits.startsWith('54') && digits.length >= 12) {
+        digits = digits.slice(2);
+    } else if (digits.startsWith('0') && digits.length >= 11) {
+        digits = digits.slice(1);
+    }
+
+    return digits;
+}
+
+/**
  * Normalizes a locally-stored Argentine phone number to the
  * international digits-only format WhatsApp links expect (549...).
  * Returns null when the number is too short to be dialable.


### PR DESCRIPTION
## Problema

Al buscar en el listado de pedidos por un fragmento numérico de teléfono con cero inicial (p. ej. `0001`) que sea substring literal del teléfono, el resultado aparecía correctamente (el backend matchea desde #228) pero el resaltado en la columna de teléfono solo remarcaba `001`, perdiendo el cero inicial.

## Causa

`highlightPhoneSegments` (`resources/js/lib/highlight.ts`) armaba el needle con `localPhoneDigits()`, que recorta el `0` inicial (y `54`/`549`) de forma incondicional. El backend (`Phone::searchPattern()`, corregido en #228) solo recorta esos prefijos cuando lo que queda sigue siendo un número local completo. El frontend estaba desalineado de esa regla.

## Solución

- Se agrega `phoneSearchDigits()` en `resources/js/lib/whatsapp.ts`, que replica la regla condicional de `Phone::searchPattern()` (recorta `549` solo con ≥13 dígitos, `54` con ≥12, `0` inicial con ≥11; los fragmentos más cortos se buscan literales, con el cero inicial).
- `highlightPhoneSegments` ahora usa `phoneSearchDigits` para el needle.
- `localPhoneDigits()` / `normalizeArPhone()` quedan intactos: siguen normalizando los links de WhatsApp como antes.
- Test de Vitest que reproduce el bug del fragmento con cero inicial.

## Verificación

- `validate-code --full` (prettier, eslint, tsc, vitest): OK.
- `highlight.test.ts`: 12/12 tests en verde.

Closes #229