### PR TITLE
feat(search): live search con loader en todos los buscadores

### DIFF
--- a/resources/js/features/searchbar.test.tsx
+++ b/resources/js/features/searchbar.test.tsx
@@ -49,7 +49,14 @@ describe('Searchbar', () => {
         });
         settle();
 
-        expect(search).toHaveBeenCalledWith('lopez', 'orders.index', undefined);
+        expect(search).toHaveBeenCalledWith(
+            'lopez',
+            'orders.index',
+            undefined,
+            {
+                onFinish: expect.any(Function),
+            },
+        );
     });
 
     it('searches a single digit, which is an order number', () => {
@@ -60,7 +67,9 @@ describe('Searchbar', () => {
         });
         settle();
 
-        expect(search).toHaveBeenCalledWith('7', 'orders.index', undefined);
+        expect(search).toHaveBeenCalledWith('7', 'orders.index', undefined, {
+            onFinish: expect.any(Function),
+        });
     });
 
     it('clears the filter when the input is emptied', () => {
@@ -71,7 +80,9 @@ describe('Searchbar', () => {
         });
         settle();
 
-        expect(search).toHaveBeenCalledWith('', 'orders.index', undefined);
+        expect(search).toHaveBeenCalledWith('', 'orders.index', undefined, {
+            onFinish: expect.any(Function),
+        });
     });
 
     it('carries the route params of pages that are not plain indexes', () => {
@@ -87,8 +98,35 @@ describe('Searchbar', () => {
         });
         settle();
 
-        expect(search).toHaveBeenCalledWith('lopez', 'classrooms.show', {
-            classroom: 4,
+        expect(search).toHaveBeenCalledWith(
+            'lopez',
+            'classrooms.show',
+            { classroom: 4 },
+            { onFinish: expect.any(Function) },
+        );
+    });
+
+    it('shows a spinner while a search is in flight', () => {
+        const { container } = render(<Searchbar indexRoute="orders.index" />);
+
+        expect(container.querySelector('svg.animate-spin')).toBeNull();
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: 'lopez' },
         });
+
+        // Not settled yet: the debounce hasn't elapsed.
+        expect(container.querySelector('svg.animate-spin')).not.toBeNull();
+
+        settle();
+
+        // Settled and the visit is in flight: still spinning.
+        expect(container.querySelector('svg.animate-spin')).not.toBeNull();
+
+        act(() => {
+            search.mock.calls[0][3]?.onFinish?.();
+        });
+
+        expect(container.querySelector('svg.animate-spin')).toBeNull();
     });
 });

--- a/resources/js/features/searchbar.tsx
+++ b/resources/js/features/searchbar.tsx
@@ -1,5 +1,6 @@
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
 import { onSearch } from '@/lib/services/filter';
 import { cn } from '@/lib/utils';
 import { router } from '@inertiajs/react';
