### PR TITLE
chore(agents): run long commands in the foreground with extended timeout

### DIFF
--- a/.claude/agents/contractor.md
+++ b/.claude/agents/contractor.md
@@ -18,7 +18,7 @@ Invoke the `serve-warrant` skill with that number and follow it strictly, with o
 
 ## Waiting for long commands
 
-`run-forensics --full` can exceed the 120s Bash timeout and get moved to the background. When that happens, **end your turn and wait for the completion notification.** Do not chase the job:
+`run-forensics --full` can exceed the 120s Bash timeout. Run it in the **foreground** anyway — pass Bash's `timeout` parameter (e.g. 300000–600000 ms) to extend the limit past 120s. Never `run_in_background` it: a subagent is **not** re-invoked when its own backgrounded Bash job finishes — that completion notification only wakes the caller of an `Agent` spawn, so backgrounding and ending your turn to "wait" hangs forever with no way to resume. Do not chase a job either:
 
 - Never `cat` or `Read` a task's `.output` file — it is a full JSONL transcript and floods your context. If you must peek, `tail -n 40` it, once.
 - Never poll with `sleep`, `until [ -s … ]`, `ps aux | grep`, or `tail -f` (which just hangs until the timeout).

--- a/.claude/agents/stenographer.md
+++ b/.claude/agents/stenographer.md
@@ -25,7 +25,7 @@ If a render still fails, re-read the actual stack trace before theorizing. Do no
 
 ## Waiting for long commands
 
-Suites and `run-forensics` can exceed the 120s Bash timeout and get moved to the background. When that happens, **end your turn and wait for the completion notification.** Do not chase the job:
+Suites (Pest/Vitest through Sail; Playwright on the host) and `run-forensics` can exceed the 120s Bash timeout. Run them in the **foreground** anyway — pass Bash's `timeout` parameter (e.g. 300000–600000 ms) to extend the limit past 120s. Never `run_in_background` them: a subagent is **not** re-invoked when its own backgrounded Bash job finishes — that completion notification only wakes the caller of an `Agent` spawn, so backgrounding and ending your turn to "wait" hangs forever with no way to resume. Do not chase a job either:
 
 - Never `cat` or `Read` a task's `.output` file — it is a full JSONL transcript and floods your context. If you must peek, `tail -n 40` it, once.
 - Never poll with `sleep`, `until [ -s … ]`, `ps aux | grep`, or `tail -f` (which just hangs until the timeout). Past runs spent 12% of all tool calls doing this.


### PR DESCRIPTION
## Qué

Corrige la sección "Waiting for long commands" en dos agentes del flujo autónomo (`contractor.md` y `stenographer.md`) para que corran `run-forensics`/las suites de test en **foreground** con el parámetro `timeout` de Bash extendido, en vez de mandarlos a background y "terminar el turno esperando la notificación".

## Por qué

Un subagente **no** es reinvocado cuando termina su propio `Bash run_in_background`: esa notificación solo despierta al llamador de un spawn de `Agent`. Un `contractor`/`stenographer` que backgroundeaba `run-forensics` y terminaba su turno para esperar quedaba colgado sin forma de reanudarse (medido en el run de #112: 3 relanzamientos, ~$0.57 extra).

## Cambios

- `run-forensics`/suites se corren en foreground extendiendo el `timeout` de Bash (300000–600000 ms); `run_in_background` queda explícitamente prohibido, con el porqué documentado.
- Se elimina la instrucción de "terminar el turno y esperar la notificación".
- Se conservan intactas las reglas anti-polling (`sleep`, `until`, `ps aux`, `tail -f`) y la de no leer el `.output` completo.
- `judge.md`, `coroner.md` y `detective.md` quedan sin tocar (el patrón de `detective` es el caso correcto: espera spawns de `Agent`, no su propio Bash).

Solo se modifica texto de instrucciones en `.claude/agents/*.md`; no cambia código de la app ni permisos.

Closes #231
