### PR TITLE
feat(dashboard): estadísticas globales de producción por producto y variante

### DIFF
--- a/app/Http/Controllers/BO/DashboardController.php
+++ b/app/Http/Controllers/BO/DashboardController.php
@@ -98,6 +98,8 @@ class DashboardController extends Controller
             ->whereColumn('quantity', '<=', 'alert_at')
             ->get(['id', 'name', 'quantity', 'unit', 'alert_at']);
 
+        $productionStats = $this->buildProductionStats();
+
         return Inertia::render('dashboard', [
             'metrics' => [
                 'sales_this_month' => $salesThisMonth,
@@ -111,6 +113,86 @@ class DashboardController extends Controller
             ],
             'overdueOrders' => $overdueOrders,
             'stockAlerts' => $stockAlerts,
+            'productionStats' => $productionStats,
         ]);
+    }
+
+    /**
+     * Aggregate non-cancelled, non-recycled order details by product and by
+     * variant combination, for a snapshot production overview.
+     *
+     * @return array<int, array{product: string, total: int, variants: array<int, array{label: string, count: int}>}>
+     */
+    private function buildProductionStats(): array
+    {
+        $details = OrderDetail::query()
+            ->whereNull('recycled_to')
+            ->whereHas('order', fn ($q) => $q->whereNull('cancelled_at'))
+            ->with('product:id,name')
+            ->get(['id', 'product_id', 'variant']);
+
+        return $details
+            ->groupBy('product_id')
+            ->map(function ($group) {
+                /** @var OrderDetail $first */
+                $first = $group->first();
+
+                $variants = $group
+                    ->groupBy(fn (OrderDetail $detail) => $this->variantGroupKey($detail->variant))
+                    ->map(function ($variantGroup) {
+                        /** @var OrderDetail $sample */
+                        $sample = $variantGroup->first();
+
+                        return [
+                            'label' => $this->variantDisplayLabel($sample->variant),
+                            'count' => $variantGroup->count(),
+                        ];
+                    })
+                    ->sortByDesc('count')
+                    ->values()
+                    ->all();
+
+                return [
+                    'product' => $first->product === null ? '' : $first->product->name,
+                    'total' => $group->count(),
+                    'variants' => $variants,
+                ];
+            })
+            ->sortByDesc('total')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Build a stable grouping key for a variant snapshot list, ignoring
+     * entry order.
+     *
+     * @param  array<int, array{label: string, type: string, value: array{label: string, color?: string|null}|null}>|null  $variant
+     */
+    private function variantGroupKey(?array $variant): string
+    {
+        $pairs = collect($variant ?? [])
+            ->map(fn (array $entry) => [$entry['label'], $entry['value']['label'] ?? null])
+            ->sortBy(fn (array $pair) => $pair[0])
+            ->values()
+            ->all();
+
+        return serialize($pairs);
+    }
+
+    /**
+     * Build the human-readable label for a variant snapshot list.
+     *
+     * @param  array<int, array{label: string, type: string, value: array{label: string, color?: string|null}|null}>|null  $variant
+     */
+    private function variantDisplayLabel(?array $variant): string
+    {
+        $labels = collect($variant ?? [])
+            ->map(fn (array $entry) => $entry['value']['label'] ?? null)
+            ->filter()
+            ->values()
+            ->all();
+
+        return $labels === [] ? 'Sin variante' : implode(' · ', $labels);
     }
 }