@@ -26,6 +27,8 @@ export function Searchbar({
     const [search, setSearch] = useState(applied);
     const [debouncedSearch] = useDebounce(search, 1000);
     const requested = useRef(applied);
+    const [inFlight, setInFlight] = useState(false);
+    const isSearching = search !== debouncedSearch || inFlight;
 
     useEffect(() => {
         // Already the applied filter: nothing to do (this is also the mount case).
@@ -37,7 +40,10 @@ export function Searchbar({
         if (debouncedSearch === requested.current) return;
 
         requested.current = debouncedSearch;
-        onSearch(debouncedSearch, indexRoute, routeParams);
+        setInFlight(true);
+        onSearch(debouncedSearch, indexRoute, routeParams, {
+            onFinish: () => setInFlight(false),
+        });
     }, [debouncedSearch, applied, indexRoute, routeParams]);
 
     return (
@@ -60,7 +66,11 @@ export function Searchbar({
                     'pointer-events-none absolute right-11',
                 )}
             >
-                <Search />
+                {isSearching ? (
+                    <Spinner size={16} className="text-muted-foreground" />
+                ) : (
+                    <Search />
+                )}
             </div>
             <Button
                 variant="outline"

--- a/resources/js/lib/services/filter.ts
+++ b/resources/js/lib/services/filter.ts
@@ -4,6 +4,7 @@ export function onSearch(
     searchTerm: string,
     indexRoute: string,
     routeParams?: Record<string, string | number>,
+    options?: { onFinish?: () => void },
 ) {
     const query = route().queryParams;
     delete query.search;
@@ -19,6 +20,7 @@ export function onSearch(
         preserveState: true,
         preserveScroll: true,
         replace: true,
+        ...options,
     });
 }
 

--- a/resources/js/pages/tracking/components/tracking-filters.tsx
+++ b/resources/js/pages/tracking/components/tracking-filters.tsx
@@ -1,5 +1,3 @@
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
     Select,
     SelectContent,
@@ -7,9 +5,8 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Searchbar } from '@/features/searchbar';
 import { capitalize } from '@/lib/utils';
-import { Search } from 'lucide-react';
-import { useState } from 'react';
 
 export type Filters = {
     search: string | null;
@@ -36,8 +33,6 @@ export function TrackingFilters({
     productTypes: ProductType[];
     onApply: (overrides: Partial<Filters> & { search?: string }) => void;
 }) {
-    const [search, setSearch] = useState(filters.search ?? '');
-
     // A classroom implies its school, so the school select also reflects
     // visits that only carried classroom_id
     const selectedSchool =
@@ -62,30 +57,17 @@ export function TrackingFilters({
 
     return (
         <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
-            <form
-                className="flex items-center gap-2"
-                onSubmit={(e) => {
-                    e.preventDefault();
-                    onApply({ search });
-                }}
-            >
-                <Input
-                    placeholder="Niño, cliente o n° de pedido"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    className="min-w-0 flex-1 md:w-64 md:flex-none"
-                />
-                <Button type="submit" variant="secondary" size="icon">
-                    <Search className="h-4 w-4" />
-                </Button>
-            </form>
+            <Searchbar
+                indexRoute="tracking.index"
+                term={filters.search}
+                placeholder="Niño, cliente o n° de pedido"
+            />
 
             <Select
                 value={selectedSchool ? String(selectedSchool.id) : 'all'}
                 onValueChange={(value) =>
                     // Changing school invalidates any classroom filter
                     onApply({
-                        search,
                         school_id: value === 'all' ? null : Number(value),
                         classroom_id: null,
                     })
@@ -110,7 +92,6 @@ export function TrackingFilters({
                 }
                 onValueChange={(value) =>
                     onApply({
-                        search,
                         classroom_id: value === 'all' ? null : Number(value),
                     })
                 }
@@ -139,7 +120,6 @@ export function TrackingFilters({
                 }
                 onValueChange={(value) =>
                     onApply({
-                        search,
                         product_type_id: value === 'all' ? null : value,
                     })
                 }

--- a/resources/js/pages/tracking/tests/tracking-filters.test.tsx
+++ b/resources/js/pages/tracking/tests/tracking-filters.test.tsx
@@ -6,6 +6,16 @@ import {
     TrackingFilters,
 } from '../components/tracking-filters';
 
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+}));
+
+vi.mock('@/lib/services/filter', () => ({
+    onSearch: vi.fn(),
+}));
+
+vi.stubGlobal('route', (name?: string) => `http://localhost/${name ?? ''}`);
+
 const schools: SchoolWithClassrooms[] = [
     {
         id: 1,
@@ -68,7 +78,6 @@ describe('TrackingFilters', () => {
         fireEvent.click(screen.getByRole('option', { name: 'San José' }));
 
         expect(onApply).toHaveBeenCalledWith({
-            search: '',
             school_id: 2,
             classroom_id: null,
         });
@@ -104,7 +113,6 @@ describe('TrackingFilters', () => {
         fireEvent.click(screen.getByRole('option', { name: '5 B' }));
 
         expect(onApply).toHaveBeenCalledWith({
-            search: '',
             classroom_id: 11,
         });
     });


### PR DESCRIPTION
## Qué resuelve

Todos los buscadores ahora hacen búsqueda en vivo (debounced) a través del componente global `Searchbar`, y muestran un indicador de carga mientras la búsqueda está en curso.

## Cambios

- **`Searchbar` (loader):** se agrega un `Spinner` (reutilizando `components/ui/spinner.tsx`) que se muestra mientras la búsqueda está en curso, tanto durante la ventana de debounce como mientras la visita de Inertia está en vuelo. El estado se limpia vía un callback `onFinish` que se pasa a `onSearch`. Aplica a todas las instancias (pedidos, cursos, combos, escuelas, productos, stock) por ser el componente compartido.
- **`/tracking`:** el campo de búsqueda deja de usar su `<form>` propio (que exigía Enter/click) y pasa a usar el `Searchbar` global con búsqueda en vivo. Los selects de escuela/curso/tipo de producto siguen funcionando sin cambios y se combinan con el término de búsqueda (el término viaja en la query string y sobrevive a los cambios de filtro).
- El debounce se mantiene en `use-debounce` a 1000ms. Highlighting y búsqueda por teléfono quedan intactos.

## Verificación

- Vitest: 11 tests en `searchbar.test.tsx` + `tracking-filters.test.tsx` en verde (cubren la aparición/limpieza del spinner y el filtrado combinado).
- run-forensics (prettier/eslint/tsc) sin observaciones.

Closes #238
