### PR TITLE
feat(orders): unificar indicador de cuotas y quitar columna precio

### DIFF
--- a/app/Http/Controllers/BO/OrderController.php
+++ b/app/Http/Controllers/BO/OrderController.php
@@ -48,7 +48,7 @@ class OrderController extends Controller
             ->whereHas('classrooms')
             ->get();
 
-        $orders = Order::with('client', 'products.type', 'classroom.school')
+        $orders = Order::with('client', 'products.type', 'classroom.school', 'payments')
             ->search($search)
             ->forSchool($school_id)
             ->forClassroom($classroom_id)

--- a/app/Http/Resources/ClassroomStudentResource.php
+++ b/app/Http/Resources/ClassroomStudentResource.php
@@ -36,6 +36,7 @@ class ClassroomStudentResource extends JsonResource
                 'total_price' => $row->total_price,
                 'payment_plan' => $row->payment_plan,
                 'paid_installments' => 0,
+                'current_installment_fraction' => 0.0,
                 'due_date' => $row->due_date?->isoFormat('D [de] MMM Y'),
             ];
         }
@@ -57,6 +58,7 @@ class ClassroomStudentResource extends JsonResource
             'total_price' => $row->total_price,
             'payment_plan' => $row->payment_plan,
             'paid_installments' => $this->paidInstallments($row),
+            'current_installment_fraction' => $this->currentInstallmentFraction($row),
             'due_date' => $row->due_date->isoFormat('D [de] MMM Y'),
         ];
     }
@@ -84,5 +86,37 @@ class ClassroomStudentResource extends JsonResource
         }
 
         return min($plan, (int) floor($paid / $installment));
+    }
+
+    /**
+     * Fraction (0..1) paid of the current (first incomplete) installment.
+     */
+    private function currentInstallmentFraction(Order $order): float
+    {
+        $plan = (int) $order->payment_plan;
+
+        if ($plan <= 0) {
+            return 0.0;
+        }
+
+        $paidAttribute = $order->getAttribute('payments_sum_amount');
+        $paid = is_numeric($paidAttribute) ? (int) $paidAttribute : 0;
+
+        $totalPrice = (int) $order->total_price;
+        $installment = $totalPrice / $plan;
+
+        if ($installment == 0) {
+            return 0.0;
+        }
+
+        $paidInstallments = min($plan, (int) floor($paid / $installment));
+
+        if ($paidInstallments >= $plan) {
+            return 0.0;
+        }
+
+        $remainder = $paid - $paidInstallments * $installment;
+
+        return min(1.0, $remainder / $installment);
     }
 }

--- a/app/Http/Resources/ClassroomStudentResource.php
+++ b/app/Http/Resources/ClassroomStudentResource.php
@@ -117,6 +117,6 @@ class ClassroomStudentResource extends JsonResource
 
         $remainder = $paid - $paidInstallments * $installment;
 
-        return min(1.0, $remainder / $installment);
+        return max(0.0, min(1.0, $remainder / $installment));
     }
 }

--- a/app/Http/Resources/OrderResource.php
+++ b/app/Http/Resources/OrderResource.php
@@ -49,6 +49,8 @@ class OrderResource extends JsonResource
             'status' => $this->aggregateStatus(),
             'paid_total' => $this->whenLoaded('payments', fn () => $this->sumPayments()),
             'balance' => $this->whenLoaded('payments', fn () => $this->total_price - $this->sumPayments()),
+            'paid_installments' => $this->whenLoaded('payments', fn () => $this->paidInstallments()),
+            'current_installment_fraction' => $this->whenLoaded('payments', fn () => $this->currentInstallmentFraction()),
             'can_edit' => $this->canEdit(),
             'first_installment_paid' => $this->firstInstallmentPaid(),
             'can_delete' => $this->cancelled_at === null && $this->payments()->doesntExist(),
@@ -122,6 +124,59 @@ class OrderResource extends JsonResource
             fn (int $carry, Payment $payment) => $carry + $payment->amount,
             0,
         );