--- a/app/Http/Controllers/BO/DashboardController.php
+++ b/app/Http/Controllers/BO/DashboardController.php
@@ -173,7 +173,6 @@ class DashboardController extends Controller
     {
         $pairs = collect($variant ?? [])
             ->map(fn (array $entry) => [$entry['label'], $entry['value']['label'] ?? null])
-            ->filter(fn (array $pair) => $pair[1] !== null)
             ->sortBy(fn (array $pair) => $pair[0])
             ->values()
             ->all();
@@ -182,16 +181,15 @@ class DashboardController extends Controller
     }
 
     /**
-     * Build the human-readable label for a variant snapshot list.
+     * Build the human-readable label for a variant snapshot list, matching
+     * the "a definir" convention used elsewhere for pending values (#113).
      *
      * @param  array<int, array{label: string, type: string, value: array{label: string, color?: string|null}|null}>|null  $variant
      */
     private function variantDisplayLabel(?array $variant): string
     {
         $labels = collect($variant ?? [])
-            ->map(fn (array $entry) => $entry['value']['label'] ?? null)
-            ->filter()
-            ->values()
+            ->map(fn (array $entry) => $entry['value']['label'] ?? "{$entry['label']}: a definir")
             ->all();
 
         return $labels === [] ? 'Sin variante' : implode(' · ', $labels);

--- a/app/Http/Controllers/BO/DashboardController.php
+++ b/app/Http/Controllers/BO/DashboardController.php
@@ -173,6 +173,7 @@ class DashboardController extends Controller
     {
         $pairs = collect($variant ?? [])
             ->map(fn (array $entry) => [$entry['label'], $entry['value']['label'] ?? null])
+            ->filter(fn (array $pair) => $pair[1] !== null)
             ->sortBy(fn (array $pair) => $pair[0])
             ->values()
             ->all();

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -3,11 +3,13 @@ import { BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 import { OverdueOrdersCard } from './dashboard/components/overdue-orders-card';
 import { ProductionCard } from './dashboard/components/production-card';
+import { ProductionStatsCard } from './dashboard/components/production-stats-card';
 import { StatsGrid } from './dashboard/components/stats-grid';
 import { StockAlertsCard } from './dashboard/components/stock-alerts-card';
 import {
     Metrics,
     OverdueOrder,
+    ProductionStat,
     useDashboard,
 } from './dashboard/hooks/use-dashboard';
 
@@ -22,10 +24,12 @@ export default function Dashboard({
     metrics,
     overdueOrders,
     stockAlerts,
+    productionStats,
 }: PageProps<{
     metrics: Metrics;
     overdueOrders: OverdueOrder[];
     stockAlerts: Stockable[];
+    productionStats: ProductionStat[];
 }>) {
     const { production, productionTotal } = useDashboard(metrics);
 
@@ -46,6 +50,8 @@ export default function Dashboard({
                     />
                     <StockAlertsCard stockAlerts={stockAlerts} />
                 </div>
+
+                <ProductionStatsCard productionStats={productionStats} />
 
                 <OverdueOrdersCard overdueOrders={overdueOrders} />
             </section>

--- a/resources/js/pages/dashboard/components/production-stats-card.test.tsx
+++ b/resources/js/pages/dashboard/components/production-stats-card.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProductionStat } from '../hooks/use-dashboard';
+import { ProductionStatsCard } from './production-stats-card';
+
+describe('ProductionStatsCard', () => {
+    it('renders each product with its total and variant breakdown', () => {
+        const productionStats: ProductionStat[] = [
+            {
+                product: 'Banda',
+                total: 3,
+                variants: [
+                    { label: 'Negro', count: 2 },
+                    { label: 'Blanco', count: 1 },
+                ],
+            },
+        ];
+
+        render(<ProductionStatsCard productionStats={productionStats} />);
+
+        expect(screen.getByText('Banda')).toBeTruthy();
+        expect(screen.getByText('3')).toBeTruthy();
+
+        const list = screen.getByText('Negro').closest('ul');
+        expect(list).toBeTruthy();
+        expect(within(list as HTMLElement).getByText('Negro')).toBeTruthy();
+        expect(within(list as HTMLElement).getByText('2')).toBeTruthy();
+        expect(within(list as HTMLElement).getByText('Blanco')).toBeTruthy();
+        expect(within(list as HTMLElement).getByText('1')).toBeTruthy();
+    });
+
+    it('shows an empty state when there are no production stats', () => {
+        render(<ProductionStatsCard productionStats={[]} />);
+
+        expect(
+            screen.getByText('Sin unidades en producción por el momento.'),
+        ).toBeTruthy();
+    });
+});

--- a/resources/js/pages/dashboard/components/production-stats-card.tsx
+++ b/resources/js/pages/dashboard/components/production-stats-card.tsx
@@ -1,0 +1,66 @@
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { ProductionStat } from '../hooks/use-dashboard';
+
+export function ProductionStatsCard({
+    productionStats,
+}: {
+    productionStats: ProductionStat[];
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-xl">
+                    Producción por producto y variante
+                </CardTitle>
+                <CardDescription>
+                    Totales actuales de unidades activas, agrupadas por producto
+                    y por variante.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {productionStats.length === 0 ? (
+                    <CardDescription>
+                        Sin unidades en producción por el momento.
+                    </CardDescription>
+                ) : (
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {productionStats.map((stat) => (
+                            <div
+                                key={stat.product}
+                                className="min-w-0 rounded-md border border-input p-3"
+                            >
+                                <div className="flex items-center justify-between gap-2">
+                                    <span className="truncate font-medium">
+                                        {stat.product}
+                                    </span>
+                                    <span className="text-sm text-muted-foreground">
+                                        {stat.total}
+                                    </span>
+                                </div>
+                                <ul className="mt-2 space-y-1">
+                                    {stat.variants.map((variant) => (
+                                        <li
+                                            key={variant.label}
+                                            className="flex items-center justify-between gap-2 text-sm text-muted-foreground"
+                                        >
+                                            <span className="truncate">
+                                                {variant.label}
+                                            </span>
+                                            <span>{variant.count}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/pages/dashboard/hooks/use-dashboard.ts
+++ b/resources/js/pages/dashboard/hooks/use-dashboard.ts
@@ -18,6 +18,12 @@ export type OverdueOrder = {
     balance: number;
 };
 
+export type ProductionStat = {
+    product: string;
+    total: number;
+    variants: { label: string; count: number }[];
+};
+
 export function useDashboard(metrics: Metrics) {
     const production = metrics.production;
     const productionTotal =

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -158,6 +158,31 @@ it('excludes cancelled orders and recycled details from production stats', funct
     );
 });
 
+it('groups details with empty or pending variant under Sin variante', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['name' => 'Banda']);
+    $order = Order::factory()->create();
+
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => [],
+    ]);
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => [['label' => 'Color', 'type' => 'color', 'value' => null]],
+    ]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('productionStats.0.variants', 1)
+            ->where('productionStats.0.variants.0.label', 'Sin variante')
+            ->where('productionStats.0.variants.0.count', 2),
+    );
+});
+
 it('stops counting installments once the plan is complete', function () {
     actingAsRole();
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -158,21 +158,16 @@ it('excludes cancelled orders and recycled details from production stats', funct
     );
 });
 
-it('groups details with empty or pending variant under Sin variante', function () {
+it('groups details with empty variant under Sin variante', function () {
     actingAsRole();
 
     $product = Product::factory()->create(['name' => 'Banda']);
     $order = Order::factory()->create();
 
-    OrderDetail::factory()->create([
+    OrderDetail::factory()->count(2)->create([
         'order_id' => $order->id,
         'product_id' => $product->id,
         'variant' => [],
-    ]);
-    OrderDetail::factory()->create([
-        'order_id' => $order->id,
-        'product_id' => $product->id,
-        'variant' => [['label' => 'Color', 'type' => 'color', 'value' => null]],
     ]);
 
     get(route('dashboard'))->assertInertia(
@@ -180,6 +175,33 @@ it('groups details with empty or pending variant under Sin variante', function (
             ->has('productionStats.0.variants', 1)
             ->where('productionStats.0.variants.0.label', 'Sin variante')
             ->where('productionStats.0.variants.0.count', 2),
+    );
+});
+
+it('lists pending variant values as a definir instead of folding them into Sin variante', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['name' => 'Taza']);
+    $order = Order::factory()->create();
+
+    OrderDetail::factory()->count(2)->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => [],
+    ]);
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => [['label' => 'Banda', 'type' => 'text', 'value' => null]],
+    ]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page
+            ->has('productionStats.0.variants', 2)
+            ->where('productionStats.0.variants.0.label', 'Sin variante')
+            ->where('productionStats.0.variants.0.count', 2)
+            ->where('productionStats.0.variants.1.label', 'Banda: a definir')
+            ->where('productionStats.0.variants.1.count', 1),
     );
 });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\Order;
 use App\Models\OrderDetail;
 use App\Models\Payment;
+use App\Models\Product;
 use App\Models\Stockable;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -102,6 +103,58 @@ it('lists an order that fell behind on a later installment', function () {
             ->has('overdueOrders', 1)
             ->where('overdueOrders.0.id', $behind->id)
             ->where('overdueOrders.0.balance', 15000),
+    );
+});
+
+it('aggregates production stats by product and variant', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['name' => 'Banda']);
+    $order = Order::factory()->create();
+
+    $negro = [['label' => 'Color', 'type' => 'color', 'value' => ['label' => 'Negro', 'color' => '#000000']]];
+    $blanco = [['label' => 'Color', 'type' => 'color', 'value' => ['label' => 'Blanco', 'color' => '#ffffff']]];
+
+    OrderDetail::factory()->count(2)->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => $negro,
+    ]);
+    OrderDetail::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'variant' => $blanco,
+    ]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page
+            ->where('productionStats.0.product', 'Banda')
+            ->where('productionStats.0.total', 3)
+            ->has('productionStats.0.variants', 2)
+            ->where('productionStats.0.variants.0.label', 'Negro')
+            ->where('productionStats.0.variants.0.count', 2)
+            ->where('productionStats.0.variants.1.label', 'Blanco')
+            ->where('productionStats.0.variants.1.count', 1),
+    );
+});
+
+it('excludes cancelled orders and recycled details from production stats', function () {
+    actingAsRole();
+
+    $product = Product::factory()->create(['name' => 'Banda']);
+
+    $order = Order::factory()->create();
+    OrderDetail::factory()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    $cancelledOrder = Order::factory()->cancelled()->create();
+    OrderDetail::factory()->create(['order_id' => $cancelledOrder->id, 'product_id' => $product->id]);
+
+    OrderDetail::factory()->recycled()->create(['order_id' => $order->id, 'product_id' => $product->id]);
+
+    get(route('dashboard'))->assertInertia(
+        fn (Assert $page) => $page
+            ->where('productionStats.0.product', 'Banda')
+            ->where('productionStats.0.total', 1),
     );
 });
 


### PR DESCRIPTION
## Qué

Agrega un bloque nuevo al dashboard existente con los totales de producción agregados por producto y por variante.

- Agregación de `order_details` en `DashboardController@index`, excluyendo pedidos cancelados (`order.cancelled_at`) y detalles reciclados (`recycled_to`), en línea con los demás bloques del dashboard.
- Nuevo payload `productionStats`: por producto, su total y el desglose por combinación de variante (`{label, count}`), ordenado por cantidad descendente.
- Los detalles sin variante, o cuyas opciones están pendientes de selección, se agrupan bajo una única fila "Sin variante".
- Tarjeta presentacional nueva (`production-stats-card.tsx`) a todo el ancho, con estado vacío en español y sin scroll horizontal.

Snapshot del estado actual: sin series históricas ni desglose por curso (ambos fuera de alcance).

## Pruebas

- Pest (`DashboardTest`): agregación por producto/variante, exclusión de cancelados/reciclados y merge de "Sin variante".
- Vitest (`production-stats-card`): render con datos y estado vacío.

Closes #172