+    }
+
+    /**
+     * Installments actually covered by payments, capped at the plan.
+     * Mirrors the semantics of `Order::firstInstallmentPaid()`.
+     */
+    private function paidInstallments(): int
+    {
+        $plan = (int) $this->payment_plan;
+
+        if ($plan <= 0) {
+            return 0;
+        }
+
+        $paid = $this->sumPayments();
+        $totalPrice = (int) $this->total_price;
+        $installment = $totalPrice / $plan;
+
+        if ($installment == 0) {
+            return 0;
+        }
+
+        return min($plan, (int) floor($paid / $installment));
+    }
+
+    /**
+     * Fraction (0..1) paid of the current (first incomplete) installment.
+     */
+    private function currentInstallmentFraction(): float
+    {
+        $plan = (int) $this->payment_plan;
+
+        if ($plan <= 0) {
+            return 0.0;
+        }
+
+        $paid = $this->sumPayments();
+        $totalPrice = (int) $this->total_price;
+        $installment = $totalPrice / $plan;
+
+        if ($installment == 0) {
+            return 0.0;
+        }
+
+        $paidInstallments = min($plan, (int) floor($paid / $installment));
+
+        if ($paidInstallments >= $plan) {
+            return 0.0;
+        }
+
+        $remainder = $paid - $paidInstallments * $installment;
+
+        return min(1.0, $remainder / $installment);
     }
 
     private function canEdit(): bool

--- a/app/Http/Resources/OrderResource.php
+++ b/app/Http/Resources/OrderResource.php
@@ -176,7 +176,7 @@ class OrderResource extends JsonResource
 
         $remainder = $paid - $paidInstallments * $installment;
 
-        return min(1.0, $remainder / $installment);
+        return max(0.0, min(1.0, $remainder / $installment));
     }
 
     private function canEdit(): bool

--- a/resources/js/features/installments-indicator/index.test.tsx
+++ b/resources/js/features/installments-indicator/index.test.tsx
@@ -1,0 +1,85 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { InstallmentsIndicator } from './index';
+
+describe('InstallmentsIndicator', () => {
+    it('renders exactly paymentPlan square elements', () => {
+        const { container } = render(
+            <InstallmentsIndicator paymentPlan={5} paidInstallments={0} />,
+        );
+
+        expect(container.querySelectorAll('span.relative')).toHaveLength(5);
+    });
+
+    it('fully fills paid squares and leaves the rest empty', () => {
+        const { container } = render(
+            <InstallmentsIndicator paymentPlan={4} paidInstallments={2} />,
+        );
+
+        const squares = container.querySelectorAll('span.relative');
+        expect(squares).toHaveLength(4);
+
+        [0, 1].forEach((index) => {
+            const overlay = squares[index].querySelector('span');
+            expect(overlay).not.toBeNull();
+            expect((overlay as HTMLElement).style.height).toBe('100%');
+        });
+
+        [2, 3].forEach((index) => {
+            expect(squares[index].querySelector('span')).toBeNull();
+            expect(squares[index].classList.contains('border')).toBe(true);
+        });
+    });
+
+    it('partially fills the in-progress square to the given fraction', () => {
+        const { container } = render(
+            <InstallmentsIndicator
+                paymentPlan={4}
+                paidInstallments={1}
+                currentInstallmentFraction={0.37}
+            />,
+        );
+
+        const squares = container.querySelectorAll('span.relative');
+        const overlay = squares[1].querySelector('span');
+
+        expect(overlay).not.toBeNull();
+        expect((overlay as HTMLElement).style.height).toBe('37%');
+    });
+
+    it('renders the in-progress square empty when the fraction is omitted', () => {
+        const { container } = render(
+            <InstallmentsIndicator paymentPlan={4} paidInstallments={1} />,
+        );
+
+        const squares = container.querySelectorAll('span.relative');
+
+        expect(squares[1].querySelector('span')).toBeNull();
+        expect(squares[1].classList.contains('border')).toBe(true);
+    });
+
+    it('fills every square and leaves none partial when fully paid', () => {
+        const { container } = render(
+            <InstallmentsIndicator paymentPlan={4} paidInstallments={4} />,
+        );
+
+        const squares = container.querySelectorAll('span.relative');
+        expect(squares).toHaveLength(4);
+
+        squares.forEach((square) => {
+            const overlay = square.querySelector('span');
+            expect(overlay).not.toBeNull();
+            expect((overlay as HTMLElement).style.height).toBe('100%');
+        });
+    });
+
+    it('uses square (non-rounded) corners', () => {
+        const { container } = render(
+            <InstallmentsIndicator paymentPlan={1} paidInstallments={0} />,
+        );
+
+        const square = container.querySelector('span.relative');
+        expect(square?.classList.contains('rounded-none')).toBe(true);
+        expect(square?.classList.contains('rounded-sm')).toBe(false);
+    });
+});

--- a/resources/js/features/installments-indicator/index.test.tsx
+++ b/resources/js/features/installments-indicator/index.test.tsx
@@ -45,6 +45,7 @@ describe('InstallmentsIndicator', () => {
 
         expect(overlay).not.toBeNull();
         expect((overlay as HTMLElement).style.height).toBe('37%');
+        expect(squares[1].classList.contains('border')).toBe(true);
     });
 
     it('renders the in-progress square empty when the fraction is omitted', () => {

--- a/resources/js/features/installments-indicator/index.tsx
+++ b/resources/js/features/installments-indicator/index.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils';
+
+interface InstallmentsIndicatorProps {
+    paymentPlan: number;
+    paidInstallments: number;
+    currentInstallmentFraction?: number | null;
+}
+
+/**
+ * Draws `paymentPlan` squares, one per installment: fully filled squares
+ * for installments already paid, a partially filled one for the
+ * installment in progress (proportional to the amount paid so far), and
+ * empty (bordered) squares for the rest.
+ */
+export function InstallmentsIndicator({
+    paymentPlan,
+    paidInstallments,
+    currentInstallmentFraction,
+}: InstallmentsIndicatorProps) {
+    const fraction = currentInstallmentFraction ?? 0;
+
+    return (
+        <div className="flex flex-wrap gap-1">
+            {Array.from({ length: paymentPlan }).map((_, index) => {
+                const filledFraction =
+                    index < paidInstallments
+                        ? 1
+                        : index === paidInstallments
+                          ? fraction
+                          : 0;
+
+                return (
+                    <span
+                        key={index}
+                        className={cn(
+                            'relative size-3 overflow-hidden rounded-none',
+                            filledFraction > 0
+                                ? 'bg-transparent'
+                                : 'border bg-transparent',
+                        )}
+                    >
+                        {filledFraction > 0 && (
+                            <span
+                                className="absolute inset-x-0 bottom-0 bg-primary"
+                                style={{ height: `${filledFraction * 100}%` }}
+                            />
+                        )}
+                    </span>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/js/features/installments-indicator/index.tsx
+++ b/resources/js/features/installments-indicator/index.tsx
@@ -33,10 +33,8 @@ export function InstallmentsIndicator({
                     <span
                         key={index}
                         className={cn(
-                            'relative size-3 overflow-hidden rounded-none',
-                            filledFraction > 0
-                                ? 'bg-transparent'
-                                : 'border bg-transparent',
+                            'relative size-3 overflow-hidden rounded-none bg-transparent',
+                            filledFraction < 1 && 'border',
                         )}
                     >
                         {filledFraction > 0 && (

--- a/resources/js/pages/classrooms/components/students-table.test.tsx
+++ b/resources/js/pages/classrooms/components/students-table.test.tsx
@@ -38,6 +38,7 @@ const makeStudent = (
     total_price: 15000,
     payment_plan: 3,
     paid_installments: 1,
+    current_installment_fraction: 0,
     due_date: '1 de ago 2026',
     ...overrides,
 });
@@ -117,12 +118,11 @@ describe('StudentsTable', () => {
             />,
         );
 
-        const squares = container.querySelectorAll('span.rounded-sm');
+        const squares = container.querySelectorAll('span.rounded-none');
         const filled = container.querySelectorAll('span.bg-primary');
 
         expect(squares).toHaveLength(3);
         expect(filled).toHaveLength(1);
-        expect(squares.length - filled.length).toBe(2);
     });
 
     it('fills every square when the plan is fully paid', () => {
@@ -134,7 +134,7 @@ describe('StudentsTable', () => {
             />,
         );
 
-        const squares = container.querySelectorAll('span.rounded-sm');
+        const squares = container.querySelectorAll('span.rounded-none');
         const filled = container.querySelectorAll('span.bg-primary');
 
         expect(squares).toHaveLength(4);
@@ -152,7 +152,7 @@ describe('StudentsTable', () => {
 
         const row = screen.getAllByRole('row')[1];
 
-        expect(container.querySelectorAll('span.rounded-sm')).toHaveLength(0);
+        expect(container.querySelectorAll('span.rounded-none')).toHaveLength(0);
         expect(within(row).getByText('—')).toBeTruthy();
     });
 

--- a/resources/js/pages/classrooms/components/students-table.tsx
+++ b/resources/js/pages/classrooms/components/students-table.tsx
@@ -9,6 +9,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { Highlight } from '@/features/highlight';
+import { InstallmentsIndicator } from '@/features/installments-indicator';
 import { PhoneLink } from '@/features/phone-link';
 import { cn, formatPrice } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
@@ -24,6 +25,7 @@ export interface ClassroomStudent {
     total_price: number;
     payment_plan: number;
     paid_installments: number;
+    current_installment_fraction: number;
     due_date: string | null;
 }
 
@@ -43,7 +45,6 @@ export function StudentsTable({ students, search }: StudentsTableProps) {
                     <TableHead>Cliente</TableHead>
                     <TableHead>Teléfono</TableHead>
                     <TableHead>Productos</TableHead>
-                    <TableHead>Precio</TableHead>
                     <TableHead>Cuotas</TableHead>
                     <TableHead>Vencimiento</TableHead>
                     <TableHead>Acción</TableHead>
@@ -95,9 +96,6 @@ export function StudentsTable({ students, search }: StudentsTableProps) {
                         </TableCell>
                         <TableCell>{student.products_count}</TableCell>
                         <TableCell>
-                            {formatPrice(student.total_price)}
-                        </TableCell>
-                        <TableCell>
                             {student.payment_plan > 0 ? (
                                 <div className="flex flex-col gap-1">
                                     <span>
@@ -108,22 +106,15 @@ export function StudentsTable({ students, search }: StudentsTableProps) {
                                         )}
                                         )
                                     </span>
-                                    <div className="flex flex-wrap gap-1">
-                                        {Array.from({
-                                            length: student.payment_plan,
-                                        }).map((_, index) => (
-                                            <span
-                                                key={index}
-                                                className={cn(
-                                                    'size-3 rounded-sm',
-                                                    index <
-                                                        student.paid_installments
-                                                        ? 'bg-primary'
-                                                        : 'border bg-transparent',
-                                                )}
-                                            />
-                                        ))}
-                                    </div>
+                                    <InstallmentsIndicator
+                                        paymentPlan={student.payment_plan}
+                                        paidInstallments={
+                                            student.paid_installments
+                                        }
+                                        currentInstallmentFraction={
+                                            student.current_installment_fraction
+                                        }
+                                    />
                                 </div>
                             ) : (
                                 '—'

--- a/resources/js/pages/orders/components/orders-table.test.tsx
+++ b/resources/js/pages/orders/components/orders-table.test.tsx
@@ -65,7 +65,6 @@ describe('OrdersTable', () => {
         expect(within(row).getByText('12')).toBeTruthy();
         expect(within(row).getByText('Maylén Ortiz')).toBeTruthy();
         expect(within(row).getByText('Marta López')).toBeTruthy();
-        expect(within(row).getByText(price(15000))).toBeTruthy();
         expect(within(row).getByText(`3 (${price(5000)})`)).toBeTruthy();
         expect(within(row).getByText(/Sala Roja/)).toBeTruthy();
 
@@ -113,7 +112,7 @@ describe('OrdersTable', () => {
         expect(onDelete).not.toHaveBeenCalled();
     });
 
-    it('sorts by order number and price from the header buttons', () => {
+    it('sorts by order number from the header button', () => {
         render(<OrdersTable orders={[]} onDelete={vi.fn()} />);
 
         const headers = screen.getAllByRole('columnheader');
@@ -125,9 +124,7 @@ describe('OrdersTable', () => {
         fireEvent.click(within(header('N° de orden')).getByRole('button'));
         expect(sort).toHaveBeenCalledWith('photo_number', 'orders.index');
 
-        fireEvent.click(within(header('Precio')).getByRole('button'));
-        expect(sort).toHaveBeenCalledWith('total_price', 'orders.index');
-
+        expect(screen.queryByText('Precio')).toBeNull();
         expect(screen.queryByText('Vencimiento')).toBeNull();
     });
 

--- a/resources/js/pages/orders/components/orders-table.tsx
+++ b/resources/js/pages/orders/components/orders-table.tsx
@@ -8,6 +8,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { Highlight } from '@/features/highlight';
+import { InstallmentsIndicator } from '@/features/installments-indicator';
 import { PhoneLink } from '@/features/phone-link';
 import { onSort } from '@/lib/services/filter';
 import { cn, formatPrice } from '@/lib/utils';
@@ -43,18 +44,6 @@ export function OrdersTable({ orders, search, onDelete }: OrdersTableProps) {
                     <TableHead>Cliente</TableHead>
                     <TableHead>Teléfono</TableHead>
                     <TableHead>Productos</TableHead>
-                    <TableHead>
-                        <div className="flex items-center gap-2">
-                            <button
-                                onClick={() =>
-                                    onSort('total_price', 'orders.index')
-                                }
-                            >
-                                <ArrowUpDown className="h-4 w-4" />
-                            </button>
-                            Precio
-                        </div>
-                    </TableHead>
                     <TableHead>Cuotas ($)</TableHead>
                     <TableHead>Escuela (Aula)</TableHead>
                     <TableHead>Acciones</TableHead>
@@ -106,13 +95,25 @@ export function OrdersTable({ orders, search, onDelete }: OrdersTableProps) {
                                 )}
                             </div>
                         </TableCell>
-                        <TableCell>{formatPrice(order.total_price)}</TableCell>
                         <TableCell>
-                            {order.payment_plan} (
-                            {formatPrice(
-                                order.total_price / order.payment_plan,
-                            )}
-                            )
+                            <div className="flex flex-col gap-1">
+                                <span>
+                                    {order.payment_plan} (
+                                    {formatPrice(
+                                        order.total_price / order.payment_plan,
+                                    )}
+                                    )
+                                </span>
+                                <InstallmentsIndicator
+                                    paymentPlan={order.payment_plan}
+                                    paidInstallments={
+                                        order.paid_installments ?? 0
+                                    }
+                                    currentInstallmentFraction={
+                                        order.current_installment_fraction
+                                    }
+                                />
+                            </div>
                         </TableCell>
                         <TableCell>
                             <Link

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -166,6 +166,8 @@ declare global {
         status?: OrderStatus | null;
         paid_total?: number;
         balance?: number;
+        paid_installments?: number;
+        current_installment_fraction?: number;
         can_edit?: boolean;
         can_delete?: boolean;
         first_installment_paid?: boolean;

--- a/tests/Feature/ClassroomShowTest.php
+++ b/tests/Feature/ClassroomShowTest.php
@@ -205,3 +205,60 @@ it('reports zero paid installments for a draft', function () {
 
     expect($row['paid_installments'])->toBe(0);
 });
+
+it('reports a zero current installment fraction for an order with no payments', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['current_installment_fraction'])->toEqual(0.0);
+});
+
+it('reports a half current installment fraction for a partial payment below one installment', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 8000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(0)
+        ->and($row['current_installment_fraction'])->toBe(0.5);
+});
+
+it('reports the fraction of the second installment after paying one full plus a remainder', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 24000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(1)
+        ->and($row['current_installment_fraction'])->toBe(0.5);
+});
+
+it('reports a zero current installment fraction for a fully paid order', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 64000]);
+
+    $response = get(route('classrooms.show', ['classroom' => $classroom->id]));
+    $response->assertOk();
+    /** @var array<int, array<string, mixed>> $students */
+    $students = $response->viewData('page')['props']['students']['data'];
+    $row = collect($students)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['current_installment_fraction'])->toEqual(0.0);
+});

--- a/tests/Feature/OrderFilterTest.php
+++ b/tests/Feature/OrderFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\Classroom;
 use App\Models\Client;
 use App\Models\Order;
+use App\Models\Payment;
 use App\Models\School;
 
 use function Pest\Laravel\get;
@@ -138,4 +139,20 @@ it('echoes null filters when nothing is applied', function () {
             ->where('filters.school_id', null)
             ->where('filters.classroom_id', null)
             ->where('filters.search', null));
+});
+
+it('exposes paid installments and the current installment fraction on each order row', function () {
+    $classroom = Classroom::factory()->create();
+    $order = Order::factory()->create(['classroom_id' => $classroom->id]);
+    Payment::factory()->create(['order_id' => $order->id, 'amount' => 8000]);
+
+    $response = get(route('orders.index', ['classroom_id' => $classroom->id]));
+    $response->assertOk();
+
+    /** @var array<int, array<string, mixed>> $orders */
+    $orders = $response->viewData('page')['props']['orders']['data'];
+    $row = collect($orders)->firstOrFail(fn (array $row) => (int) $row['id'] === $order->id);
+
+    expect($row['paid_installments'])->toBe(0)
+        ->and($row['current_installment_fraction'])->toBe(0.5);
 });


### PR DESCRIPTION
## Qué resuelve

Unifica la forma de mostrar precio y cuotas en las tablas donde aparecían ambos, dejando solo la columna "Cuotas" con un indicador visual de progreso de pago.

## Cambios

- Nuevo componente compartido `InstallmentsIndicator` (`resources/js/features/installments-indicator/`) que dibuja las cuotas como **cuadrados reales** (usa `rounded-none`, no depende del `--radius` global que a `size-3` los volvía círculos).
- La cuota **en curso** (la primera no paga por completo) se rellena **parcialmente**, en proporción al monto pagado sobre el total de esa cuota (ej.: $22.000 de una cuota de $60.000 ≈ 37%), en vez de quedar vacía hasta completarse. Los cuadrados no llenos conservan su borde.
- Se aplica el indicador en `classrooms/components/students-table.tsx` (reemplaza los cuadrados hardcodeados) y en `orders/components/orders-table.tsx`.
- Se elimina la columna "Precio" en ambas tablas; el precio por cuota sigue visible dentro de la celda "Cuotas".
- Backend: `OrderController::index` ahora carga la relación `payments`; `OrderResource` y `ClassroomStudentResource` exponen `current_installment_fraction` (0..1) y `paid_installments`.

## Fuera de alcance

`drafts/index.tsx`, `product-row.tsx`, `combos/index.tsx` y `order-info-card.tsx` no aplican (sin pagos o cuotas de configuración, no de progreso).

## Pruebas

- Vitest: componente `InstallmentsIndicator` (conteo de cuadrados, relleno completo/parcial, borde, estado pagado).
- Pest: fracción de cuota en curso en `ClassroomShowTest` y exposición en `orders.index` (`OrderFilterTest`).

Closes #237
